### PR TITLE
fix(dockerproxy): propagate logger to HTTP request context

### DIFF
--- a/internal/dockerproxy/registry.go
+++ b/internal/dockerproxy/registry.go
@@ -171,6 +171,12 @@ var digestPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
 // handle is the single ServeMux entry — we route by URL shape ourselves
 // because the OCI <name> can itself contain slashes (e.g. "library/ubuntu").
 func (r *Registry) handle(w http.ResponseWriter, req *http.Request) {
+	// net/http gives each request a fresh context that doesn't carry our
+	// logger, so any downstream CAS call that does console.GetLogger(ctx)
+	// would hit the "no logger found" fallback and spam warnings. Attach the
+	// registry's logger up front so every handler and backend call made with
+	// req.Context() inherits it.
+	req = req.WithContext(console.WithLogger(req.Context(), r.logger))
 	r.logger.Tracef("dockerproxy: %s %s", req.Method, req.URL.RequestURI())
 	// Version probe — both GET and HEAD must return 200 with the API version header.
 	if req.URL.Path == "/v2/" || req.URL.Path == "/v2" {


### PR DESCRIPTION
## Summary

- Fixes #109: the in-process OCI registry added in #98 was spamming `DEBUG: no logger found in context, using default logger. This is probably a bug.` — once per blob HEAD/POST/PATCH/PUT and manifest PUT during every `docker push`.
- Root cause: `net/http` gives every incoming request a fresh `req.Context()` that doesn't carry grog's logger. The `dockerproxy` handlers then forward `req.Context()` into CAS calls (`Exists`, `Size`, `Load`, `WriteBytes`, `BeginWrite`, …), and every backend (`fs`, `s3`, `gcs`, `azure`, `remote_wrapper`) resolves the logger via `console.GetLogger(ctx)` — hitting the "no logger found" fallback each time.
- Fix: attach the registry's own logger (already captured from the ctx passed to `New`) to each request context at the top of `Registry.handle`, so every downstream `req.Context()`-derived call inherits it.

## Test plan

- [x] `go test ./internal/dockerproxy/ -count=1` passes
- [x] `go test ./internal/... -count=1` passes
- [x] `go vet ./...` clean
- [ ] Manual: run a build with `--log-level=debug` that caches a docker image and confirm the "no logger found" spam is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)