### PR TITLE
chore: expose GROG_WORKSPACE_ROOT in target environment

### DIFF
--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -145,6 +145,7 @@ func GetExtendedTargetEnv(ctx context.Context, target *model.Target) []string {
 		"GROG_ARCH="+config.Global.Arch,
 		"GROG_PLATFORM="+config.Global.GetPlatform(),
 		"GROG_PACKAGE="+target.Label.Package,
+		"GROG_WORKSPACE_ROOT="+config.Global.WorkspaceRoot,
 		"GROG_GIT_HASH="+gitHash,
 	)
 }


### PR DESCRIPTION
## Summary
- include the workspace root path in the environment passed to target executions

## Testing
- go test ./... (fails: interrupted after hanging)
- pre-commit run --all-files (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6909270588b08327977367580833651d