### PR TITLE
Show stream toggle command bar in task UI

### DIFF
--- a/internal/console/stream_logs_toggle.go
+++ b/internal/console/stream_logs_toggle.go
@@ -1,0 +1,57 @@
+package console
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type streamLogsToggleKey struct{}
+
+// StreamLogsToggle manages the state for streaming target logs to the console.
+type StreamLogsToggle struct {
+	enabled atomic.Bool
+}
+
+// NewStreamLogsToggle returns a new toggle initialized with the provided value.
+func NewStreamLogsToggle(initial bool) *StreamLogsToggle {
+	toggle := &StreamLogsToggle{}
+	toggle.enabled.Store(initial)
+	return toggle
+}
+
+// Enabled reports whether streaming is currently enabled.
+func (t *StreamLogsToggle) Enabled() bool {
+	if t == nil {
+		return false
+	}
+	return t.enabled.Load()
+}
+
+// Toggle flips the current state and returns the new value.
+func (t *StreamLogsToggle) Toggle() bool {
+	if t == nil {
+		return false
+	}
+	for {
+		current := t.enabled.Load()
+		if t.enabled.CompareAndSwap(current, !current) {
+			return !current
+		}
+	}
+}
+
+// WithStreamLogsToggle stores the toggle in the context for downstream use.
+func WithStreamLogsToggle(ctx context.Context, toggle *StreamLogsToggle) context.Context {
+	if toggle == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, streamLogsToggleKey{}, toggle)
+}
+
+// GetStreamLogsToggle retrieves the toggle stored in the context, if present.
+func GetStreamLogsToggle(ctx context.Context) *StreamLogsToggle {
+	if toggle, ok := ctx.Value(streamLogsToggleKey{}).(*StreamLogsToggle); ok {
+		return toggle
+	}
+	return nil
+}

--- a/internal/console/task_ui.go
+++ b/internal/console/task_ui.go
@@ -172,8 +172,14 @@ func (m *model) View() string {
 	defer m.tasksMutex.RUnlock()
 	s := ""
 
+	label := m.streamLogsCommandLabel()
+
 	// Render header
-	s += m.header + "\n"
+	if label == "" {
+		s += m.header + "\n"
+	} else {
+		s += m.header + ": " + label + "\n"
+	}
 
 	// Render tasks in order:
 	// Tasks may be sparse so we need to sort the task ids and then loop
@@ -190,10 +196,6 @@ func (m *model) View() string {
 		}
 	}
 
-	if label := m.streamLogsCommandLabel(); label != "" {
-		s += "\n" + label + "\n"
-	}
-
 	return s
 }
 
@@ -202,7 +204,7 @@ func (m *model) streamLogsCommandLabel() string {
 		return ""
 	}
 	if m.streamLogsToggle.Enabled() {
-		return "(s)top streaming logs"
+		return color.New(color.Bold).Sprint("(s)") + "top streaming logs"
 	}
-	return "(s)tream logs"
+	return color.New(color.Bold).Sprint("(s)") + "tream logs"
 }

--- a/internal/console/task_ui_test.go
+++ b/internal/console/task_ui_test.go
@@ -2,9 +2,11 @@ package console
 
 import (
 	"context"
-	tea "github.com/charmbracelet/bubbletea"
+	"strings"
 	"testing"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestStartTaskUICtrlCCancelsContext(t *testing.T) {
@@ -21,5 +23,50 @@ func TestStartTaskUICtrlCCancelsContext(t *testing.T) {
 		// expected
 	case <-time.After(time.Second):
 		t.Fatal("context not cancelled after ctrl+c")
+	}
+}
+
+func TestStartTaskUIToggleStreamLogs(t *testing.T) {
+	parent := context.Background()
+	toggle := NewStreamLogsToggle(false)
+	ctxWithToggle := WithStreamLogsToggle(parent, toggle)
+	_, program, _ := StartTaskUI(ctxWithToggle)
+
+	// ensure program has started
+	time.Sleep(10 * time.Millisecond)
+
+	program.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+
+	deadline := time.After(time.Second)
+	for {
+		if toggle.Enabled() {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("stream logs toggle did not enable after pressing 's'")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	program.Quit()
+}
+
+func TestModelViewShowsStreamLogsCommandBar(t *testing.T) {
+	toggle := NewStreamLogsToggle(false)
+	ctx := WithStreamLogsToggle(context.Background(), toggle)
+	m := initialModel(ctx, nil, func() {})
+
+	view := m.View()
+	if !strings.Contains(view, "(s)tream logs") {
+		t.Fatalf("expected view to include stream logs prompt, got: %q", view)
+	}
+
+	toggle.Toggle()
+
+	view = m.View()
+	if !strings.Contains(view, "(s)top streaming logs") {
+		t.Fatalf("expected view to include stop streaming prompt, got: %q", view)
 	}
 }

--- a/internal/console/tea_writer.go
+++ b/internal/console/tea_writer.go
@@ -2,8 +2,10 @@ package console
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
+	"io"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // TeaWriter small helper so that we can use a tea.Program as a sync for zap
@@ -38,3 +40,21 @@ func (w TeaWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 func (w TeaWriter) Sync() error { return nil }
+
+// StreamToggleWriter writes to the underlying writer only when the toggle is enabled.
+type StreamToggleWriter struct {
+	writer io.Writer
+	toggle *StreamLogsToggle
+}
+
+// NewStreamToggleWriter wraps the provided writer with a toggle check.
+func NewStreamToggleWriter(writer io.Writer, toggle *StreamLogsToggle) *StreamToggleWriter {
+	return &StreamToggleWriter{writer: writer, toggle: toggle}
+}
+
+func (w *StreamToggleWriter) Write(p []byte) (int, error) {
+	if w.toggle == nil || w.toggle.Enabled() {
+		return w.writer.Write(p)
+	}
+	return len(p), nil
+}

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -95,11 +95,24 @@ func runTargetCommand(
 
 	var buffer bytes.Buffer
 
-	if program := console.GetTeaProgram(ctx); program != nil && streamLogs {
-		teaWriter := console.NewTeaWriter(program)
-		multiOut := io.MultiWriter(logWriter, teaWriter, &buffer)
-		cmd.Stdout = multiOut
-		cmd.Stderr = multiOut
+	if program := console.GetTeaProgram(ctx); program != nil {
+		toggle := console.GetStreamLogsToggle(ctx)
+		if toggle != nil {
+			teaWriter := console.NewTeaWriter(program)
+			toggleWriter := console.NewStreamToggleWriter(teaWriter, toggle)
+			multiOut := io.MultiWriter(logWriter, toggleWriter, &buffer)
+			cmd.Stdout = multiOut
+			cmd.Stderr = multiOut
+		} else if streamLogs {
+			teaWriter := console.NewTeaWriter(program)
+			multiOut := io.MultiWriter(logWriter, teaWriter, &buffer)
+			cmd.Stdout = multiOut
+			cmd.Stderr = multiOut
+		} else {
+			multiOut := io.MultiWriter(logWriter, &buffer)
+			cmd.Stdout = multiOut
+			cmd.Stderr = multiOut
+		}
 	} else {
 		multiOut := io.MultiWriter(logWriter, &buffer)
 		cmd.Stdout = multiOut


### PR DESCRIPTION
## Summary
- update the task UI to render a command bar that reflects the streaming toggle state
- stop printing transient toggle messages now that the command bar communicates the status
- add a unit test to ensure the view renders the correct prompt before and after toggling

## Testing
- go test ./internal/console
- go test ./integration/... *(fails: requires the built grog binary which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1614602c8327bccf35e3e8454a03