### PR TITLE
Make hashing configurable

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -15,6 +15,7 @@ requires_grog = ">=0.15.0"
 fail_fast = true # Exit immediately when encountering an issue
 num_workers = 4
 load_outputs = "minimal"
+hash_algorithm = "xxh3" # default
 
 # Target Selection
 all_platforms = false
@@ -55,6 +56,7 @@ For instance, to set or override the `fail_fast` option set `GROG_FAIL_FAST=fals
 - **load_outputs**: Determines what outputs are loaded from the cache. Available options are:
   - `all` (default): Load all outputs from the cache.
   - `minimal`: Only load outputs of a target if a **direct dependant** needs to be re-built. This setting is useful to save bandwidth and disk space in CI settings.
+- **hash_algorithm**: Selects the hash function used for cache keys and change detection. `xxh3` (default) offers extremely fast, 64-bit hashes with a negligible collision probability for typical builds, while `sha256` is slower but cryptographically strong—use it if you are hashing untrusted inputs or want a vanishingly small risk of collisions despite the performance cost.
 - **all_platforms**: When set to `true` skips the platform selection step and builds all targets for all platforms ([read more](/topics/querying)).
 - **skip_workspace_lock**: When `true`, Grog does not acquire a workspace-level lock before executing. **Warning:** Running multiple grog instances without locking can corrupt the workspace or cache.
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -168,6 +168,7 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetDefault("os", runtime.GOOS)
 	viper.SetDefault("arch", runtime.GOARCH)
 	viper.SetDefault("cache.gcs.shared_cache", true)
+	viper.SetDefault("hash_algorithm", config.HashAlgorithmXXH3)
 	viper.SetDefault("environment_variables", make(map[string]string))
 
 	names := []string{"grog"}
@@ -221,6 +222,8 @@ func initConfig(cmd *cobra.Command) error {
 	if err := viper.Unmarshal(&config.Global); err != nil {
 		return fmt.Errorf("Failed to parse config: %v\n", err)
 	}
+
+	config.Global.HashAlgorithm = strings.ToLower(config.Global.HashAlgorithm)
 
 	logger := console.InitLogger()
 	logger.Debugf("Using config file: %s", viper.ConfigFileUsed())

--- a/internal/hashing/get_hasher.go
+++ b/internal/hashing/get_hasher.go
@@ -1,9 +1,76 @@
 package hashing
 
-import "github.com/zeebo/xxh3"
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
 
-// GetHasher returns a new hasher
-// abstracted here to make testing new hash algorithms easier
-func GetHasher() *xxh3.Hasher {
-	return xxh3.New()
+	"grog/internal/config"
+
+	"github.com/zeebo/xxh3"
+)
+
+// Hasher defines the hashing interface used throughout grog.
+type Hasher interface {
+	io.Writer
+	WriteString(string) (int, error)
+	SumString() string
 }
+
+// GetHasher returns a new hasher instance based on the configured algorithm.
+// xxh3 is the default for speed, but sha256 can be selected for a
+// cryptographic-grade hash.
+func GetHasher() Hasher {
+	switch config.Global.HashAlgorithm {
+	case config.HashAlgorithmSHA256:
+		return newSHA256Hasher()
+	case "", config.HashAlgorithmXXH3:
+		fallthrough
+	default:
+		return newXXH3Hasher()
+	}
+}
+
+type xxh3Hasher struct {
+	hasher *xxh3.Hasher
+}
+
+func newXXH3Hasher() Hasher {
+	return &xxh3Hasher{hasher: xxh3.New()}
+}
+
+func (h *xxh3Hasher) Write(p []byte) (int, error) {
+	return h.hasher.Write(p)
+}
+
+func (h *xxh3Hasher) WriteString(s string) (int, error) {
+	return h.hasher.WriteString(s)
+}
+
+func (h *xxh3Hasher) SumString() string {
+	return fmt.Sprintf("%x", h.hasher.Sum64())
+}
+
+type sha256Hasher struct {
+	hasher hash.Hash
+}
+
+func newSHA256Hasher() Hasher {
+	return &sha256Hasher{hasher: sha256.New()}
+}
+
+func (h *sha256Hasher) Write(p []byte) (int, error) {
+	return h.hasher.Write(p)
+}
+
+func (h *sha256Hasher) WriteString(s string) (int, error) {
+	return io.WriteString(h.hasher, s)
+}
+
+func (h *sha256Hasher) SumString() string {
+	return fmt.Sprintf("%x", h.hasher.Sum(nil))
+}
+
+var _ Hasher = (*xxh3Hasher)(nil)
+var _ Hasher = (*sha256Hasher)(nil)

--- a/internal/hashing/hash_files.go
+++ b/internal/hashing/hash_files.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 )
 
-// HashFile computes the xxhash hash of a single file.
+// HashFile computes the configured hash of a single file.
 func HashFile(filePath string) (string, error) {
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -21,10 +21,10 @@ func HashFile(filePath string) (string, error) {
 		return "", err
 	}
 	// Return the hash as a hexadecimal string.
-	return fmt.Sprintf("%x", hasher.Sum64()), nil
+	return hasher.SumString(), nil
 }
 
-// HashFiles computes a combined xxhash hash for multiple files relative to packagePath
+// HashFiles computes a combined hash for multiple files relative to packagePath
 // Sorts the array to ensure consistent outputs.
 func HashFiles(absolutePackagePath string, fileList []string) (string, error) {
 	combinedHasher := GetHasher()
@@ -53,5 +53,5 @@ func HashFiles(absolutePackagePath string, fileList []string) (string, error) {
 	}
 
 	// Return the combined hash as a hexadecimal string.
-	return fmt.Sprintf("%x", combinedHasher.Sum64()), nil
+	return combinedHasher.SumString(), nil
 }

--- a/internal/hashing/hash_string.go
+++ b/internal/hashing/hash_string.go
@@ -1,16 +1,14 @@
 package hashing
 
-import (
-	"fmt"
-
-	"github.com/zeebo/xxh3"
-)
-
-// HashString computes the xxhash hash of a string
+// HashString computes the configured hash of a string.
 func HashString(str string) string {
-	return fmt.Sprintf("%x", xxh3.HashString(str))
+	hasher := GetHasher()
+	_, _ = hasher.WriteString(str)
+	return hasher.SumString()
 }
 
 func HashBytes(bytes []byte) string {
-	return fmt.Sprintf("%x", xxh3.Hash128(bytes))
+	hasher := GetHasher()
+	_, _ = hasher.Write(bytes)
+	return hasher.SumString()
 }

--- a/internal/hashing/hash_strings.go
+++ b/internal/hashing/hash_strings.go
@@ -1,14 +1,13 @@
 package hashing
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 )
 
-// HashStrings computes the xxhash hash of a list of string
+// HashStrings computes the configured hash of a list of strings.
 func HashStrings(strList []string) string {
 	// Sort the strings to ensure consistent outputs.
 	sort.Strings(strList)
-	return fmt.Sprintf("%x", HashString(strings.Join(strList, ",")))
+	return HashString(strings.Join(strList, ","))
 }

--- a/internal/hashing/hash_target.go
+++ b/internal/hashing/hash_target.go
@@ -27,7 +27,7 @@ func GetTargetChangeHash(target model.Target, dependencyHashes []string) (string
 	return fmt.Sprintf("%s_%s", targetDefinitionHash, inputContentHash), err
 }
 
-// hashTargetDefinition computes the xxhash hash of a single file.
+// hashTargetDefinition computes the configured hash of a single file.
 func hashTargetDefinition(target model.Target, dependencyHashes []string) (string, error) {
 	hasher := GetHasher()
 
@@ -45,7 +45,7 @@ func hashTargetDefinition(target model.Target, dependencyHashes []string) (strin
 		return "", err
 	}
 	// Return the hash as a hexadecimal string.
-	return fmt.Sprintf("%x", hasher.Sum64()), nil
+	return hasher.SumString(), nil
 }
 
 func sorted(s []string) string {

--- a/internal/output/get_output_hash.go
+++ b/internal/output/get_output_hash.go
@@ -16,7 +16,7 @@ func getOutputHash(outputs []*gen.Output) (string, error) {
 
 	marshalOptions := proto.MarshalOptions{Deterministic: true}
 	// Calculate combined hash
-	digests := make([]string, len(outputs))
+	digests := make([]string, 0, len(outputs))
 	for _, output := range outputs {
 		var digest string
 		data, err := marshalOptions.Marshal(output)
@@ -37,5 +37,5 @@ func getOutputHash(outputs []*gen.Output) (string, error) {
 		}
 	}
 
-	return fmt.Sprintf("%x", hasher.Sum64()), nil
+	return hasher.SumString(), nil
 }

--- a/internal/output/handlers/dir_output_handler.go
+++ b/internal/output/handlers/dir_output_handler.go
@@ -72,7 +72,7 @@ func (d *DirectoryOutputHandler) getDirectoryHash(ctx context.Context, target mo
 		return "", fmt.Errorf("failed to hash tree: %w", err)
 	}
 
-	treeDigest := fmt.Sprintf("%x", hasher.Sum64())
+	treeDigest := hasher.SumString()
 	return treeDigest, nil
 }
 
@@ -116,8 +116,8 @@ func (d *DirectoryOutputHandler) Write(
 		return nil, fmt.Errorf("failed to hash tree: %w", err)
 	}
 
-	treeDigest := fmt.Sprintf("%x", hasher.Sum64())
-	err = d.cas.Write(ctx, fmt.Sprintf("%x", hasher.Sum64()), bytes.NewReader(marshalledTree))
+	treeDigest := hasher.SumString()
+	err = d.cas.Write(ctx, treeDigest, bytes.NewReader(marshalledTree))
 	if err != nil {
 		return nil, fmt.Errorf("failed to write tree to cache: %w", err)
 	}
@@ -282,14 +282,14 @@ func computeDirectoryDigest(dir *gen.Directory) (*gen.Digest, error) {
 		return nil, fmt.Errorf("failed to marshal directory: %w", err)
 	}
 
-	// Compute xxhash hash
+	// Compute hash
 	hasher := hashing.GetHasher()
 	if _, err := hasher.Write(data); err != nil {
 		return nil, fmt.Errorf("failed to hash directory: %w", err)
 	}
 
 	return &gen.Digest{
-		Hash:      fmt.Sprintf("%x", hasher.Sum64()),
+		Hash:      hasher.SumString(),
 		SizeBytes: int64(len(data)),
 	}, nil
 }
@@ -309,7 +309,7 @@ func computeFileDigest(path string) (*gen.Digest, error) {
 	}
 
 	return &gen.Digest{
-		Hash:      fmt.Sprintf("%x", hasher.Sum64()),
+		Hash:      hasher.SumString(),
 		SizeBytes: size,
 	}, nil
 }

--- a/internal/output/handlers/docker_output_handler.go
+++ b/internal/output/handlers/docker_output_handler.go
@@ -59,7 +59,7 @@ func (d *DockerOutputHandler) Hash(ctx context.Context, target model.Target, out
 		return "", fmt.Errorf("failed to hash Docker image tarball for image %q: %w", imageName, err)
 	}
 
-	return fmt.Sprintf("%x", hasher.Sum64()), nil
+	return hasher.SumString(), nil
 }
 
 // Write saves the Docker image as a tarball and stores it in the cache using go-containerregistry
@@ -133,7 +133,7 @@ func hashLocalTarball(ref name.Reference, img v1.Image) (string, error) {
 		hashReader.Close()
 		return "", fmt.Errorf("failed to hash Docker image tarball for image %q: %w", ref.Name(), err)
 	}
-	return fmt.Sprintf("%x", hasher.Sum64()), nil
+	return hasher.SumString(), nil
 }
 
 // Load loads the Docker image tarball from the cache and imports it into the Docker engine using go-containerregistry


### PR DESCRIPTION
## Summary
- add a configurable hashing interface that supports xxh3 by default and sha256 as an alternative
- thread the selected hasher through hashing utilities and output handlers while fixing deterministic output hashing
- document the new hash_algorithm setting and guidance on when to prefer sha256

## Testing
- `go test ./...` *(fails: integration suite requires Docker and the pkl CLI, and completion fixtures differ in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692764c16cec8327b7f711947f706e4d)