### PR TITLE
Add shell completions for target commands

### DIFF
--- a/docs/src/content/docs/get-started.mdx
+++ b/docs/src/content/docs/get-started.mdx
@@ -372,3 +372,4 @@ Now that you've set up Grog and created your first build targets, you might want
 - [Remote Caching](/guides/remote-caching) - Set up remote caching for your builds
 - [Docker Outputs](/guides/docker-outputs) - Learn more about caching Docker images
 - [Troubleshooting](/reference/troubleshooting) - Solve common issues
+- [Shell Completions](/guides/shell-completions) - Enable target auto completion

--- a/docs/src/content/docs/guides/shell-completions.mdx
+++ b/docs/src/content/docs/guides/shell-completions.mdx
@@ -4,7 +4,7 @@ description: Enable bash or zsh completions for the grog CLI.
 ---
 
 Grog ships with a built in `completion` command that can generate shell completion scripts for
-`bash` and `zsh`. Installing these scripts enables auto completion of target labels and patterns
+`bash`, `fish`, and `zsh`. Installing these scripts enables auto completion of target labels and patterns
 for the most common commands.
 
 ```bash
@@ -12,8 +12,10 @@ for the most common commands.
 source <(grog completion bash)
 
 # Zsh
-compdef _grog grog
 source <(grog completion zsh)
+
+# Fish
+source <(grog completion fish)
 ```
 
 Add the lines above to your shell startup files (e.g. `.bashrc` or `.zshrc`) to load the completions automatically.

--- a/docs/src/content/docs/guides/shell-completions.mdx
+++ b/docs/src/content/docs/guides/shell-completions.mdx
@@ -1,0 +1,19 @@
+---
+title: Shell Completions
+description: Enable bash or zsh completions for the grog CLI.
+---
+
+Grog ships with a built in `completion` command that can generate shell completion scripts for
+`bash` and `zsh`. Installing these scripts enables auto completion of target labels and patterns
+for the most common commands.
+
+```bash
+# Bash
+source <(grog completion bash)
+
+# Zsh
+compdef _grog grog
+source <(grog completion zsh)
+```
+
+Add the lines above to your shell startup files (e.g. `.bashrc` or `.zshrc`) to load the completions automatically.

--- a/integration/test_repos/completions/BUILD.pkl
+++ b/integration/test_repos/completions/BUILD.pkl
@@ -1,0 +1,11 @@
+amends ".../pkl/package.pkl"
+
+targets {
+  new {
+    name = "bin"
+    inputs {
+      "bin.sh"
+    }
+    bin_output = "bin.sh"
+  }
+}

--- a/integration/test_repos/completions/bin.sh
+++ b/integration/test_repos/completions/bin.sh
@@ -1,0 +1,1 @@
+echo "Hello World"

--- a/integration/test_repos/completions/package_1/BUILD.pkl
+++ b/integration/test_repos/completions/package_1/BUILD.pkl
@@ -1,0 +1,23 @@
+amends ".../pkl/package.pkl"
+
+targets {
+  new {
+    name = "foo"
+    command = "echo 'hello foo'"
+  }
+
+  new {
+    name = "foo_foo"
+    command = "echo 'hello foo_test'"
+  }
+
+  new {
+    name = "foo_test"
+    command = "echo 'hello foo_test'"
+  }
+
+  new {
+    name = "bar"
+    command = "echo 'hello foo'"
+  }
+}

--- a/integration/test_repos/completions/package_1/nested/BUILD.pkl
+++ b/integration/test_repos/completions/package_1/nested/BUILD.pkl
@@ -1,0 +1,8 @@
+amends ".../pkl/package.pkl"
+
+targets {
+  new {
+    name = "nested"
+    command = "echo 'hello world'"
+  }
+}

