### PR TITLE
fix: bound directory CAS I/O concurrency to prevent thread exhaustion

### DIFF
--- a/internal/output/handlers/dir_output_handler.go
+++ b/internal/output/handlers/dir_output_handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -20,8 +21,16 @@ import (
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
 
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/proto"
 )
+
+// maxConcurrentCASOps limits the number of concurrent CAS file I/O operations
+// (uploads and downloads) to prevent thread exhaustion when directory outputs
+// contain many files. Each CAS operation may pin an OS thread (e.g. blocking
+// on S3 HTTP calls), so unbounded concurrency can exceed Go's 10,000-thread
+// limit in workspaces with many targets and large directory outputs.
+var maxConcurrentCASOps = int64(runtime.NumCPU() * 4)
 
 // DirectoryOutputHandler handles directory outputs by turning them into a merkle tree
 // whose definition and file contents are stored in the CAS.
@@ -209,11 +218,12 @@ func (d *DirectoryOutputHandler) Write(
 	}, nil
 }
 
-// uploadFilesToCas uploads all files in parallel to the CAS.
+// uploadFilesToCas uploads files to the CAS with bounded concurrency.
 func uploadFilesToCas(ctx context.Context, cas *caching.Cas, fileUploads []fileUpload, progress *worker.ProgressTracker) (int64, error) {
 	logger := console.GetLogger(ctx)
 	var sizeBytes atomic.Int64
 
+	sem := semaphore.NewWeighted(maxConcurrentCASOps)
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(fileUploads))
 
@@ -222,6 +232,12 @@ func uploadFilesToCas(ctx context.Context, cas *caching.Cas, fileUploads []fileU
 		localUploadAction := uploadAction
 		go func() {
 			defer wg.Done()
+			if err := sem.Acquire(ctx, 1); err != nil {
+				errChan <- err
+				return
+			}
+			defer sem.Release(1)
+
 			logger.Debugf("uploading %s to CAS digest %s", localUploadAction.absolutePath, localUploadAction.digest)
 			file, err := os.Open(localUploadAction.absolutePath)
 			if err != nil {
@@ -507,9 +523,10 @@ func (d *DirectoryOutputHandler) Load(
 
 	// WaitGroup to wait for all goroutines to finish
 	var waitGroup sync.WaitGroup
+	sem := semaphore.NewWeighted(maxConcurrentCASOps)
 	errChan := make(chan error, len(tree.Children))
 	// Recursively load the directory structure
-	if err := d.loadDirectoryRecursive(ctx, dirPath, tree.Root, childrenMap, progress, &waitGroup, errChan); err != nil {
+	if err := d.loadDirectoryRecursive(ctx, dirPath, tree.Root, childrenMap, progress, &waitGroup, sem, errChan); err != nil {
 		return fmt.Errorf("failed to load directory structure: %w", err)
 	}
 
@@ -537,6 +554,7 @@ func (d *DirectoryOutputHandler) loadDirectoryRecursive(
 	childrenMap map[string]*gen.Directory,
 	progress *worker.ProgressTracker,
 	waitGroup *sync.WaitGroup,
+	sem *semaphore.Weighted,
 	errChan chan error,
 ) error {
 	// Create all files
@@ -547,6 +565,12 @@ func (d *DirectoryOutputHandler) loadDirectoryRecursive(
 		// Fetch file contents from CAS
 		go func(filePath string, digest string) {
 			defer waitGroup.Done()
+			if err := sem.Acquire(ctx, 1); err != nil {
+				errChan <- err
+				return
+			}
+			defer sem.Release(1)
+
 			console.GetLogger(ctx).Debugf("loading file for directory output %s from digest %s", filePath, digest)
 			err := d.downloadFile(ctx, digest, filePath, fileNode.IsExecutable, progress)
 			if err != nil {
@@ -571,7 +595,7 @@ func (d *DirectoryOutputHandler) loadDirectoryRecursive(
 		}
 
 		// Recursively load the subdirectory
-		if err := d.loadDirectoryRecursive(ctx, subDirPath, childDir, childrenMap, progress, waitGroup, errChan); err != nil {
+		if err := d.loadDirectoryRecursive(ctx, subDirPath, childDir, childrenMap, progress, waitGroup, sem, errChan); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a `semaphore.Weighted` to `uploadFilesToCas` and `loadDirectoryRecursive` to limit concurrent CAS file operations to `NumCPU * 4`.

Fixes #99

## Problem

Both functions spawn one goroutine per file with no bound. When many targets with large directory outputs build concurrently against an S3 backend, the combined goroutine count from file I/O, AWS SDK connection pools, and subprocess threads exceeds Go's 10,000-thread limit, crashing the process.

## Changes

- `uploadFilesToCas`: goroutines now acquire a semaphore slot before performing the CAS write
- `loadDirectoryRecursive`: same pattern for CAS downloads, with the semaphore shared across recursive calls
- Default concurrency: `runtime.NumCPU() * 4` (exported as `maxConcurrentCASOps` for testability)
- Uses `golang.org/x/sync/semaphore` which is already a dependency (used in `docker_output_handler.go`)

## Testing

- All existing `TestDirectoryOutputHandler_*` tests pass
- Tested in CI against a workspace with 70 selected targets and S3 cache backend (previously crashed every run)