### PR TITLE
perf(traces): batch span loading and stream export output

### DIFF
--- a/internal/cmd/cmds/traces.go
+++ b/internal/cmd/cmds/traces.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -351,22 +352,12 @@ var tracesExportCmd = &cobra.Command{
 			logger.Fatalf("failed to list traces: %v", err)
 		}
 
-		var traces []*tracing.BuildTrace
-		for _, entry := range entries {
-			trace, loadErr := store.FindAndLoad(ctx, entry.TraceID)
-			if loadErr != nil {
-				logger.Warnf("skipping trace %s: %v", entry.TraceID, loadErr)
-				continue
-			}
-			traces = append(traces, trace)
-		}
-
-		if len(traces) == 0 {
+		if len(entries) == 0 {
 			logger.Info("No traces to export.")
 			return
 		}
 
-		w := os.Stdout
+		var w io.Writer = os.Stdout
 		if tracesExportOutput != "" {
 			f, openErr := os.Create(tracesExportOutput)
 			if openErr != nil {
@@ -378,11 +369,11 @@ var tracesExportCmd = &cobra.Command{
 
 		switch tracesExportFormat {
 		case "jsonl":
-			if err := tracing.ExportJSONL(traces, w); err != nil {
+			if err := tracing.ExportJSONL(ctx, store, entries, w); err != nil {
 				logger.Fatalf("export failed: %v", err)
 			}
 		case "otel":
-			if err := tracing.ExportOTLP(traces, w); err != nil {
+			if err := tracing.ExportOTLP(ctx, store, entries, w); err != nil {
 				logger.Fatalf("export failed: %v", err)
 			}
 		default:

--- a/internal/tracing/export.go
+++ b/internal/tracing/export.go
@@ -1,6 +1,8 @@
 package tracing
 
 import (
+	"bufio"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -9,53 +11,117 @@ import (
 	"time"
 )
 
-// ExportJSONL writes each BuildTrace as a single JSON line.
-func ExportJSONL(traces []*BuildTrace, w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	for _, trace := range traces {
-		// Flatten into a single JSON object with build fields + spans array
-		obj := map[string]any{
-			"trace_id":                  trace.Build.TraceID,
-			"workspace":                 trace.Build.Workspace,
-			"git_commit":                trace.Build.GitCommit,
-			"git_branch":                trace.Build.GitBranch,
-			"grog_version":              trace.Build.GrogVersion,
-			"platform":                  trace.Build.Platform,
-			"command":                   trace.Build.Command,
-			"start_time_unix_millis":    trace.Build.StartTimeUnixMillis,
-			"total_duration_millis":     trace.Build.TotalDurationMillis,
-			"total_targets":             trace.Build.TotalTargets,
-			"success_count":             trace.Build.SuccessCount,
-			"failure_count":             trace.Build.FailureCount,
-			"cache_hit_count":           trace.Build.CacheHitCount,
-			"critical_path_exec_millis": trace.Build.CriticalPathExecMillis,
-			"critical_path_cache_millis": trace.Build.CriticalPathCacheMillis,
-			"async_cache_wait_millis":   trace.Build.AsyncCacheWaitMillis,
-			"is_ci":                     trace.Build.IsCI,
-			"requested_patterns":        trace.Build.RequestedPatterns,
-			"spans":                     trace.Spans,
+// SpanLoader loads spans for a batch of traces in one query.
+// Satisfied by *TraceStore.
+type SpanLoader interface {
+	LoadSpansForTraces(ctx context.Context, traceIDs []string) (map[string][]SpanRow, error)
+}
+
+// exportChunkSize bounds how many traces' spans are held in memory at once.
+const exportChunkSize = 200
+
+func buildJSONLObj(b BuildRow, spans []SpanRow) map[string]any {
+	return map[string]any{
+		"trace_id":                   b.TraceID,
+		"workspace":                  b.Workspace,
+		"git_commit":                 b.GitCommit,
+		"git_branch":                 b.GitBranch,
+		"grog_version":               b.GrogVersion,
+		"platform":                   b.Platform,
+		"command":                    b.Command,
+		"start_time_unix_millis":     b.StartTimeUnixMillis,
+		"total_duration_millis":      b.TotalDurationMillis,
+		"total_targets":              b.TotalTargets,
+		"success_count":              b.SuccessCount,
+		"failure_count":              b.FailureCount,
+		"cache_hit_count":            b.CacheHitCount,
+		"critical_path_exec_millis":  b.CriticalPathExecMillis,
+		"critical_path_cache_millis": b.CriticalPathCacheMillis,
+		"async_cache_wait_millis":    b.AsyncCacheWaitMillis,
+		"is_ci":                      b.IsCI,
+		"requested_patterns":         b.RequestedPatterns,
+		"spans":                      spans,
+	}
+}
+
+// ExportJSONL streams traces as newline-delimited JSON, loading spans in
+// chunks so memory stays bounded regardless of how many builds are exported.
+func ExportJSONL(ctx context.Context, loader SpanLoader, builds []BuildRow, w io.Writer) error {
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+	encoder := json.NewEncoder(bw)
+
+	return forEachChunk(ctx, loader, builds, func(b BuildRow, spans []SpanRow) error {
+		if err := encoder.Encode(buildJSONLObj(b, spans)); err != nil {
+			return fmt.Errorf("encode trace %s: %w", b.TraceID, err)
 		}
-		if err := encoder.Encode(obj); err != nil {
-			return fmt.Errorf("encode trace %s: %w", trace.Build.TraceID, err)
+		return nil
+	})
+}
+
+// ExportOTLP streams traces as an OTLP JSON document. The top-level object
+// must be emitted as a single value, so spans are still loaded chunk-by-chunk
+// but each resourceSpans entry is written to the buffered writer as it is
+// produced to avoid holding every OTLP span in memory.
+func ExportOTLP(ctx context.Context, loader SpanLoader, builds []BuildRow, w io.Writer) error {
+	bw := bufio.NewWriter(w)
+	defer bw.Flush()
+
+	if _, err := bw.WriteString("{\n  \"resourceSpans\": ["); err != nil {
+		return err
+	}
+
+	first := true
+	err := forEachChunk(ctx, loader, builds, func(b BuildRow, spans []SpanRow) error {
+		rs := buildOTLPResourceSpans(&BuildTrace{Build: b, Spans: spans})
+		data, err := json.MarshalIndent(rs, "    ", "  ")
+		if err != nil {
+			return fmt.Errorf("encode trace %s: %w", b.TraceID, err)
+		}
+		if first {
+			if _, err := bw.WriteString("\n    "); err != nil {
+				return err
+			}
+			first = false
+		} else {
+			if _, err := bw.WriteString(",\n    "); err != nil {
+				return err
+			}
+		}
+		_, err = bw.Write(data)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = bw.WriteString("\n  ]\n}\n")
+	return err
+}
+
+func forEachChunk(ctx context.Context, loader SpanLoader, builds []BuildRow, emit func(BuildRow, []SpanRow) error) error {
+	for start := 0; start < len(builds); start += exportChunkSize {
+		end := start + exportChunkSize
+		if end > len(builds) {
+			end = len(builds)
+		}
+		chunk := builds[start:end]
+
+		ids := make([]string, len(chunk))
+		for i, b := range chunk {
+			ids[i] = b.TraceID
+		}
+		spansByID, err := loader.LoadSpansForTraces(ctx, ids)
+		if err != nil {
+			return fmt.Errorf("load spans: %w", err)
+		}
+		for _, b := range chunk {
+			if err := emit(b, spansByID[b.TraceID]); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
-}
-
-// ExportOTLP writes traces in OpenTelemetry-compatible JSON format.
-func ExportOTLP(traces []*BuildTrace, w io.Writer) error {
-	export := otlpExport{
-		ResourceSpans: make([]otlpResourceSpans, 0, len(traces)),
-	}
-
-	for _, trace := range traces {
-		rs := buildOTLPResourceSpans(trace)
-		export.ResourceSpans = append(export.ResourceSpans, rs)
-	}
-
-	encoder := json.NewEncoder(w)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(export)
 }
 
 // OTLP JSON structures

--- a/internal/tracing/store.go
+++ b/internal/tracing/store.go
@@ -289,6 +289,57 @@ func (s *TraceStore) LoadSpans(ctx context.Context, traceID string) ([]SpanRow, 
 	return scanSpanRows(rows)
 }
 
+// LoadSpansForTraces retrieves all spans for the given trace IDs in a single
+// parquet scan, returning a map keyed by trace_id. Large ID sets are chunked
+// internally to keep the generated SQL bounded.
+func (s *TraceStore) LoadSpansForTraces(ctx context.Context, traceIDs []string) (map[string][]SpanRow, error) {
+	result := make(map[string][]SpanRow, len(traceIDs))
+	if len(traceIDs) == 0 {
+		return result, nil
+	}
+
+	const chunkSize = 500
+	for start := 0; start < len(traceIDs); start += chunkSize {
+		end := start + chunkSize
+		if end > len(traceIDs) {
+			end = len(traceIDs)
+		}
+		chunk := traceIDs[start:end]
+
+		quoted := make([]string, 0, len(chunk))
+		for _, id := range chunk {
+			quoted = append(quoted, "'"+sanitize(id)+"'")
+		}
+
+		query := fmt.Sprintf(`SELECT trace_id, label, package, change_hash, output_hash,
+			status, cache_result, command, exit_code, is_test,
+			start_time_unix_millis, end_time_unix_millis, total_duration_millis,
+			queue_wait_millis, hash_duration_millis, cache_check_millis,
+			command_duration_millis, output_write_millis, output_load_millis,
+			cache_write_millis, dep_load_millis, tags, dependencies
+			FROM read_parquet('%s', union_by_name=true)
+			WHERE trace_id IN (%s)`,
+			s.resolver.SpansGlob(), strings.Join(quoted, ","))
+
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			if isNoFilesError(err) {
+				continue
+			}
+			return nil, err
+		}
+		spans, err := scanSpanRows(rows)
+		rows.Close()
+		if err != nil {
+			return nil, err
+		}
+		for _, sp := range spans {
+			result[sp.TraceID] = append(result[sp.TraceID], sp)
+		}
+	}
+	return result, nil
+}
+
 // FindAndLoad retrieves a full trace by ID prefix.
 func (s *TraceStore) FindAndLoad(ctx context.Context, traceIDPrefix string) (*BuildTrace, error) {
 	build, err := s.LoadBuild(ctx, traceIDPrefix)


### PR DESCRIPTION
## Summary
- `grog traces export` was running 1 + 2N full parquet-glob scans (one `FindAndLoad` per build) and buffering every trace in RAM before emitting a byte. On a workspace with ~2k builds that's ~4k glob scans over a 100 MB+ parquet tree.
- Add `TraceStore.LoadSpansForTraces` that fetches spans for many trace IDs in a single DuckDB query (chunked at 500 IDs to keep SQL bounded).
- Stream the export: iterate builds in chunks of 200, load that chunk's spans, emit through a `bufio.Writer` and discard before loading the next chunk. Memory stays bounded regardless of total trace count; first bytes hit the writer after the first chunk instead of after all traces load.
- `ExportJSONL` / `ExportOTLP` now take `(ctx, SpanLoader, []BuildRow, w)` instead of a pre-materialized `[]*BuildTrace`. `FindAndLoad` is untouched — `traces show <id>` still uses it.

## Measured
On `~/.grog/782aaff89def2cf9-feat-grog-dashboard` (1,944 builds, 3,888 parquet files, 101 MB on disk):
- Full `--format=jsonl` export: **8.4s**, 131 MB output, 1,944 lines.
- Full `--format=otel` export (10 builds smoke test): 1.4s, valid JSON.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/tracing/... ./internal/cmd/...`
- [x] Full JSONL export on 1,944-build workspace — 8.4s, line count matches build count, spot-checked first/last lines
- [x] OTLP export validates as JSON via `python3 -c "import json; json.load(...)"`
- [ ] Reviewer: confirm the `IN (…)` chunk size of 500 is fine for your DuckDB builds (bump down if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)