### PR TITLE
fix: attach stdin to grog run

### DIFF
--- a/docs/src/content/docs/guides/binary-outputs.mdx
+++ b/docs/src/content/docs/guides/binary-outputs.mdx
@@ -39,7 +39,7 @@ targets:
       unzip protoc.zip -d protoc
       chmod +x protoc/bin/protoc
     outputs:
-      - protoc/include/google/protobuf/
+      - dir::protoc/include/google/protobuf/
     bin_output: protoc/bin/protoc
 
   # Target that uses the tool

--- a/docs/src/content/docs/reference/labels.md
+++ b/docs/src/content/docs/reference/labels.md
@@ -59,7 +59,7 @@ You can combine the recursive wildcard with a specific target name to match targ
 - `//package/path/...:target_name`: Matches any target named `target_name` in `package/path` or any of its sub-packages.
   - Example: `//test/...:all_tests` matches the `all_tests` target in the `test` package and any sub-package under `test`.
 
-**All Targets in a Package (`*` or `all`):**
+**All Targets in a Package with `all`:**
 
 You can match all targets directly within a specific package (non-recursively) using `:...` or `:all`.
 

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -1,7 +1,6 @@
 package cmds
 
 import (
-	"github.com/spf13/cobra"
 	"grog/internal/caching"
 	"grog/internal/caching/backends"
 	"grog/internal/completions"
@@ -16,6 +15,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
 )
 
 var runOptions struct {
@@ -126,6 +127,7 @@ Any arguments after the target are passed directly to the binary being executed.
 		runCommand.Env = execution.GetExtendedTargetEnv(ctx, runTarget)
 		runCommand.Stdout = os.Stdout
 		runCommand.Stderr = os.Stderr
+		runCommand.Stdin = os.Stdin
 
 		if runOptions.inPackage {
 			packagePath := config.GetPathAbsoluteToWorkspaceRoot(runTarget.Label.Package)


### PR DESCRIPTION
Otherwise `grog run` programs cannot be interactive.