### PR TITLE
fix: non-deterministic directory hashes

### DIFF
--- a/internal/hashing/hash_bytes.go
+++ b/internal/hashing/hash_bytes.go
@@ -1,0 +1,7 @@
+package hashing
+
+func HashBytes(bytes []byte) string {
+	hasher := GetHasher()
+	_, _ = hasher.Write(bytes)
+	return hasher.SumString()
+}

--- a/internal/hashing/hash_string.go
+++ b/internal/hashing/hash_string.go
@@ -6,9 +6,3 @@ func HashString(str string) string {
 	_, _ = hasher.WriteString(str)
 	return hasher.SumString()
 }
-
-func HashBytes(bytes []byte) string {
-	hasher := GetHasher()
-	_, _ = hasher.Write(bytes)
-	return hasher.SumString()
-}


### PR DESCRIPTION
Of course the tree children need to be sorted before the protobuf is hashed to make this consistent.