### PR TITLE
refactor(docker): rename "tarball" backend to "fs"

### DIFF
--- a/docs/src/content/docs/topics/docker-outputs.mdx
+++ b/docs/src/content/docs/topics/docker-outputs.mdx
@@ -30,7 +30,7 @@ The filesystem backend stores Docker images as content-addressable blobs (manife
 
 ```toml
 [docker]
-backend = "tarball"  # This is the default, so it's optional
+backend = "fs"  # This is the default, so it's optional
 ```
 
 **Advantages:**

--- a/integration/test_repos/docker_output/grog.toml
+++ b/integration/test_repos/docker_output/grog.toml
@@ -1,2 +1,2 @@
 [docker]
-backend = "tarball"
+backend = "fs"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,9 +139,9 @@ func (w WorkspaceConfig) Validate() error {
 	}
 
 	if w.Docker.Backend != "" &&
-		(w.Docker.Backend != DockerBackendFSTarball && w.Docker.Backend != DockerBackendRegistry) {
+		(w.Docker.Backend != DockerBackendFS && w.Docker.Backend != DockerBackendRegistry) {
 		return fmt.Errorf("invalid docker backend: %s. Must be either %s or %s",
-			w.Docker.Backend, DockerBackendFSTarball, DockerBackendRegistry)
+			w.Docker.Backend, DockerBackendFS, DockerBackendRegistry)
 	}
 
 	// assert that tags and exclude tags do not overlap
@@ -240,8 +240,8 @@ Backend  CacheBackend `mapstructure:"backend"`
 	S3       S3CacheConfig  `mapstructure:"s3"`
 }
 const (
-	DockerBackendFSTarball = "tarball"
-	DockerBackendRegistry  = "registry"
+	DockerBackendFS       = "fs"
+	DockerBackendRegistry = "registry"
 )
 
 type DockerConfig struct {

--- a/internal/hashing/hash_target.go
+++ b/internal/hashing/hash_target.go
@@ -45,7 +45,7 @@ func hashTargetDefinition(target model.Target, dependencyHashes []string) (strin
 	}
 
 	// Include the docker backend in the hash for targets with docker outputs
-	// so that cache results from different backends (tarball vs registry) can co-exist
+	// so that cache results from different backends (fs vs registry) can co-exist
 	if hasDockerOutput(target) {
 		_, err = hasher.WriteString(config.Global.Docker.Backend)
 	}

--- a/internal/hashing/hash_target_test.go
+++ b/internal/hashing/hash_target_test.go
@@ -39,8 +39,8 @@ func TestHashTargetDefinition_DockerBackendAffectsHashForDockerTargets(t *testin
 		Outputs: []model.Output{model.NewOutput("docker", "my-image")},
 	}
 
-	config.Global.Docker.Backend = config.DockerBackendFSTarball
-	hashTarball, err := hashTargetDefinition(dockerTarget, nil)
+	config.Global.Docker.Backend = config.DockerBackendFS
+	hashFS, err := hashTargetDefinition(dockerTarget, nil)
 	if err != nil {
 		t.Fatalf("hashTargetDefinition returned error: %v", err)
 	}
@@ -51,8 +51,8 @@ func TestHashTargetDefinition_DockerBackendAffectsHashForDockerTargets(t *testin
 		t.Fatalf("hashTargetDefinition returned error: %v", err)
 	}
 
-	if hashTarball == hashRegistry {
-		t.Fatalf("expected different hashes for different docker backends, got: %s", hashTarball)
+	if hashFS == hashRegistry {
+		t.Fatalf("expected different hashes for different docker backends, got: %s", hashFS)
 	}
 }
 
@@ -63,8 +63,8 @@ func TestHashTargetDefinition_DockerBackendDoesNotAffectNonDockerTargets(t *test
 		Outputs: []model.Output{model.NewOutput("file", "output.txt")},
 	}
 
-	config.Global.Docker.Backend = config.DockerBackendFSTarball
-	hashTarball, err := hashTargetDefinition(target, nil)
+	config.Global.Docker.Backend = config.DockerBackendFS
+	hashFS, err := hashTargetDefinition(target, nil)
 	if err != nil {
 		t.Fatalf("hashTargetDefinition returned error: %v", err)
 	}
@@ -75,8 +75,8 @@ func TestHashTargetDefinition_DockerBackendDoesNotAffectNonDockerTargets(t *test
 		t.Fatalf("hashTargetDefinition returned error: %v", err)
 	}
 
-	if hashTarball != hashRegistry {
-		t.Fatalf("expected same hash for non-docker target regardless of docker backend, got: %s vs %s", hashTarball, hashRegistry)
+	if hashFS != hashRegistry {
+		t.Fatalf("expected same hash for non-docker target regardless of docker backend, got: %s vs %s", hashFS, hashRegistry)
 	}
 }
 

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -66,7 +66,7 @@ func NewRegistry(
 		r.Register(handlers.NewDockerRegistryOutputHandler(cas, config.Global.Docker))
 	} else {
 		// The backend setting is validated in the config package
-		// so we can assume it's either "docker" or "fs-tarball"
+		// so we can assume it's either "registry" or "fs"
 		r.Register(handlers.NewDockerOutputHandler(ctx, cas))
 	}
 	return r


### PR DESCRIPTION
## Summary
- Rename the `tarball` docker cache backend option to `fs`. Since #98 the backend streams images via an in-process OCI registry into the filesystem CAS, so "tarball" is no longer accurate.
- Updates the config constant (`DockerBackendFSTarball` → `DockerBackendFS`), the docs, the integration test fixture, and stale comments.

**Breaking change:** users with `backend = "tarball"` in `grog.toml` must update to `backend = "fs"`. Default behavior is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/config/... ./internal/hashing/...`
- [ ] Verify docker integration test still passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)