### PR TITLE
feat: add progress tracking to local docker tar setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,9 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/fatih/color v1.18.0
 	github.com/google/go-containerregistry v0.20.7
+	github.com/lucasb-eyer/go-colorful v1.3.0
 	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.1
@@ -100,7 +102,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -110,7 +111,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -40,6 +40,10 @@ var RootCmd = &cobra.Command{
 			return err
 		}
 
+		if !console.UseTea() {
+			config.Global.DisableProgressTracker = true
+		}
+
 		if err := config.Global.ValidateGrogVersion(Version); err != nil {
 			console.InitLogger().Fatalf("Invalid grog version: %v", err)
 		}

--- a/internal/console/task_ui.go
+++ b/internal/console/task_ui.go
@@ -39,7 +39,8 @@ func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.M
 
 	var opts []tea.ProgramOption
 	opts = append(opts, tea.WithContext(ctx))
-	if !UseTea() {
+	useTea := UseTea()
+	if !useTea {
 		// If we're in daemon mode don't render the TUI
 		opts = append(opts, tea.WithInput(nil), tea.WithoutRenderer())
 	}


### PR DESCRIPTION
## Summary
- only compute cached docker tarball size when progress tracking is active
- disable progress tracking when the task UI is disabled to avoid background updates, applying the toggle during root command initialization
- promote termenv and go-colorful to direct dependencies alongside the TUI progress tracking changes

## Testing
- pre-commit run -a *(fails: `pre-commit` not available in the environment)*
- go test ./... *(interrupted manually after prolonged execution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929978797048327b932ea5a6283c6b5)