### PR TITLE
[codex] Update Slack invite link in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <br>
   <img src="https://github.com/chrismatix/grog/actions/workflows/test.yml/badge.svg" alt="Test status">
   <img src="https://img.shields.io/github/v/release/chrismatix/grog.svg" alt="release version">
+  <a href="https://join.slack.com/t/grog-build/shared_invite/zt-3vipu1c5w-9ouz0nDV0YNKYIqskMgv5Q"><img src="https://img.shields.io/badge/Slack-Join%20chat-4A154B?logo=slack&logoColor=white" alt="Join Slack"></a>
 </p>
 
 Grog **is** the monorepo build tool for the [grug-brained](https://grugbrain.dev/) developer.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
       plugins: [starlightThemeRapide()],
       social: [
         { icon: "github", label: "GitHub", href: "https://github.com/chrismatix/grog" },
-        { icon: "slack", label: "Slack", href: "https://grog-build.slack.com" },
+        { icon: "slack", label: "Slack", href: "https://join.slack.com/t/grog-build/shared_invite/zt-3vipu1c5w-9ouz0nDV0YNKYIqskMgv5Q" },
       ],
       sidebar: [
         {


### PR DESCRIPTION
## Summary
- update the docs site Slack social link to use the new shared invite URL
- add a Slack badge to the README that points to the same invite URL

## Validation
- not run; docs-only change