--- a/integration/test_repos/completions/package_2/BUILD.pkl
+++ b/integration/test_repos/completions/package_2/BUILD.pkl
@@ -1,0 +1,11 @@
+amends ".../pkl/package.pkl"
+
+targets {
+  new {
+    name = "package_2"
+    command = "echo 'hello git changes'"
+    dependencies {
+      "//package_1:foo"
+    }
+  }
+}

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -10,6 +10,7 @@ import (
 	"grog/internal/analysis"
 	"grog/internal/caching"
 	"grog/internal/caching/backends"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/dag"
@@ -32,7 +33,7 @@ var BuildCmd = &cobra.Command{
   grog build //path/to/package:target  # Build a specific target
   grog build //path/to/package/...     # Build all targets in a package and subpackages`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: targetPatternCompletion,
+	ValidArgsFunction: completions.TargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -31,7 +31,8 @@ var BuildCmd = &cobra.Command{
 	Example: `  grog build                      # Build all targets in the current package
   grog build //path/to/package:target  # Build a specific target
   grog build //path/to/package/...     # Build all targets in a package and subpackages`,
-	Args:  cobra.ArbitraryArgs, // Optional argument for target pattern
+	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
+	ValidArgsFunction: targetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -33,9 +33,9 @@ var BuildCmd = &cobra.Command{
   grog build //path/to/package:target  # Build a specific target
   grog build //path/to/package/...     # Build all targets in a package and subpackages`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: completions.TargetPatternCompletion,
+	ValidArgsFunction: completions.BuildTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
 		if err != nil {

--- a/internal/cmd/cmds/changes.go
+++ b/internal/cmd/cmds/changes.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"grog/internal/analysis"
+	"grog/internal/console"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -30,7 +31,7 @@ Can optionally include transitive dependents of changed targets to find all affe
   grog changes --since=v1.0.0 --target-type=test     # Show only test targets changed since v1.0.0`,
 	Args: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		if changesOptions.since == "" {
 			logger.Fatalf("--since flag is required")
@@ -51,7 +52,7 @@ Can optionally include transitive dependents of changed targets to find all affe
 			return
 		}
 
-		packages, err := loading.LoadPackages(ctx, "")
+		packages, err := loading.LoadAllPackages(ctx)
 		if err != nil {
 			logger.Fatalf(
 				"could not load packages: %v",

--- a/internal/cmd/cmds/changes.go
+++ b/internal/cmd/cmds/changes.go
@@ -23,12 +23,12 @@ var changesOptions struct {
 var ChangesCmd = &cobra.Command{
 	Use:   "changes",
 	Short: "Lists targets whose inputs have been modified since a given commit.",
-	Long:  `Identifies targets that need to be rebuilt due to changes in their input files since a specified git commit.
+	Long: `Identifies targets that need to be rebuilt due to changes in their input files since a specified git commit.
 Can optionally include transitive dependents of changed targets to find all affected targets.`,
 	Example: `  grog changes --since=HEAD~1                      # Show targets changed in the last commit
   grog changes --since=main --dependents=transitive  # Show targets changed since main branch, including dependents
   grog changes --since=v1.0.0 --target-type=test     # Show only test targets changed since v1.0.0`,
-	Args:  cobra.MaximumNArgs(0),
+	Args: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 
@@ -51,7 +51,7 @@ Can optionally include transitive dependents of changed targets to find all affe
 			return
 		}
 
-		packages, err := loading.LoadPackages(ctx)
+		packages, err := loading.LoadPackages(ctx, "")
 		if err != nil {
 			logger.Fatalf(
 				"could not load packages: %v",

--- a/internal/cmd/cmds/check.go
+++ b/internal/cmd/cmds/check.go
@@ -3,18 +3,19 @@ package cmds
 import (
 	"github.com/spf13/cobra"
 	"grog/internal/analysis"
+	"grog/internal/console"
 	"grog/internal/loading"
 	"os"
 )
 
 var CheckCmd = &cobra.Command{
-	Use:   "check",
-	Short: "Loads the build graph and runs basic consistency checks.",
-	Long:  `Loads the build graph and performs the same consistency checks as 'grog build' without actually building anything.`,
+	Use:     "check",
+	Short:   "Loads the build graph and runs basic consistency checks.",
+	Long:    `Loads the build graph and performs the same consistency checks as 'grog build' without actually building anything.`,
 	Example: `  grog check  # Validate the build graph for consistency issues`,
-	Args:  cobra.NoArgs,
+	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		graph := loading.MustLoadGraphForBuild(ctx, logger)
 

--- a/internal/cmd/cmds/clean.go
+++ b/internal/cmd/cmds/clean.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"github.com/spf13/cobra"
 	"grog/internal/config"
+	"grog/internal/console"
 	"os"
 )
 
@@ -11,13 +12,13 @@ var expunge bool
 var CleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Removes all cached artifacts.",
-	Long:  `Removes cached artifacts from the workspace or the entire grog cache.
+	Long: `Removes cached artifacts from the workspace or the entire grog cache.
 By default, only the workspace-specific cache is cleaned. Use the --expunge flag to remove all cached artifacts.`,
 	Example: `  grog clean            # Clean the workspace cache
   grog clean --expunge   # Clean the entire grog cache`,
-	Args:  cobra.NoArgs,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, logger := setupCommand()
+		_, logger := console.SetupCommand()
 
 		var dirToClear string
 		if expunge {

--- a/internal/cmd/cmds/deps.go
+++ b/internal/cmd/cmds/deps.go
@@ -17,13 +17,14 @@ var depsOptions struct {
 var DepsCmd = &cobra.Command{
 	Use:   "deps",
 	Short: "Lists (transitive) dependencies of a target.",
-	Long:  `Lists the direct or transitive dependencies of a specified target.
+	Long: `Lists the direct or transitive dependencies of a specified target.
 By default, only direct dependencies are shown. Use the --transitive flag to show all transitive dependencies.
 Dependencies can be filtered by target type using the --target-type flag.`,
 	Example: `  grog deps //path/to/package:target           # Show direct dependencies
   grog deps -t //path/to/package:target          # Show transitive dependencies
   grog deps --target-type=test //path/to/package:target  # Show only test dependencies`,
-	Args:  cobra.MaximumNArgs(1),
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: targetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/deps.go
+++ b/internal/cmd/cmds/deps.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/model"
@@ -25,9 +26,9 @@ Dependencies can be filtered by target type using the --target-type flag.`,
   grog deps -t //path/to/package:target          # Show transitive dependencies
   grog deps --target-type=test //path/to/package:target  # Show only test dependencies`,
 	Args:              cobra.MaximumNArgs(1),
-	ValidArgsFunction: completions.TargetLabelCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
 			logger.Fatalf("`%s` requires a target label", cmd.UseLine())

--- a/internal/cmd/cmds/deps.go
+++ b/internal/cmd/cmds/deps.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"github.com/spf13/cobra"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -24,7 +25,7 @@ Dependencies can be filtered by target type using the --target-type flag.`,
   grog deps -t //path/to/package:target          # Show transitive dependencies
   grog deps --target-type=test //path/to/package:target  # Show only test dependencies`,
 	Args:              cobra.MaximumNArgs(1),
-	ValidArgsFunction: targetLabelCompletion,
+	ValidArgsFunction: completions.TargetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss/tree"
 	"github.com/spf13/cobra"
 	"grog/internal/analysis"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/dag"
 	"grog/internal/label"
@@ -34,7 +35,7 @@ Supports tree, JSON, and Mermaid diagram output formats. By default, only direct
   grog graph -o mermaid //path/to/package:target  # Output as Mermaid diagram
   grog graph -t //path/to/package:target      # Include transitive dependencies`,
 	Args:              cobra.ArbitraryArgs,
-	ValidArgsFunction: targetPatternCompletion,
+	ValidArgsFunction: completions.TargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -27,17 +27,18 @@ var graphOptions struct {
 var GraphCmd = &cobra.Command{
 	Use:   "graph",
 	Short: "Outputs the target dependency graph.",
-	Long:  `Visualizes the dependency graph of targets in various formats.
+	Long: `Visualizes the dependency graph of targets in various formats.
 Supports tree, JSON, and Mermaid diagram output formats. By default, only direct dependencies are shown.`,
 	Example: `  grog graph                                # Show dependency tree for all targets
   grog graph //path/to/package:target         # Show dependencies for a specific target
   grog graph -o mermaid //path/to/package:target  # Output as Mermaid diagram
   grog graph -t //path/to/package:target      # Include transitive dependencies`,
-	Args:  cobra.ArbitraryArgs,
+	Args:              cobra.ArbitraryArgs,
+	ValidArgsFunction: targetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 
-		packages, err := loading.LoadPackages(ctx)
+		packages, err := loading.LoadPackages(ctx, "")
 		if err != nil {
 			logger.Fatalf(
 				"could not load packages: %v",

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"github.com/charmbracelet/lipgloss"
+	"grog/internal/console"
 	"sort"
 
 	"github.com/TyphonHill/go-mermaid/diagrams/flowchart"
@@ -35,11 +36,11 @@ Supports tree, JSON, and Mermaid diagram output formats. By default, only direct
   grog graph -o mermaid //path/to/package:target  # Output as Mermaid diagram
   grog graph -t //path/to/package:target      # Include transitive dependencies`,
 	Args:              cobra.ArbitraryArgs,
-	ValidArgsFunction: completions.TargetPatternCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
-		packages, err := loading.LoadPackages(ctx, "")
+		packages, err := loading.LoadAllPackages(ctx)
 		if err != nil {
 			logger.Fatalf(
 				"could not load packages: %v",

--- a/internal/cmd/cmds/info.go
+++ b/internal/cmd/cmds/info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/viper"
 	"grog/internal/caching/backends"
 	"grog/internal/config"
+	"grog/internal/console"
 	"os"
 	"text/tabwriter"
 )
@@ -16,9 +17,9 @@ var InfoCmd = &cobra.Command{
 	Long:  `Displays detailed information about the grog CLI configuration, workspace settings, and cache statistics.`,
 	Example: `  grog info                   # Show all grog information
   grog info --version          # Show only the version information`,
-	Args:  cobra.ArbitraryArgs, // Optional argument for target pattern
+	Args: cobra.ArbitraryArgs, // Optional argument for target pattern
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		version := cmd.VersionTemplate()
 		platform := config.Global.GetPlatform()

--- a/internal/cmd/cmds/list.go
+++ b/internal/cmd/cmds/list.go
@@ -21,7 +21,8 @@ var ListCmd = &cobra.Command{
   grog list //path/to/package:target    # List a specific target
   grog list //path/to/package/...       # List all targets in a package and subpackages
   grog list --target-type=test          # List only test targets`,
-	Args:    cobra.ArbitraryArgs, // Optional argument for target pattern
+	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
+	ValidArgsFunction: targetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/list.go
+++ b/internal/cmd/cmds/list.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/selection"
@@ -23,9 +24,9 @@ var ListCmd = &cobra.Command{
   grog list //path/to/package/...       # List all targets in a package and subpackages
   grog list --target-type=test          # List only test targets`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: completions.TargetPatternCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
 		if err != nil {

--- a/internal/cmd/cmds/list.go
+++ b/internal/cmd/cmds/list.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"github.com/spf13/cobra"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -22,7 +23,7 @@ var ListCmd = &cobra.Command{
   grog list //path/to/package/...       # List all targets in a package and subpackages
   grog list --target-type=test          # List only test targets`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: targetPatternCompletion,
+	ValidArgsFunction: completions.TargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/logs.go
+++ b/internal/cmd/cmds/logs.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -21,7 +22,7 @@ Use the --path-only flag to only print the path to the log file instead of its c
 	Example: `  grog logs //path/to/package:target       # Show log contents
   grog logs -p //path/to/package:target      # Show only the log file path`,
 	Args:              cobra.ExactArgs(1), // Requires exactly one target argument
-	ValidArgsFunction: targetLabelCompletion,
+	ValidArgsFunction: completions.TargetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/logs.go
+++ b/internal/cmd/cmds/logs.go
@@ -16,11 +16,12 @@ var logsOptions struct {
 var LogsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Print the latest log file for the given target.",
-	Long:  `Displays the contents of the most recent log file for a specified target.
+	Long: `Displays the contents of the most recent log file for a specified target.
 Use the --path-only flag to only print the path to the log file instead of its contents.`,
 	Example: `  grog logs //path/to/package:target       # Show log contents
   grog logs -p //path/to/package:target      # Show only the log file path`,
-	Args:  cobra.ExactArgs(1), // Requires exactly one target argument
+	Args:              cobra.ExactArgs(1), // Requires exactly one target argument
+	ValidArgsFunction: targetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/logs.go
+++ b/internal/cmd/cmds/logs.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/logs"
@@ -22,9 +23,9 @@ Use the --path-only flag to only print the path to the log file instead of its c
 	Example: `  grog logs //path/to/package:target       # Show log contents
   grog logs -p //path/to/package:target      # Show only the log file path`,
 	Args:              cobra.ExactArgs(1), // Requires exactly one target argument
-	ValidArgsFunction: completions.TargetLabelCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
 		if err != nil {

--- a/internal/cmd/cmds/owners.go
+++ b/internal/cmd/cmds/owners.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"github.com/spf13/cobra"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/model"
@@ -18,7 +19,7 @@ This is useful for finding which targets will be affected by changes to specific
   grog owners path/to/file1.txt path/to/file2.txt  # Find targets that use any of the specified files`,
 	Args: cobra.MinimumNArgs(1), // Require at least one file argument
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		graph := loading.MustLoadGraphForQuery(ctx, logger)
 

--- a/internal/cmd/cmds/owners.go
+++ b/internal/cmd/cmds/owners.go
@@ -12,11 +12,11 @@ import (
 var OwnersCmd = &cobra.Command{
 	Use:   "owners",
 	Short: "Lists targets that own the specified files as inputs.",
-	Long:  `Identifies and lists all targets that include the specified files as inputs.
+	Long: `Identifies and lists all targets that include the specified files as inputs.
 This is useful for finding which targets will be affected by changes to specific files.`,
 	Example: `  grog owners path/to/file.txt                # Find targets that use a specific file
   grog owners path/to/file1.txt path/to/file2.txt  # Find targets that use any of the specified files`,
-	Args:  cobra.MinimumNArgs(1), // Require at least one file argument
+	Args: cobra.MinimumNArgs(1), // Require at least one file argument
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/rdeps.go
+++ b/internal/cmd/cmds/rdeps.go
@@ -17,13 +17,14 @@ var rDepsOptions struct {
 var RDepsCmd = &cobra.Command{
 	Use:   "rdeps",
 	Short: "Lists (transitive) dependants (reverse dependencies) of a target.",
-	Long:  `Lists the direct or transitive dependants (reverse dependencies) of a specified target.
+	Long: `Lists the direct or transitive dependants (reverse dependencies) of a specified target.
 By default, only direct dependants are shown. Use the --transitive flag to show all transitive dependants.
 Dependants can be filtered by target type using the --target-type flag.`,
 	Example: `  grog rdeps //path/to/package:target           # Show direct dependants
   grog rdeps -t //path/to/package:target          # Show transitive dependants
   grog rdeps --target-type=test //path/to/package:target  # Show only test dependants`,
-	Args:  cobra.MaximumNArgs(1),
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: targetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/rdeps.go
+++ b/internal/cmd/cmds/rdeps.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/model"
@@ -25,9 +26,9 @@ Dependants can be filtered by target type using the --target-type flag.`,
   grog rdeps -t //path/to/package:target          # Show transitive dependants
   grog rdeps --target-type=test //path/to/package:target  # Show only test dependants`,
 	Args:              cobra.MaximumNArgs(1),
-	ValidArgsFunction: completions.TargetLabelCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
 			logger.Fatalf("`%s` requires a target label", cmd.UseLine())

--- a/internal/cmd/cmds/rdeps.go
+++ b/internal/cmd/cmds/rdeps.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"github.com/spf13/cobra"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -24,7 +25,7 @@ Dependants can be filtered by target type using the --target-type flag.`,
   grog rdeps -t //path/to/package:target          # Show transitive dependants
   grog rdeps --target-type=test //path/to/package:target  # Show only test dependants`,
 	Args:              cobra.MaximumNArgs(1),
-	ValidArgsFunction: targetLabelCompletion,
+	ValidArgsFunction: completions.TargetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/caching"
 	"grog/internal/caching/backends"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/execution"
 	"grog/internal/label"
@@ -28,7 +29,7 @@ Any arguments after the target are passed directly to the binary being executed.
   grog run //path/to/package:target arg1 arg2   # Run with arguments
   grog run -i //path/to/package:target          # Run in the package directory`,
 	Args:              cobra.ArbitraryArgs,
-	ValidArgsFunction: targetLabelCompletion,
+	ValidArgsFunction: completions.TargetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -22,12 +22,13 @@ var runOptions struct {
 var RunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Builds and runs a single target's binary output.",
-	Long:  `Builds a single target that produces a binary output and then executes it with the provided arguments.
+	Long: `Builds a single target that produces a binary output and then executes it with the provided arguments.
 Any arguments after the target are passed directly to the binary being executed.`,
 	Example: `  grog run //path/to/package:target           # Run the target
   grog run //path/to/package:target arg1 arg2   # Run with arguments
   grog run -i //path/to/package:target          # Run in the package directory`,
-	Args:  cobra.ArbitraryArgs,
+	Args:              cobra.ArbitraryArgs,
+	ValidArgsFunction: targetLabelCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -6,6 +6,7 @@ import (
 	"grog/internal/caching/backends"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/execution"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -29,9 +30,9 @@ Any arguments after the target are passed directly to the binary being executed.
   grog run //path/to/package:target arg1 arg2   # Run with arguments
   grog run -i //path/to/package:target          # Run in the package directory`,
 	Args:              cobra.ArbitraryArgs,
-	ValidArgsFunction: completions.TargetLabelCompletion,
+	ValidArgsFunction: completions.BinaryTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
 			logger.Fatalf("`%s` requires a target pattern", cmd.UseLine())

--- a/internal/cmd/cmds/taint.go
+++ b/internal/cmd/cmds/taint.go
@@ -15,13 +15,14 @@ import (
 var TaintCmd = &cobra.Command{
 	Use:   "taint",
 	Short: "Taints targets by pattern to force execution regardless of cache status.",
-	Long:  `Marks specified targets as "tainted", which forces them to be rebuilt on the next build command,
+	Long: `Marks specified targets as "tainted", which forces them to be rebuilt on the next build command,
 regardless of whether they would normally be considered up-to-date according to the cache.
 This is useful when you want to force a rebuild of specific targets.`,
 	Example: `  grog taint //path/to/package:target      # Taint a specific target
   grog taint //path/to/package/...         # Taint all targets in a package and subpackages
   grog taint //path/to/package:*           # Taint all targets in a package`,
-	Args:  cobra.MinimumNArgs(1),
+	Args:              cobra.MinimumNArgs(1),
+	ValidArgsFunction: targetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/taint.go
+++ b/internal/cmd/cmds/taint.go
@@ -23,9 +23,9 @@ This is useful when you want to force a rebuild of specific targets.`,
   grog taint //path/to/package/...         # Taint all targets in a package and subpackages
   grog taint //path/to/package:*           # Taint all targets in a package`,
 	Args:              cobra.MinimumNArgs(1),
-	ValidArgsFunction: completions.TargetPatternCompletion,
+	ValidArgsFunction: completions.AllTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
 		if err != nil {

--- a/internal/cmd/cmds/taint.go
+++ b/internal/cmd/cmds/taint.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/caching"
 	"grog/internal/caching/backends"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/hashing"
@@ -22,7 +23,7 @@ This is useful when you want to force a rebuild of specific targets.`,
   grog taint //path/to/package/...         # Taint all targets in a package and subpackages
   grog taint //path/to/package:*           # Taint all targets in a package`,
 	Args:              cobra.MinimumNArgs(1),
-	ValidArgsFunction: targetPatternCompletion,
+	ValidArgsFunction: completions.TargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/test.go
+++ b/internal/cmd/cmds/test.go
@@ -15,7 +15,8 @@ var TestCmd = &cobra.Command{
 	Example: `  grog test                      # Run all tests in the current package
   grog test //path/to/package:test  # Run a specific test
   grog test //path/to/package/...   # Run all tests in a package and subpackages`,
-	Args:  cobra.ArbitraryArgs, // Optional argument for target pattern
+	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
+	ValidArgsFunction: targetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/test.go
+++ b/internal/cmd/cmds/test.go
@@ -2,6 +2,7 @@ package cmds
 
 import (
 	"github.com/spf13/cobra"
+	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
@@ -16,7 +17,7 @@ var TestCmd = &cobra.Command{
   grog test //path/to/package:test  # Run a specific test
   grog test //path/to/package/...   # Run all tests in a package and subpackages`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: targetPatternCompletion,
+	ValidArgsFunction: completions.TargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx, logger := setupCommand()
 

--- a/internal/cmd/cmds/test.go
+++ b/internal/cmd/cmds/test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"grog/internal/completions"
 	"grog/internal/config"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/selection"
@@ -17,9 +18,9 @@ var TestCmd = &cobra.Command{
   grog test //path/to/package:test  # Run a specific test
   grog test //path/to/package/...   # Run all tests in a package and subpackages`,
 	Args:              cobra.ArbitraryArgs, // Optional argument for target pattern
-	ValidArgsFunction: completions.TargetPatternCompletion,
+	ValidArgsFunction: completions.TestTargetPatternCompletion,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, logger := setupCommand()
+		ctx, logger := console.SetupCommand()
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
 		if err != nil {

--- a/internal/cmd/completions.go
+++ b/internal/cmd/completions.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"context"
+	"github.com/spf13/cobra"
+	"grog/internal/config"
+	"grog/internal/label"
+	"grog/internal/loading"
+	"sort"
+	"strings"
+)
+
+func targetPatternCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ctx := context.Background()
+	currentPkg, err := config.Global.GetCurrentPackage()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	pattern := label.ParsePartialTargetPattern(currentPkg, toComplete)
+	dir := pattern.Prefix
+	if dir == "" && !strings.HasPrefix(toComplete, "//") {
+		dir = currentPkg
+	}
+
+	packages, err := loading.LoadPackages(ctx, dir)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var comps []string
+	for _, pkg := range packages {
+		for lbl := range pkg.Targets {
+			if pattern.Prefix != "" && !strings.HasPrefix(lbl.Package, pattern.Prefix) {
+				continue
+			}
+			if pattern.TargetPattern != "" && !strings.HasPrefix(lbl.Name, pattern.TargetPattern) {
+				continue
+			}
+			comps = append(comps, lbl.String())
+		}
+	}
+	sort.Strings(comps)
+	return comps, cobra.ShellCompDirectiveNoFileComp
+}
+
+func targetLabelCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return targetPatternCompletion(cmd, args, toComplete)
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -45,6 +45,9 @@ func Stamp(version string, commit string, buildDate string) {
 func init() {
 	cobra.OnInitialize()
 
+	RootCmd.InitDefaultCompletionCmd()
+	RootCmd.CompletionOptions.DisableDefaultCmd = false
+
 	// Find the current workspace root
 	workspaceRoot := config.MustFindWorkspaceRoot()
 	viper.Set("workspace_root", workspaceRoot)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -18,15 +18,21 @@ var RootCmd = &cobra.Command{
 	Use: "grog",
 	// PersistentPreRunE runs before any subcommand's Run, after flags are parsed.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if cmd.Flags().Changed("help") || cmd.Flags().Changed("version") ||
+			cmd.Name() == "help" || cmd.Name() == "completion" {
+			return nil
+		}
+
+		workspaceRoot := config.MustFindWorkspaceRoot()
+		viper.Set("workspace_root", workspaceRoot)
+		viper.AddConfigPath(workspaceRoot)
+
 		// Initialize config (read file, env, flags)
 		if err := initConfig(); err != nil {
 			return err
 		}
 
-		if err := config.Global.Validate(); err != nil {
-			return err
-		}
-		return nil
+		return config.Global.Validate()
 	},
 }
 
@@ -48,14 +54,9 @@ func init() {
 	RootCmd.InitDefaultCompletionCmd()
 	RootCmd.CompletionOptions.DisableDefaultCmd = false
 
-	// Find the current workspace root
-	workspaceRoot := config.MustFindWorkspaceRoot()
-	viper.Set("workspace_root", workspaceRoot)
-
 	// Set up Viper
 	viper.SetConfigType("toml")
 	viper.SetEnvPrefix("GROG")
-	viper.AddConfigPath(workspaceRoot)                     // search in workspace root
 	viper.AddConfigPath("$HOME/.grog")                     // optionally look for config in the home directory
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_")) // allow FLAG-NAME to map to ENV VAR_NAME
 	viper.AutomaticEnv()                                   // read in environment variables that match

--- a/internal/completions/targets.go
+++ b/internal/completions/targets.go
@@ -1,4 +1,4 @@
-package cmd
+package completions
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func targetPatternCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func TargetPatternCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	ctx := context.Background()
 	currentPkg, err := config.Global.GetCurrentPackage()
 	if err != nil {
@@ -44,6 +44,6 @@ func targetPatternCompletion(cmd *cobra.Command, args []string, toComplete strin
 	return comps, cobra.ShellCompDirectiveNoFileComp
 }
 
-func targetLabelCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return targetPatternCompletion(cmd, args, toComplete)
+func TargetLabelCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return TargetPatternCompletion(cmd, args, toComplete)
 }

--- a/internal/completions/targets_test.go
+++ b/internal/completions/targets_test.go
@@ -10,50 +10,51 @@ import (
 	"testing"
 )
 
-func setupCompletionWorkspace(t *testing.T) string {
-	t.Helper()
-	root := t.TempDir()
-	config.Global.WorkspaceRoot = root
-	config.Global.Root = root
-	if err := os.WriteFile(filepath.Join(root, "grog.toml"), []byte{}, 0644); err != nil {
-		t.Fatalf("failed to write grog.toml: %v", err)
-	}
-	return root
-}
-
-func writeBuild(path string, content string) {
-	os.MkdirAll(filepath.Dir(path), 0755)
-	os.WriteFile(path, []byte(content), 0644)
-}
-
-func TestTargetPatternCompletion(t *testing.T) {
-	root := setupCompletionWorkspace(t)
-
-	// root package
-	writeBuild(filepath.Join(root, "BUILD.json"), `{"targets":[{"name":"root","command":"echo root"}]}`)
-	// foo package with subpackage bar
-	writeBuild(filepath.Join(root, "foo", "BUILD.json"), `{"targets":[{"name":"foo","command":"echo foo"},{"name":"foo_test","command":"echo test"}]}`)
-	writeBuild(filepath.Join(root, "foo", "bar", "BUILD.json"), `{"targets":[{"name":"bar","command":"echo bar"}]}`)
-
+func TestTargetPatternCompletionsAll(t *testing.T) {
 	cases := []struct {
-		wd     string
-		input  string
-		expect []string
+		workingDirectory string
+		input            string
+		expect           []string
 	}{
-		{"", "", []string{"//:root", "//foo/"}},
-		{"", "//foo/", []string{"//foo/bar/", "//foo:foo", "//foo:foo_test"}},
-		{"foo", "", []string{"//foo/bar/", "//foo:foo", "//foo:foo_test"}},
-		{"foo", ":foo", []string{"//foo:foo"}},
-		{"foo", ":f", []string{"//foo:foo", "//foo:foo_test"}},
-		{"", "//foo/bar:", []string{"//foo/bar:bar"}},
+		{"", "", []string{"//:bin", "//package_1", "//package_2"}},
+		{"", "//package_1/", []string{
+			"//package_1/nested",
+			"//package_1:bar",
+			"//package_1:foo",
+			"//package_1:foo_foo",
+			"//package_1:foo_test",
+		}},
+		{"package_1", "", []string{
+			"//package_1/nested",
+			"//package_1:bar",
+			"//package_1:foo",
+			"//package_1:foo_foo",
+			"//package_1:foo_test",
+		}},
+		{"package_1", "nes", []string{"//package_1/nested"}},
+		{"package_1", "foo", []string{"//package_1:foo", "//package_1:foo_foo", "//package_1:foo_test"}},
+		{"package_1", "foo_", []string{"//package_1:foo_foo", "//package_1:foo_test"}},
+		{"package_1", "foo_test", []string{"//package_1:foo_test"}},
+		{"", "//package_1/nested:", []string{"//package_1/nested:nested"}},
 	}
+
+	testFile, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+
+	testDir := filepath.Dir(testFile)
+	testRepoPath := filepath.Join(testDir, "..", "integration", "test_repos", "completions")
 
 	for _, c := range cases {
-		t.Run(c.wd+"-"+c.input, func(t *testing.T) {
-			if err := os.Chdir(filepath.Join(root, c.wd)); err != nil {
+		t.Run(c.workingDirectory+"-"+c.input, func(t *testing.T) {
+			config.Global.WorkspaceRoot = testRepoPath
+
+			if err := os.Chdir(filepath.Join(testRepoPath, c.workingDirectory)); err != nil {
 				t.Fatalf("chdir failed: %v", err)
 			}
-			res, _ := TargetPatternCompletion(&cobra.Command{}, nil, c.input)
+
+			res, _ := AllTargetPatternCompletion(&cobra.Command{}, nil, c.input)
 			sort.Strings(res)
 			if !reflect.DeepEqual(res, c.expect) {
 				t.Errorf("completion(%q)=%v; want %v", c.input, res, c.expect)

--- a/internal/completions/targets_test.go
+++ b/internal/completions/targets_test.go
@@ -1,0 +1,63 @@
+package completions
+
+import (
+	"github.com/spf13/cobra"
+	"grog/internal/config"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func setupCompletionWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	config.Global.WorkspaceRoot = root
+	config.Global.Root = root
+	if err := os.WriteFile(filepath.Join(root, "grog.toml"), []byte{}, 0644); err != nil {
+		t.Fatalf("failed to write grog.toml: %v", err)
+	}
+	return root
+}
+
+func writeBuild(path string, content string) {
+	os.MkdirAll(filepath.Dir(path), 0755)
+	os.WriteFile(path, []byte(content), 0644)
+}
+
+func TestTargetPatternCompletion(t *testing.T) {
+	root := setupCompletionWorkspace(t)
+
+	// root package
+	writeBuild(filepath.Join(root, "BUILD.json"), `{"targets":[{"name":"root","command":"echo root"}]}`)
+	// foo package with subpackage bar
+	writeBuild(filepath.Join(root, "foo", "BUILD.json"), `{"targets":[{"name":"foo","command":"echo foo"},{"name":"foo_test","command":"echo test"}]}`)
+	writeBuild(filepath.Join(root, "foo", "bar", "BUILD.json"), `{"targets":[{"name":"bar","command":"echo bar"}]}`)
+
+	cases := []struct {
+		wd     string
+		input  string
+		expect []string
+	}{
+		{"", "", []string{"//:root", "//foo/"}},
+		{"", "//foo/", []string{"//foo/bar/", "//foo:foo", "//foo:foo_test"}},
+		{"foo", "", []string{"//foo/bar/", "//foo:foo", "//foo:foo_test"}},
+		{"foo", ":foo", []string{"//foo:foo"}},
+		{"foo", ":f", []string{"//foo:foo", "//foo:foo_test"}},
+		{"", "//foo/bar:", []string{"//foo/bar:bar"}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.wd+"-"+c.input, func(t *testing.T) {
+			if err := os.Chdir(filepath.Join(root, c.wd)); err != nil {
+				t.Fatalf("chdir failed: %v", err)
+			}
+			res, _ := TargetPatternCompletion(&cobra.Command{}, nil, c.input)
+			sort.Strings(res)
+			if !reflect.DeepEqual(res, c.expect) {
+				t.Errorf("completion(%q)=%v; want %v", c.input, res, c.expect)
+			}
+		})
+	}
+}

--- a/internal/console/cmd_setup.go
+++ b/internal/console/cmd_setup.go
@@ -1,16 +1,15 @@
-package cmds
+package console
 
 import (
 	"context"
 	"go.uber.org/zap"
-	"grog/internal/console"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
-// setupCommand universal helper for setting up the context and logger for each command
-func setupCommand() (context.Context, *zap.SugaredLogger) {
+// SetupCommand universal helper for setting up the context and logger for each command
+func SetupCommand() (context.Context, *zap.SugaredLogger) {
 	ctx, cancel := context.WithCancel(context.Background())
 	// Listen for SIGTERM or SIGINT to cancel the context
 	signalChan := make(chan os.Signal, 1)
@@ -18,12 +17,12 @@ func setupCommand() (context.Context, *zap.SugaredLogger) {
 	go func() {
 		select {
 		case sig := <-signalChan:
-			console.GetLogger(ctx).Infof("Received signal %v, exiting...", sig)
+			GetLogger(ctx).Infof("Received signal %v, exiting...", sig)
 			cancel()
 		case <-ctx.Done():
 		}
 	}()
 
-	logger := console.GetLogger(ctx)
-	return console.WithLogger(ctx, logger), logger
+	logger := GetLogger(ctx)
+	return WithLogger(ctx, logger), logger
 }

--- a/internal/label/partial_pattern_test.go
+++ b/internal/label/partial_pattern_test.go
@@ -1,0 +1,27 @@
+package label
+
+import "testing"
+
+func TestParsePartialTargetPattern(t *testing.T) {
+	currentPkg := "foo/bar"
+
+	cases := []struct {
+		pattern   string
+		prefix    string
+		target    string
+		recursive bool
+	}{
+		{":baz", "foo/bar", "baz", false},
+		{"//foo:b", "foo", "b", false},
+		{"//foo/...", "foo", "", true},
+		{"//foo/...:b", "foo", "b", true},
+		{"qux", "foo/bar", "qux", false},
+	}
+
+	for _, c := range cases {
+		p := ParsePartialTargetPattern(currentPkg, c.pattern)
+		if p.prefix != c.prefix || p.targetPattern != c.target || p.recursive != c.recursive {
+			t.Errorf("ParsePartialTargetPattern(%q) = {prefix:%q target:%q recursive:%v}; want {prefix:%q target:%q recursive:%v}", c.pattern, p.prefix, p.targetPattern, p.recursive, c.prefix, c.target, c.recursive)
+		}
+	}
+}

--- a/internal/label/target_pattern.go
+++ b/internal/label/target_pattern.go
@@ -8,9 +8,9 @@ import (
 // TargetPattern represents a Bazel target pattern, e.g. "//pkg/..." or "//pkg/...:target".
 // It supports recursive (hierarchical) matching using the "..." wildcard.
 type TargetPattern struct {
-	prefix        string // package prefix (without trailing slash)
-	targetPattern string // target name filter (if empty, matches any target)
-	recursive     bool   // true if "..." is used for recursive matching
+       prefix        string // package prefix (without trailing slash)
+       targetPattern string // target name filter (if empty, matches any target)
+       recursive     bool   // true if "..." is used for recursive matching
 }
 
 // ParseTargetPattern parses a Bazel target pattern.
@@ -200,3 +200,12 @@ func (p TargetPattern) String() string {
 	}
 	return base
 }
+
+// Prefix returns the package prefix of the pattern.
+func (p TargetPattern) Prefix() string { return p.prefix }
+
+// Target returns the target pattern portion.
+func (p TargetPattern) Target() string { return p.targetPattern }
+
+// Recursive reports whether the pattern matches recursively.
+func (p TargetPattern) Recursive() bool { return p.recursive }

--- a/internal/label/target_pattern.go
+++ b/internal/label/target_pattern.go
@@ -109,6 +109,53 @@ func GetMatchAllTargetPattern() TargetPattern {
 	return TargetPattern{prefix: "", recursive: true}
 }
 
+// ParsePartialTargetPattern parses a target pattern but is lenient towards
+// incomplete patterns. It is primarily used for shell completions where the
+// user might not have typed the full pattern yet. Any missing parts are simply
+// returned empty without an error.
+func ParsePartialTargetPattern(currentPackage, pattern string) TargetPattern {
+	if strings.HasPrefix(pattern, ":") {
+		if currentPackage == "." {
+			currentPackage = ""
+		}
+		return TargetPattern{prefix: currentPackage, targetPattern: pattern[1:]}
+	}
+
+	if !strings.HasPrefix(pattern, "//") {
+		// Relative pattern without explicit ":" or shorthand.
+		colonIdx := strings.Index(pattern, ":")
+		var targetName string
+		if colonIdx == -1 {
+			targetName = pattern
+		} else {
+			targetName = pattern[colonIdx+1:]
+		}
+		return TargetPattern{prefix: currentPackage, targetPattern: targetName}
+	}
+
+	body := pattern[2:]
+	prefix := body
+	targetPattern := ""
+	recursive := false
+
+	if idx := strings.Index(body, "..."); idx != -1 {
+		recursive = true
+		prefix = body[:idx]
+		if len(body) > idx+3 && body[idx+3] == ':' {
+			targetPattern = body[idx+4:]
+		}
+	} else if colonIdx := strings.Index(body, ":"); colonIdx != -1 {
+		prefix = body[:colonIdx]
+		targetPattern = body[colonIdx+1:]
+	}
+
+	if len(prefix) > 0 && prefix[len(prefix)-1] == '/' {
+		prefix = prefix[:len(prefix)-1]
+	}
+
+	return TargetPattern{prefix: prefix, targetPattern: targetPattern, recursive: recursive}
+}
+
 // Matches returns true if the given TargetLabel matches the pattern.
 func (p TargetPattern) Matches(t TargetLabel) bool {
 	// Package matching.

--- a/internal/loading/load.go
+++ b/internal/loading/load.go
@@ -11,13 +11,18 @@ import (
 	"sync"
 )
 
-func LoadPackages(ctx context.Context) ([]*model.Package, error) {
+func LoadPackages(ctx context.Context, dir string) ([]*model.Package, error) {
 	workspaceRoot := config.Global.WorkspaceRoot
 	logger := console.GetLogger(ctx)
 
+	startDir := workspaceRoot
+	if dir != "" {
+		startDir = config.GetPathAbsoluteToWorkspaceRoot(dir)
+	}
+
 	fileListQueue := make(chan *gocodewalker.File, 100)
 
-	fileWalker := gocodewalker.NewParallelFileWalker([]string{workspaceRoot}, fileListQueue)
+	fileWalker := gocodewalker.NewParallelFileWalker([]string{startDir}, fileListQueue)
 	go fileWalker.Start()
 
 	packageLoader := NewPackageLoader(logger)

--- a/internal/loading/load.go
+++ b/internal/loading/load.go
@@ -11,14 +11,13 @@ import (
 	"sync"
 )
 
-func LoadPackages(ctx context.Context, dir string) ([]*model.Package, error) {
-	workspaceRoot := config.Global.WorkspaceRoot
-	logger := console.GetLogger(ctx)
+func LoadAllPackages(ctx context.Context) ([]*model.Package, error) {
+	return LoadPackages(ctx, config.Global.WorkspaceRoot)
+}
 
-	startDir := workspaceRoot
-	if dir != "" {
-		startDir = config.GetPathAbsoluteToWorkspaceRoot(dir)
-	}
+// LoadPackages loads all packages in the given directory and its subdirectories.
+func LoadPackages(ctx context.Context, startDir string) ([]*model.Package, error) {
+	logger := console.GetLogger(ctx)
 
 	fileListQueue := make(chan *gocodewalker.File, 100)
 

--- a/internal/loading/load_graph.go
+++ b/internal/loading/load_graph.go
@@ -10,7 +10,7 @@ import (
 )
 
 func MustLoadGraphForBuild(ctx context.Context, logger *zap.SugaredLogger) *dag.DirectedTargetGraph {
-	packages, err := LoadPackages(ctx)
+	packages, err := LoadPackages(ctx, "")
 	if err != nil {
 		logger.Fatalf(
 			"could not load packages: %v",
@@ -32,7 +32,7 @@ func MustLoadGraphForBuild(ctx context.Context, logger *zap.SugaredLogger) *dag.
 }
 
 func MustLoadGraphForQuery(ctx context.Context, logger *zap.SugaredLogger) *dag.DirectedTargetGraph {
-	packages, err := LoadPackages(ctx)
+	packages, err := LoadPackages(ctx, "")
 	if err != nil {
 		logger.Fatalf("could not load packages: %v", err)
 	}

--- a/internal/loading/load_graph.go
+++ b/internal/loading/load_graph.go
@@ -10,7 +10,7 @@ import (
 )
 
 func MustLoadGraphForBuild(ctx context.Context, logger *zap.SugaredLogger) *dag.DirectedTargetGraph {
-	packages, err := LoadPackages(ctx, "")
+	packages, err := LoadAllPackages(ctx)
 	if err != nil {
 		logger.Fatalf(
 			"could not load packages: %v",
@@ -32,7 +32,7 @@ func MustLoadGraphForBuild(ctx context.Context, logger *zap.SugaredLogger) *dag.
 }
 
 func MustLoadGraphForQuery(ctx context.Context, logger *zap.SugaredLogger) *dag.DirectedTargetGraph {
-	packages, err := LoadPackages(ctx, "")
+	packages, err := LoadAllPackages(ctx)
 	if err != nil {
 		logger.Fatalf("could not load packages: %v", err)
 	}

--- a/internal/selection/query_selection.go
+++ b/internal/selection/query_selection.go
@@ -19,9 +19,13 @@ func (s *Selector) SelectTargets(
 func (s *Selector) FilterTargets(targets []*model.Target) []*model.Target {
 	var filteredLabels []*model.Target
 	for _, target := range targets {
-		if s.targetMatchesFilters(target) && targetMatchesPlatform(target) {
+		if s.Match(target) {
 			filteredLabels = append(filteredLabels, target)
 		}
 	}
 	return filteredLabels
+}
+
+func (s *Selector) Match(target *model.Target) bool {
+	return s.targetMatchesFilters(target) && targetMatchesPlatform(target)
 }

--- a/internal/selection/selector.go
+++ b/internal/selection/selector.go
@@ -92,16 +92,5 @@ func (s *Selector) targetExcludeTagsMatch(target *model.Target) bool {
 }
 
 func (s *Selector) targetMatchesTypeSelection(target *model.Target) bool {
-	switch s.TargetType {
-	case TestOnly:
-		return target.IsTest()
-	case NonTestOnly:
-		return !target.IsTest()
-	case BinOutput:
-		return target.HasBinOutput()
-	case AllTargets:
-		return true
-	}
-
-	return false
+	return TargetMatchesTypeSelection(target, s.TargetType)
 }

--- a/internal/selection/target_matchers.go
+++ b/internal/selection/target_matchers.go
@@ -24,3 +24,18 @@ func targetMatchesPlatform(target *model.Target) bool {
 
 	return true
 }
+
+func TargetMatchesTypeSelection(target *model.Target, targetType TargetTypeSelection) bool {
+	switch targetType {
+	case TestOnly:
+		return target.IsTest()
+	case NonTestOnly:
+		return !target.IsTest()
+	case BinOutput:
+		return target.HasBinOutput()
+	case AllTargets:
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary
- add `completion` command and auto completions for target labels/patterns
- support partial target pattern parsing
- restrict package loading to a directory
- document how to enable shell completions

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6851253a8eb483278c45bd77b9de8815