### PR TITLE
feat: include docker backend type in target cache key

### DIFF
--- a/internal/hashing/hash_target.go
+++ b/internal/hashing/hash_target.go
@@ -44,11 +44,26 @@ func hashTargetDefinition(target model.Target, dependencyHashes []string) (strin
 		_, err = hasher.WriteString(config.Global.GetPlatform())
 	}
 
+	// Include the docker backend in the hash for targets with docker outputs
+	// so that cache results from different backends (tarball vs registry) can co-exist
+	if hasDockerOutput(target) {
+		_, err = hasher.WriteString(config.Global.Docker.Backend)
+	}
+
 	if err != nil {
 		return "", err
 	}
 	// Return the hash as a hexadecimal string.
 	return hasher.SumString(), nil
+}
+
+func hasDockerOutput(target model.Target) bool {
+	for _, output := range target.AllOutputs() {
+		if output.Type == "docker" {
+			return true
+		}
+	}
+	return false
 }
 
 func sorted(s []string) string {

--- a/internal/hashing/hash_target_test.go
+++ b/internal/hashing/hash_target_test.go
@@ -3,6 +3,7 @@ package hashing
 import (
 	"testing"
 
+	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/model"
 )
@@ -28,6 +29,54 @@ func TestHashTargetDefinition_FingerprintAffectsHash(t *testing.T) {
 
 	if hashWithV1 == hashWithV101 {
 		t.Fatalf("expected hash to change when fingerprint value changes: %s", hashWithV101)
+	}
+}
+
+func TestHashTargetDefinition_DockerBackendAffectsHashForDockerTargets(t *testing.T) {
+	dockerTarget := model.Target{
+		Label:   label.TL("pkg", "target"),
+		Command: "docker build .",
+		Outputs: []model.Output{model.NewOutput("docker", "my-image")},
+	}
+
+	config.Global.Docker.Backend = config.DockerBackendFSTarball
+	hashTarball, err := hashTargetDefinition(dockerTarget, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	config.Global.Docker.Backend = config.DockerBackendRegistry
+	hashRegistry, err := hashTargetDefinition(dockerTarget, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	if hashTarball == hashRegistry {
+		t.Fatalf("expected different hashes for different docker backends, got: %s", hashTarball)
+	}
+}
+
+func TestHashTargetDefinition_DockerBackendDoesNotAffectNonDockerTargets(t *testing.T) {
+	target := model.Target{
+		Label:   label.TL("pkg", "target"),
+		Command: "echo hi",
+		Outputs: []model.Output{model.NewOutput("file", "output.txt")},
+	}
+
+	config.Global.Docker.Backend = config.DockerBackendFSTarball
+	hashTarball, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	config.Global.Docker.Backend = config.DockerBackendRegistry
+	hashRegistry, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	if hashTarball != hashRegistry {
+		t.Fatalf("expected same hash for non-docker target regardless of docker backend, got: %s vs %s", hashTarball, hashRegistry)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Include the configured docker backend (`tarball` or `registry`) in the target definition hash for targets with docker outputs
- This allows cache results from different docker backends to co-exist per target, preventing stale/incompatible cache hits when switching backends
- Non-docker targets are unaffected

## Test plan
- [x] New test: changing docker backend produces different hash for docker targets
- [x] New test: changing docker backend does not affect non-docker targets
- [ ] Verify `go test ./...` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)