### PR TITLE
Add grog version requirement option

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -9,6 +9,7 @@ Find below a complete example of a grog configuration file:
 ```toml
 # Workspace Settings
 root = "/home/grace/grog_data"
+required_grog_version = "^0.13"
 
 # Execution Settings
 fail_fast = true # Exit immediately when encountering an issue
@@ -42,6 +43,9 @@ For instance, to set or override the `fail_fast` option set `GROG_FAIL_FAST=fals
 ## Configuration Variables Explained
 
 - **root**: The base directory where Grog stores its internal files. Defaults to `~/.grog`.
+- **required_grog_version**: A [semver](https://semver.org/) range that the running
+  Grog binary must satisfy. If the version is outside of this range Grog exits with
+  an error.
 - **fail_fast**: When true, Grog will stop execution after encountering the first error, cancelling all running tasks. Defaults to `false`.
 - **num_workers**: Number of concurrent workers for parallel task execution. Defaults to the number of CPUs.
 - **log_level**: Determines verbosity of logging (e.g., "debug", "info"). Defaults to `info`.

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,9 @@ require (
 	github.com/docker/docker v27.5.0+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/google/go-containerregistry v0.20.3
-	github.com/mattn/go-isatty v0.0.20
-	github.com/sergi/go-diff v1.4.0
+       github.com/mattn/go-isatty v0.0.20
+       github.com/blang/semver/v4 v4.0.0
+       github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR5wKP38=
 github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/boyter/gocodewalker v1.4.0 h1:fVmFeQxKpj5tlpjPcyTtJ96btgaHYd9yn6m+T/66et4=

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -53,6 +53,8 @@ type TestTable struct {
 	// Only run this test when REQUIRES_CREDENTIALS is set
 	// (for tests that require cloud credentials)
 	RequiresCredentials bool `yaml:"requires_credentials"`
+	// Whether to skip the clean step
+	SkipClean bool `yaml:"skip_clean"`
 }
 
 // TestStep defines a single test step
@@ -107,13 +109,15 @@ func TestCliScenarios(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 
 			// Clear repository cache
-			output, err := runBinary([]string{"clean"}, tt.Repo, []string{})
-			if err != nil {
-				t.Fatalf(
-					"could not run `grog clean` on repo %s: %v\nCommand output:\n%s",
-					tt.Repo,
-					err,
-					output)
+			if !tt.SkipClean {
+				output, err := runBinary([]string{"clean"}, tt.Repo, []string{})
+				if err != nil {
+					t.Fatalf(
+						"could not run `grog clean` on repo %s: %v\nCommand output:\n%s",
+						tt.Repo,
+						err,
+						output)
+				}
 			}
 
 			testCaseNames := make(map[string]bool)
@@ -144,7 +148,7 @@ func TestCliScenarios(t *testing.T) {
 
 				t.Run(tc.Name, func(t *testing.T) {
 
-					output, err = runBinary(tc.GrogArgs, tt.Repo, tc.EnvVars)
+					output, err := runBinary(tc.GrogArgs, tt.Repo, tc.EnvVars)
 
 					if err != nil && !tc.ExpectFail {
 						fmt.Printf("Command ouput: %s\n", output)

--- a/integration/fixtures/errors_if_version_does_not_match.txt
+++ b/integration/fixtures/errors_if_version_does_not_match.txt
@@ -1,1 +1,0 @@
-FATAL: Invalid grog version: grog version v0.13.0-2-g3dc2f4c does not satisfy >=99.0.0

--- a/integration/fixtures/errors_if_version_does_not_match.txt
+++ b/integration/fixtures/errors_if_version_does_not_match.txt
@@ -1,0 +1,1 @@
+FATAL: Invalid grog version: grog version v0.13.0-2-g3dc2f4c does not satisfy >=99.0.0

--- a/integration/test_repos/version_requirement/grog.toml
+++ b/integration/test_repos/version_requirement/grog.toml
@@ -1,0 +1,1 @@
+required_grog_version = ">=99.0.0"

--- a/integration/test_scenarios/version_requirement.yaml
+++ b/integration/test_scenarios/version_requirement.yaml
@@ -1,0 +1,7 @@
+name: require grog version
+repo: version_requirement
+cases:
+  - name: errors_if_version_does_not_match
+    grog_args:
+      - info
+    expect_fail: true

--- a/integration/test_scenarios/version_requirement.yaml
+++ b/integration/test_scenarios/version_requirement.yaml
@@ -1,5 +1,6 @@
 name: require grog version
 repo: version_requirement
+skip_clean: true
 cases:
   - name: errors_if_version_does_not_match
     grog_args:

--- a/integration/test_scenarios/version_requirement.yaml
+++ b/integration/test_scenarios/version_requirement.yaml
@@ -6,3 +6,4 @@ cases:
     grog_args:
       - info
     expect_fail: true
+    skip_fixture: true

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 )
 
+var Version string
+
 var RootCmd = &cobra.Command{
 	Use: "grog",
 	// PersistentPreRunE runs before any subcommand's Run, after flags are parsed.
@@ -37,13 +39,17 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		return config.Global.ValidateGrogVersion(cmd.Version)
+		if err := config.Global.ValidateGrogVersion(Version); err != nil {
+			console.InitLogger().Fatalf("Invalid grog version: %v", err)
+		}
+		return nil
 	},
 }
 
 // Stamp sets the data for the version command
 func Stamp(version string, commit string, buildDate string) {
 	RootCmd.Version = version
+	Version = version
 
 	RootCmd.SetVersionTemplate(fmt.Sprintf(
 		"%s (%s) built on %s",

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,7 +33,11 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
-		return config.Global.Validate()
+		if err := config.Global.Validate(); err != nil {
+			return err
+		}
+
+		return config.Global.ValidateGrogVersion(cmd.Version)
 	},
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,17 +126,17 @@ func (w WorkspaceConfig) ValidateGrogVersion(currentVersion string) error {
 		return nil
 	}
 
-	r, err := semver.ParseRange(w.RequiredGrogVersion)
+	required, err := semver.ParseRange(w.RequiredGrogVersion)
 	if err != nil {
 		return fmt.Errorf("invalid required_grog_version: %w", err)
 	}
 
-	v, err := semver.ParseTolerant(currentVersion)
+	actual, err := semver.ParseTolerant(currentVersion)
 	if err != nil {
 		return fmt.Errorf("invalid grog version %q: %w", currentVersion, err)
 	}
 
-	if !r(v) {
+	if !required(actual) {
 		return fmt.Errorf("grog version %s does not satisfy %s", currentVersion, w.RequiredGrogVersion)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	semver "github.com/blang/semver/v4"
 )
 
 type WorkspaceConfig struct {
@@ -46,6 +48,9 @@ type WorkspaceConfig struct {
 	// Due to the concurrent nature of grog's execution we don't want to include
 	// logs that don't have a guaranteed order
 	DisableNonDeterministicLogging bool `mapstructure:"disable_non_deterministic_logging"`
+
+	// Require that the running grog version matches this semver range
+	RequiredGrogVersion string `mapstructure:"required_grog_version"`
 }
 
 var Global WorkspaceConfig
@@ -108,6 +113,31 @@ func (w WorkspaceConfig) Validate() error {
 	_, err := ParseLoadOutputsMode(w.LoadOutputs)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// ValidateGrogVersion checks if the provided current version satisfies the
+// RequiredGrogVersion constraint if it is set. The version string should
+// follow semver conventions.
+func (w WorkspaceConfig) ValidateGrogVersion(currentVersion string) error {
+	if w.RequiredGrogVersion == "" {
+		return nil
+	}
+
+	r, err := semver.ParseRange(w.RequiredGrogVersion)
+	if err != nil {
+		return fmt.Errorf("invalid required_grog_version: %w", err)
+	}
+
+	v, err := semver.ParseTolerant(currentVersion)
+	if err != nil {
+		return fmt.Errorf("invalid grog version %q: %w", currentVersion, err)
+	}
+
+	if !r(v) {
+		return fmt.Errorf("grog version %s does not satisfy %s", currentVersion, w.RequiredGrogVersion)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- allow specifying `required_grog_version` in `grog.toml`
- error if the running grog does not satisfy the semver range
- document the new option
- add integration test case for invalid version range

## Testing
- `go test ./...` *(fails: docker/pkl not available)*

------
https://chatgpt.com/codex/tasks/task_e_687ece9ba21c8327af9421003abe9cac