### PR TITLE
chore: extract shared archive helpers for directory output handling

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -1,0 +1,168 @@
+package archive
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TarGzipDirectory walks the source directory and writes a tar.gz archive to the provided writer.
+// Symlinks are preserved and stored using PAX headers.
+func TarGzipDirectory(ctx context.Context, src string, w io.Writer) error {
+	gzipWriter := gzip.NewWriter(w)
+	defer gzipWriter.Close()
+
+	tarWriter := tar.NewWriter(gzipWriter)
+	defer tarWriter.Close()
+
+	return filepath.WalkDir(src, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if path == src {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		relativePath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		var linkTarget string
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+
+		header, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+
+		header.Name = filepath.ToSlash(relativePath)
+		header.Format = tar.FormatPAX
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if entry.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(tarWriter, file); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+// ExtractTarGzip extracts a tar.gz archive into destDir, restoring files, directories, and symlinks.
+// It returns the number of filesystem entries created.
+func ExtractTarGzip(ctx context.Context, r io.Reader, destDir string) (int, error) {
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return 0, err
+	}
+
+	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return 0, err
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+	fileCount := 0
+
+	for {
+		header, tarErr := tarReader.Next()
+		if tarErr == io.EOF {
+			break
+		}
+		if tarErr != nil {
+			return fileCount, fmt.Errorf("error reading tar header: %w", tarErr)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fileCount, ctx.Err()
+		default:
+		}
+
+		targetPath := filepath.Join(destDir, filepath.FromSlash(header.Name))
+		if !strings.HasPrefix(targetPath, filepath.Clean(destDir)+string(filepath.Separator)) && filepath.Clean(targetPath) != filepath.Clean(destDir) {
+			return fileCount, fmt.Errorf("tar entry escapes destination: %s", header.Name)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.RemoveAll(targetPath); err != nil {
+				return fileCount, err
+			}
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return fileCount, err
+			}
+			fileCount++
+
+		case tar.TypeSymlink:
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fileCount, fmt.Errorf("failed to create parent directories for symlink %s: %w", targetPath, err)
+			}
+			if err := os.RemoveAll(targetPath); err != nil {
+				return fileCount, fmt.Errorf("failed to remove existing path for symlink %s: %w", targetPath, err)
+			}
+			if err := os.Symlink(header.Linkname, targetPath); err != nil {
+				return fileCount, fmt.Errorf("failed to create symlink %s -> %s: %w", targetPath, header.Linkname, err)
+			}
+			fileCount++
+
+		default:
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fileCount, fmt.Errorf("failed to create parent directories for file %s: %w", targetPath, err)
+			}
+
+			file, openErr := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+			if openErr != nil {
+				return fileCount, fmt.Errorf("failed to create file %s: %w", targetPath, openErr)
+			}
+
+			if _, err := io.Copy(file, tarReader); err != nil {
+				file.Close()
+				return fileCount, fmt.Errorf("failed to copy file %s: %w", targetPath, err)
+			}
+
+			if err := file.Close(); err != nil {
+				return fileCount, fmt.Errorf("failed to close file %s: %w", targetPath, err)
+			}
+			fileCount++
+		}
+	}
+
+	return fileCount, nil
+}

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -1,0 +1,70 @@
+package archive_test
+
+import (
+	"bytes"
+	"context"
+	"grog/internal/archive"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTarGzipDirectoryAndExtractTarGzip(t *testing.T) {
+	ctx := context.Background()
+
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "file.txt"), []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	nestedDir := filepath.Join(srcDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "nested.txt"), []byte("nested"), 0o644); err != nil {
+		t.Fatalf("failed to write nested file: %v", err)
+	}
+
+	if err := os.Symlink("file.txt", filepath.Join(srcDir, "link")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := archive.TarGzipDirectory(ctx, srcDir, &buf); err != nil {
+		t.Fatalf("TarGzipDirectory failed: %v", err)
+	}
+
+	destDir := filepath.Join(t.TempDir(), "restore")
+	count, err := archive.ExtractTarGzip(ctx, bytes.NewReader(buf.Bytes()), destDir)
+	if err != nil {
+		t.Fatalf("ExtractTarGzip failed: %v", err)
+	}
+
+	if count != 4 { // nested dir + two files + symlink
+		t.Fatalf("unexpected entry count: %d", count)
+	}
+
+	restored, err := os.ReadFile(filepath.Join(destDir, "file.txt"))
+	if err != nil {
+		t.Fatalf("failed to read restored file: %v", err)
+	}
+	if string(restored) != "content" {
+		t.Fatalf("restored content mismatch: %s", restored)
+	}
+
+	nested, err := os.ReadFile(filepath.Join(destDir, "nested", "nested.txt"))
+	if err != nil {
+		t.Fatalf("failed to read nested file: %v", err)
+	}
+	if string(nested) != "nested" {
+		t.Fatalf("nested content mismatch: %s", nested)
+	}
+
+	linkTarget, err := os.Readlink(filepath.Join(destDir, "link"))
+	if err != nil {
+		t.Fatalf("failed to read restored symlink: %v", err)
+	}
+	if linkTarget != "file.txt" {
+		t.Fatalf("symlink target mismatch: %s", linkTarget)
+	}
+}

