### PR TITLE
feat: log dependency cycle chain when detected

### DIFF
--- a/internal/analysis/analyze.go
+++ b/internal/analysis/analyze.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"grog/internal/dag"
 	"grog/internal/model"
+	"strings"
 )
 
 // BuildGraph builds a directed graph of targets and analyzes it.
@@ -25,8 +26,12 @@ func BuildGraph(nodes model.BuildNodeMap) (*dag.DirectedTargetGraph, error) {
 		}
 	}
 
-	if graph.HasCycle() {
-		return &dag.DirectedTargetGraph{}, fmt.Errorf("cycle detected")
+	if cycle, hasCycle := graph.FindCycle(); hasCycle {
+		var chain []string
+		for _, node := range cycle {
+			chain = append(chain, node.GetLabel().String())
+		}
+		return &dag.DirectedTargetGraph{}, fmt.Errorf("cycle detected: %s", strings.Join(chain, " -> "))
 	}
 
 	return graph, nil

--- a/internal/dag/graph_test.go
+++ b/internal/dag/graph_test.go
@@ -169,6 +169,37 @@ func TestDirectedTargetGraph_HasCycle(t *testing.T) {
 	}
 }
 
+func TestDirectedTargetGraph_FindCycle(t *testing.T) {
+	graph := NewDirectedGraph()
+	target1 := &model.Target{Label: label.TargetLabel{Name: "target1"}}
+	target2 := &model.Target{Label: label.TargetLabel{Name: "target2"}}
+	target3 := &model.Target{Label: label.TargetLabel{Name: "target3"}}
+
+	graph.AddNode(target1)
+	graph.AddNode(target2)
+	graph.AddNode(target3)
+
+	graph.AddEdge(target1, target2)
+	graph.AddEdge(target2, target3)
+	graph.AddEdge(target3, target1)
+
+	cycle, found := graph.FindCycle()
+	if !found {
+		t.Fatalf("expected to find a cycle")
+	}
+
+	expected := []model.BuildNode{target1, target2, target3, target1}
+	if len(cycle) != len(expected) {
+		t.Fatalf("unexpected cycle length: got %d, want %d", len(cycle), len(expected))
+	}
+
+	for i := range expected {
+		if cycle[i] != expected[i] {
+			t.Fatalf("unexpected cycle node at %d: got %s, want %s", i, cycle[i].GetLabel(), expected[i].GetLabel())
+		}
+	}
+}
+
 func TestDirectedTargetGraph_GetDescendants(t *testing.T) {
 	graph := NewDirectedGraph()
 


### PR DESCRIPTION
## Summary
- add a FindCycle helper that returns the detected cycle chain and reuse it inside HasCycle
- include the concrete cycle sequence in BuildGraph errors so the fatal log shows the loop
- cover the new helper with a unit test verifying the reported chain order

## Testing
- go test ./internal/dag ./internal/analysis

------
https://chatgpt.com/codex/tasks/task_e_69036d96a7dc8327abbc0fa24d5c994c