### PR TITLE
Add BuildNode abstraction

### DIFF
--- a/internal/analysis/analyze.go
+++ b/internal/analysis/analyze.go
@@ -8,7 +8,8 @@ import (
 
 // BuildGraph builds a directed graph of targets and analyzes it.
 func BuildGraph(targets model.TargetMap) (*dag.DirectedTargetGraph, error) {
-	graph := dag.NewDirectedGraphFromMap(targets)
+	nodeMap := model.BuildNodeMapFromTargets(targets.TargetsAlphabetically()...)
+	graph := dag.NewDirectedGraphFromMap(nodeMap)
 
 	// Add edges defined by dependencies
 	for _, target := range targets {

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -173,11 +173,11 @@ func printMermaidDiagram(graph *dag.DirectedTargetGraph) {
 		toList := out[from]
 		// Sort each destination slice.
 		sort.Slice(toList, func(i, j int) bool {
-			return toList[i].Label.String() < toList[j].Label.String()
+			return toList[i].GetLabel().String() < toList[j].GetLabel().String()
 		})
 
 		for _, to := range toList {
-			chart.AddLink(nodeMap[from.String()], nodeMap[to.Label.String()])
+			chart.AddLink(nodeMap[from.String()], nodeMap[to.GetLabel().String()])
 		}
 	}
 

--- a/internal/dag/graph_test.go
+++ b/internal/dag/graph_test.go
@@ -149,7 +149,7 @@ func TestDirectedTargetGraph_HasCycle(t *testing.T) {
 	}
 
 	// Remove one edge to break the cycle: target1 -> target2 -> target3
-	graph.outEdges[target3.Label] = []*model.Target{}
+	graph.outEdges[target3.Label] = []model.BuildNode{}
 
 	// Check if there is a cycle
 	graph = NewDirectedGraph()

--- a/internal/loading/dto.go
+++ b/internal/loading/dto.go
@@ -32,10 +32,25 @@ type PackageDTO struct {
 	// Used for logging
 	SourceFilePath string
 
-	Targets []*TargetDTO `json:"targets" yaml:"targets" pkl:"targets"`
+	Targets      []*TargetDTO      `json:"targets" yaml:"targets" pkl:"targets"`
+	Environments []*EnvironmentDTO `json:"environments,omitempty" yaml:"environments,omitempty" pkl:"environments"`
 
 	// DefaultPlatform specifies the platform selector at the package level.
 	// This serves as the default for target-level platform selectors.
 	// If a target specifies its own platform selector, it overrides this default.
 	DefaultPlatform *model.PlatformConfig `json:"default_platform,omitempty" yaml:"default_platform,omitempty" pkl:"default_platform"`
+}
+
+type EnvironmentDTO struct {
+	Name         string                  `json:"name" yaml:"name" pkl:"name"`
+	Dependencies []string                `json:"dependencies,omitempty" yaml:"dependencies,omitempty" pkl:"dependencies"`
+	Command      string                  `json:"command,omitempty" yaml:"command,omitempty" pkl:"command"`
+	OutputImage  string                  `json:"output_image,omitempty" yaml:"output_image,omitempty" pkl:"output_image"`
+	Inputs       []string                `json:"inputs,omitempty" yaml:"inputs,omitempty" pkl:"inputs"`
+	Defaults     *EnvironmentDefaultsDTO `json:"defaults,omitempty" yaml:"defaults,omitempty" pkl:"defaults"`
+}
+
+type EnvironmentDefaultsDTO struct {
+	MountDependencies     string `json:"mount_dependencies,omitempty" yaml:"mount_dependencies,omitempty" pkl:"mount_dependencies"`
+	MountDependencyInputs bool   `json:"mount_dependency_inputs,omitempty" yaml:"mount_dependency_inputs,omitempty" pkl:"mount_dependency_inputs"`
 }

--- a/internal/model/build_node.go
+++ b/internal/model/build_node.go
@@ -1,0 +1,10 @@
+package model
+
+import "grog/internal/label"
+
+// BuildNode represents a node in the build graph. It is implemented by
+// regular build targets and environment targets.
+type BuildNode interface {
+	GetLabel() label.TargetLabel
+	GetDependencies() []label.TargetLabel
+}

--- a/internal/model/build_node_map.go
+++ b/internal/model/build_node_map.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"fmt"
+	"grog/internal/label"
+	"maps"
+	"slices"
+	"sort"
+)
+
+type BuildNodeMap map[label.TargetLabel]BuildNode
+
+func BuildNodeMapFromPackages(packages []*Package) (BuildNodeMap, error) {
+	nodes := make(BuildNodeMap)
+	for _, pkg := range packages {
+		for _, t := range pkg.GetTargets() {
+			if _, ok := nodes[t.Label]; ok {
+				return nil, fmt.Errorf("duplicate target label: %s", t.Label)
+			}
+			nodes[t.Label] = t
+		}
+		for _, env := range pkg.GetEnvironments() {
+			if _, ok := nodes[env.Label]; ok {
+				return nil, fmt.Errorf("duplicate target label: %s", env.Label)
+			}
+			nodes[env.Label] = env
+		}
+	}
+	return nodes, nil
+}
+
+// BuildNodeMapFromTargets constructs a BuildNodeMap from the provided targets.
+func BuildNodeMapFromTargets(targets ...*Target) BuildNodeMap {
+	nodes := make(BuildNodeMap)
+	for _, t := range targets {
+		nodes[t.Label] = t
+	}
+	return nodes
+}
+
+func (m BuildNodeMap) NodesAlphabetically() []BuildNode {
+	nodes := slices.Collect(maps.Values(m))
+	sort.Slice(nodes, func(i, j int) bool {
+		return nodes[i].GetLabel().String() < nodes[j].GetLabel().String()
+	})
+	return nodes
+}

--- a/internal/model/environment.go
+++ b/internal/model/environment.go
@@ -1,0 +1,23 @@
+package model
+
+import "grog/internal/label"
+
+// Environment defines a build environment configuration which can be referenced
+// by targets or other environments.
+type Environment struct {
+	Label        label.TargetLabel    `json:"label" yaml:"label"`
+	Dependencies []label.TargetLabel  `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Command      string               `json:"command,omitempty" yaml:"command,omitempty"`
+	OutputImage  string               `json:"output_image,omitempty" yaml:"output_image,omitempty"`
+	Inputs       []string             `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	Defaults     *EnvironmentDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+}
+
+// EnvironmentDefaults capture default settings for environment usage.
+type EnvironmentDefaults struct {
+	MountDependencies     string `json:"mount_dependencies,omitempty" yaml:"mount_dependencies,omitempty"`
+	MountDependencyInputs bool   `json:"mount_dependency_inputs,omitempty" yaml:"mount_dependency_inputs,omitempty"`
+}
+
+func (e *Environment) GetLabel() label.TargetLabel          { return e.Label }
+func (e *Environment) GetDependencies() []label.TargetLabel { return e.Dependencies }

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -12,9 +12,17 @@ type Package struct {
 	// for logging purposes
 	SourceFilePath string
 
-	Targets map[label.TargetLabel]*Target `json:"targets"`
+	Targets      map[label.TargetLabel]*Target      `json:"targets"`
+	Environments map[label.TargetLabel]*Environment `json:"environments,omitempty"`
 }
 
 func (p *Package) GetTargets() []*Target {
 	return slices.Collect(maps.Values(p.Targets))
+}
+
+func (p *Package) GetEnvironments() []*Environment {
+	if p.Environments == nil {
+		return nil
+	}
+	return slices.Collect(maps.Values(p.Environments))
 }

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -143,3 +143,11 @@ func (t *Target) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(wrapper)
 }
+
+func (t *Target) GetLabel() label.TargetLabel {
+	return t.Label
+}
+
+func (t *Target) GetDependencies() []label.TargetLabel {
+	return t.Dependencies
+}


### PR DESCRIPTION
## Summary
- add BuildNode interface and environment type
- allow packages to include environments
- update DAG implementation to use BuildNode
- refactor graph walker and CLI graph command for generic nodes

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Docker daemon not running)*
- `make unit-test`


------
https://chatgpt.com/codex/tasks/task_e_6863a952ecf083279ec909aa3c78b5bf