### PR TITLE
fix: cache duration tracking

### DIFF
--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -89,7 +89,9 @@ func (r *Registry) HasCacheHit(ctx context.Context, target *model.Target) (bool,
 		return false, nil
 	}
 	start := time.Now()
-	defer r.addCacheDuration(time.Since(start))
+	defer func() {
+		r.addCacheDuration(time.Since(start))
+	}()
 	r.targetMutexMap.Lock(target.Label.String())
 	defer r.targetMutexMap.Unlock(target.Label.String())
 	// check for the default file system key for checking if the inputs changed
@@ -139,7 +141,9 @@ func (r *Registry) WriteOutputs(ctx context.Context, target *model.Target) error
 		return nil
 	}
 	start := time.Now()
-	defer r.addCacheDuration(time.Since(start))
+	defer func() {
+		r.addCacheDuration(time.Since(start))
+	}()
 
 	r.targetMutexMap.Lock(target.Label.String())
 	defer r.targetMutexMap.Unlock(target.Label.String())
@@ -180,7 +184,9 @@ func (r *Registry) LoadOutputs(ctx context.Context, target *model.Target) error 
 		return nil
 	}
 	start := time.Now()
-	defer r.addCacheDuration(time.Since(start))
+	defer func() {
+		r.addCacheDuration(time.Since(start))
+	}()
 	r.targetMutexMap.Lock(target.Label.String())
 	defer r.targetMutexMap.Unlock(target.Label.String())
 	if target.OutputsLoaded {


### PR DESCRIPTION
## Summary
- ensure registry cache duration measurement defers evaluate after cache operations for accurate timing

## Testing
- go test ./... *(fails: integration tests expect built grog binary at dist/grog; see output for missing file errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0867b9888327a3d4f98a49e93d83)