### PR TITLE
fix: incomplete tar.gz writes in DirectoryOutputHandler

### DIFF
--- a/internal/output/handlers/dir_output_handler_test.go
+++ b/internal/output/handlers/dir_output_handler_test.go
@@ -1,0 +1,62 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"grog/internal/caching"
+	"grog/internal/caching/backends"
+	"grog/internal/config"
+	"grog/internal/label"
+	"grog/internal/model"
+	"grog/internal/output/handlers"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDirectoryOutputHandler_WriteAndLoad(t *testing.T) {
+	ctx := context.Background()
+
+	rootDir := t.TempDir()
+	config.Global = config.WorkspaceConfig{Root: rootDir, WorkspaceRoot: rootDir}
+
+	cacheBackend, err := backends.NewFileSystemCache(ctx)
+	if err != nil {
+		t.Fatalf("failed to create cache backend: %v", err)
+	}
+	targetCache := caching.NewTargetCache(cacheBackend)
+	handler := handlers.NewDirectoryOutputHandler(targetCache)
+
+	target := model.Target{Label: label.TL("pkg", "target"), ChangeHash: "hash"}
+	output := model.NewOutput("dir", "out")
+
+	dirPath := filepath.Join(rootDir, "pkg", "out")
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	content := bytes.Repeat([]byte("hello world"), 1024*100)
+	if err := os.WriteFile(filepath.Join(dirPath, "file.txt"), content, 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	if err := handler.Write(ctx, target, output); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if err := os.RemoveAll(dirPath); err != nil {
+		t.Fatalf("failed to remove directory: %v", err)
+	}
+
+	if err := handler.Load(ctx, target, output); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	loaded, err := os.ReadFile(filepath.Join(dirPath, "file.txt"))
+	if err != nil {
+		t.Fatalf("failed to read restored file: %v", err)
+	}
+
+	if !bytes.Equal(loaded, content) {
+		t.Fatalf("restored file content mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- properly close tar and gzip writers before closing the pipe
- wait for compression goroutine and propagate errors so cache receives full archive

## Testing
- `go test ./...` *(fails: could not run `grog clean` on repo binary_output: fork/exec /workspace/grog/dist/grog: no such file or directory)*
- `go test ./integration -run TestCliScenarios/Binary_outputs -count=1` *(fails: could not run `grog clean` on repo binary_output: fork/exec /workspace/grog/dist/grog: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1365cd0832780c1c664e0a73215