--- a/internal/output/handlers/dir_output_handler.go
+++ b/internal/output/handlers/dir_output_handler.go
@@ -1,17 +1,13 @@
 package handlers
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
-	"fmt"
+	"grog/internal/archive"
 	"grog/internal/caching"
 	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/model"
 	"io"
-	"io/fs"
-	"os"
 	"path/filepath"
 )
 
@@ -55,98 +51,8 @@ func (d *DirectoryOutputHandler) Write(
 	errChan := make(chan error, 1)
 
 	go func() {
-		gzipWriter := gzip.NewWriter(pipeWriter)
-		tarWriter := tar.NewWriter(gzipWriter)
-
-		walkErr := filepath.WalkDir(directoryPath, func(path string, directoryEntry fs.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if path == directoryPath { // skip the root directory entry
-				return nil
-			}
-
-			fileInfo, err := directoryEntry.Info()
-			if err != nil {
-				return err
-			}
-
-			// Handle symlinks differently:
-			if fileInfo.Mode()&os.ModeSymlink != 0 {
-				linkTarget, err := os.Readlink(path)
-				if err != nil {
-					return err
-				}
-				// Just link to the target in the header
-				header, err := tar.FileInfoHeader(fileInfo, linkTarget)
-				if err != nil {
-					return err
-				}
-				relativePath, err := filepath.Rel(directoryPath, path)
-				if err != nil {
-					return err
-				}
-				header.Name = filepath.ToSlash(relativePath)
-				header.Format = tar.FormatPAX
-
-				if err := tarWriter.WriteHeader(header); err != nil {
-					return err
-				}
-				// Do not copy file content for symlink.
-				return nil
-			}
-
-			header, err := tar.FileInfoHeader(fileInfo, "")
-			if err != nil {
-				return err
-			}
-
-			relativePath, err := filepath.Rel(directoryPath, path)
-			if err != nil {
-				return err
-			}
-			header.Name = filepath.ToSlash(relativePath) // POSIX‑style paths in the archive
-			header.Format = tar.FormatPAX
-
-			if err := tarWriter.WriteHeader(header); err != nil {
-				return err
-			}
-
-			if !directoryEntry.IsDir() {
-				file, err := os.Open(path)
-				if err != nil {
-					return err
-				}
-				if _, err := io.Copy(tarWriter, file); err != nil {
-					logger.Debugf("Error writing file %s error: %v", path, err)
-					file.Close()
-					return err
-				}
-				file.Close()
-			}
-			return nil
-		})
-
-		// Ensure tar and gzip writers are closed and their errors captured
-		if err := tarWriter.Close(); err != nil {
-			pipeWriter.CloseWithError(err)
-			errChan <- err
-			return
-		}
-		if err := gzipWriter.Close(); err != nil {
-			pipeWriter.CloseWithError(err)
-			errChan <- err
-			return
-		}
-
-		// Propagate any walk error after writers are closed
-		if walkErr != nil {
-			pipeWriter.CloseWithError(walkErr)
-			errChan <- walkErr
-		} else {
-			pipeWriter.Close()
-			errChan <- nil
-		}
+		errChan <- archive.TarGzipDirectory(ctx, directoryPath, pipeWriter)
+		pipeWriter.Close()
 	}()
 
 	logger.Debug("streaming tar.gz to cache")
@@ -161,136 +67,19 @@ func (d *DirectoryOutputHandler) Write(
 	return goroutineErr
 }
 
-// Load extracts the compressed directory from the cache and writes it to the target directory.
-//
-// This is a bit more complicated than the Write method because we need to extract the compressed
-// data to a temporary file first, then read it back into a tar reader and extract the files.
-//
-// This is because the tar reader doesn't support reading from a stream, so we need to write the
-// compressed data to a temporary file first.
 func (d *DirectoryOutputHandler) Load(ctx context.Context, target model.Target, output model.Output) error {
 	logger := console.GetLogger(ctx)
 	dirPath := config.GetPathAbsoluteToWorkspaceRoot(filepath.Join(target.Label.Package, output.Identifier))
 
-	// Create a temporary file to store the compressed data
-	tempFile, err := os.CreateTemp("", fmt.Sprintf("%s_dir_output_*.tar.gz", target.ChangeHash))
-	if err != nil {
-		return err
-	}
-	tempFilePath := tempFile.Name()
-	defer console.WarnOnError(ctx, func() error {
-		if err := os.Remove(tempFilePath); err != nil {
-			return fmt.Errorf("failed to clean up tmp tar file file %s: %w", tempFilePath, err)
-		}
-		return nil
-	})
-
-	// Get the compressed file from the cache
 	contentReader, err := d.targetCache.LoadFileStream(ctx, target, output)
 	if err != nil {
 		return err
 	}
 	defer console.WarnOnError(ctx, contentReader.Close)
 
-	// Copy the compressed data to the temporary file
-	if _, err := io.Copy(tempFile, contentReader); err != nil {
-		return err
-	}
-
-	// Close the file to ensure all data is written
-	if err := tempFile.Close(); err != nil {
-		return err
-	}
-
-	// Reopen the temporary file for reading
-	tempFile, err = os.Open(tempFilePath)
+	fileCount, err := archive.ExtractTarGzip(ctx, contentReader, dirPath)
 	if err != nil {
 		return err
-	}
-	defer console.WarnOnError(ctx, tempFile.Close)
-
-	// Create the target directory if it doesn't exist
-	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		return err
-	}
-
-	// Create a gzip reader
-	// NOTE does not need to be closed since it's closed by the tar reader
-	gzipReader, err := gzip.NewReader(tempFile)
-	if err != nil {
-		return err
-	}
-
-	// Create a tar reader
-	tarReader := tar.NewReader(gzipReader)
-
-	// Extract the files
-	fileCount := 0
-	for {
-		header, tarError := tarReader.Next()
-		if tarError == io.EOF {
-			break
-		}
-		if tarError != nil {
-			return fmt.Errorf("error reading tar header: %w", tarError)
-		}
-
-		// Get the target path
-		targetPath := filepath.Join(dirPath, header.Name)
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			// Remove any files that already exist
-			if err := os.RemoveAll(targetPath); err != nil {
-				return err
-			}
-			if err := os.MkdirAll(targetPath, 0755); err != nil {
-				return err
-			}
-			fileCount++
-			continue
-
-		case tar.TypeSymlink:
-			// Ensure the parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-				return fmt.Errorf("failed to create parent directories for symlink %s: %w", targetPath, err)
-			}
-
-			// Remove any existing file/symlink so os.Symlink doesn't fail
-			if err := os.RemoveAll(targetPath); err != nil {
-				return fmt.Errorf("failed to remove existing path for symlink %s: %w", targetPath, err)
-			}
-
-			// header.Linkname holds the symlink target as written by FileInfoHeader
-			if err := os.Symlink(header.Linkname, targetPath); err != nil {
-				return fmt.Errorf("failed to create symlink %s -> %s: %w", targetPath, header.Linkname, err)
-			}
-
-			fileCount++
-			continue
-
-		default:
-			// Create parent directories if needed
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
-				return fmt.Errorf("failed to create parent directories for file %s: %w", targetPath, err)
-			}
-
-			// Create the file
-			file, tarError := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY, os.FileMode(header.Mode))
-			if tarError != nil {
-				return fmt.Errorf("failed to create file %s: %w", targetPath, tarError)
-			}
-
-			if _, err := io.Copy(file, tarReader); err != nil {
-				return fmt.Errorf("failed to copy file %s: %w", targetPath, err)
-			}
-
-			if err := file.Close(); err != nil {
-				return fmt.Errorf("failed to close file %s: %w", targetPath, err)
-			}
-
-			fileCount++
-		}
 	}
 
 	logger.Debugf("Successfully extracted %d files to %s", fileCount, dirPath)


### PR DESCRIPTION
## Summary
- add an internal/archive package to centralize tar.gz creation and extraction for directory outputs
- refactor the directory output handler to stream through the shared archive helpers
- cover the archive round-trip with a focused unit test

## Testing
- go test ./... *(fails: integration suite expects a built dist/grog binary and completions targets are empty in this environment)*
- go test ./internal/completions -run TestTargetPatternCompletionsAll -count=1 *(fails: completion lists are empty in this environment)*
- pre-commit run -a *(fails: pre-commit is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f833d6708327a4dafa26bfee35a1)