### PR TITLE
feat: upload caches asynchronously during `grog run`

### DIFF
--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -84,6 +84,26 @@ func RunBuild(
 	loadOutputsMode config.LoadOutputsMode,
 	commandOverride ...string,
 ) {
+	RunBuildAndAfter(ctx, logger, targetPatterns, graph, testFilter, streamLogs, loadOutputsMode, nil, commandOverride...)
+}
+
+// RunBuildAndAfter runs the build, then (only on build success) invokes
+// afterBuildSuccess in parallel with any in-flight async cache writes. The
+// async cache wait, trace finalization, and elapsed-time logging all happen
+// after the callback returns, so the callback gets to run while uploads
+// continue in the background. If afterBuildSuccess is nil, behavior matches
+// RunBuild.
+func RunBuildAndAfter(
+	ctx context.Context,
+	logger *console.Logger,
+	targetPatterns []label.TargetPattern,
+	graph *dag.DirectedTargetGraph,
+	testFilter selection.TargetTypeSelection,
+	streamLogs bool,
+	loadOutputsMode config.LoadOutputsMode,
+	afterBuildSuccess func() error,
+	commandOverride ...string,
+) {
 	startTime := time.Now()
 
 	// Determine command name for tracing
@@ -172,7 +192,41 @@ func RunBuild(
 		config.Global.EnableCache,
 		loadOutputsMode,
 	)
+	if afterBuildSuccess != nil {
+		executor.DeferAsyncWait()
+	}
 	completionMap, executionErr := executor.Execute(ctx)
+
+	// small helper for logging
+	goal := "Build"
+	if testFilter == selection.TestOnly {
+		goal = "Test"
+	} else if testFilter == selection.AllTargets {
+		goal = "Build and test"
+	}
+
+	// When an after-build callback is supplied (e.g. `grog run`), print the
+	// build-success summary before invoking it so the user sees the build
+	// finished before any binary output appears, and so async cache writes
+	// run in parallel with the user's command.
+	var afterBuildErr error
+	calledAfterBuild := false
+	if afterBuildSuccess != nil && buildSucceeded(executionErr, completionMap) {
+		successCount, cacheHits := completionMap.TargetSuccessCount()
+		logger.Infof("%s completed successfully. %s completed (%d cache hits).",
+			goal,
+			console.FCountTargets(successCount),
+			cacheHits)
+		afterBuildErr = afterBuildSuccess()
+		calledAfterBuild = true
+	}
+
+	// Block on outstanding async cache writes so the trace and elapsed time
+	// below report accurate numbers. WaitForAsyncWrites is a no-op if the
+	// build path already waited inside Execute.
+	if afterBuildSuccess != nil && ctx.Err() == nil {
+		executor.WaitForAsyncWrites(ctx)
+	}
 
 	// Write trace (synchronous — Parquet writes are fast for local FS,
 	// and we need to ensure the write completes before the process exits)
@@ -245,14 +299,6 @@ func RunBuild(
 		logger.Errorf("execution failed: %s", executionErr)
 	}
 
-	// small helper for logging
-	goal := "Build"
-	if testFilter == selection.TestOnly {
-		goal = "Test"
-	} else if testFilter == selection.AllTargets {
-		goal = "Build and test"
-	}
-
 	executionErrors := completionMap.GetErrors()
 	successCount, cacheHits := completionMap.TargetSuccessCount()
 
@@ -291,11 +337,31 @@ func RunBuild(
 	}
 
 	if executionErr == nil {
-		logger.Infof("%s completed successfully. %s completed (%d cache hits).",
-			goal,
-			console.FCountTargets(successCount),
-			cacheHits)
+		// Skip the success message if we already printed it before invoking
+		// the after-build callback above.
+		if !calledAfterBuild {
+			logger.Infof("%s completed successfully. %s completed (%d cache hits).",
+				goal,
+				console.FCountTargets(successCount),
+				cacheHits)
+		}
 	} else {
 		os.Exit(1)
 	}
+
+	if afterBuildErr != nil {
+		logger.Fatalf("%v", afterBuildErr)
+	}
+}
+
+// buildSucceeded reports whether the build phase finished cleanly and it is
+// safe to run a dependent post-build step such as user binaries.
+func buildSucceeded(executionErr error, completionMap dag.CompletionMap) bool {
+	if executionErr != nil {
+		return false
+	}
+	if completionMap == nil {
+		return false
+	}
+	return len(completionMap.GetErrors()) == 0
 }

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fatih/color"
@@ -167,7 +168,12 @@ func RunBuildAndAfter(
 	taintCache := caching.NewTaintCache(cache)
 	registry := output.NewRegistry(ctx, cas)
 
-	// Only lock the workspace once necessary, i.e., before we start building
+	// Only lock the workspace once necessary, i.e., before we start building.
+	// The lock is released via releaseWorkspaceLock below. Callers that run a
+	// post-build step (e.g. `grog run` executing a user binary) release it
+	// before invoking the callback so the binary — which may itself shell out
+	// to `grog` — isn't blocked by a lock its parent process still holds.
+	releaseWorkspaceLock := func() {}
 	if config.Global.SkipWorkspaceLock {
 		logger.Warn("Skipping workspace lock. Concurrent grog executions may corrupt the cache or workspace state.")
 	} else {
@@ -175,11 +181,15 @@ func RunBuildAndAfter(
 		if err := locker.Lock(ctx); err != nil {
 			logger.Fatalf("could not acquire workspace lock: %v", err)
 		}
-		defer func() {
-			if err := locker.Unlock(); err != nil {
-				logger.Fatalf("failed to release workspace lock: %v", err)
-			}
-		}()
+		var unlockOnce sync.Once
+		releaseWorkspaceLock = func() {
+			unlockOnce.Do(func() {
+				if err := locker.Unlock(); err != nil {
+					logger.Errorf("failed to release workspace lock: %v", err)
+				}
+			})
+		}
+		defer releaseWorkspaceLock()
 	}
 
 	executor := execution.NewExecutor(
@@ -208,7 +218,9 @@ func RunBuildAndAfter(
 	// When an after-build callback is supplied (e.g. `grog run`), print the
 	// build-success summary before invoking it so the user sees the build
 	// finished before any binary output appears, and so async cache writes
-	// run in parallel with the user's command.
+	// run in parallel with the user's command. The workspace lock is released
+	// up front because the callback may run user binaries that themselves
+	// invoke `grog` — holding the lock across that would deadlock the child.
 	var afterBuildErr error
 	calledAfterBuild := false
 	if afterBuildSuccess != nil && buildSucceeded(executionErr, completionMap) {
@@ -217,6 +229,7 @@ func RunBuildAndAfter(
 			goal,
 			console.FCountTargets(successCount),
 			cacheHits)
+		releaseWorkspaceLock()
 		afterBuildErr = afterBuildSuccess()
 		calledAfterBuild = true
 	}

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -202,7 +202,6 @@ func RunBuildAndAfter(
 	}
 	completionMap, executionErr := executor.Execute(ctx)
 
-	// small helper for logging
 	goal := "Build"
 	if testFilter == selection.TestOnly {
 		goal = "Test"
@@ -210,24 +209,26 @@ func RunBuildAndAfter(
 		goal = "Build and test"
 	}
 
-	// Print the build summary before invoking the callback so the user sees
-	// the build finished before any binary output appears.
-	var afterBuildErr error
-	calledAfterBuild := false
-	if afterBuildSuccess != nil && buildSucceeded(executionErr, completionMap) {
+	// Print the build summary once, up front — it doubles as the signal that
+	// the build finished before any callback output appears.
+	buildOK := buildSucceeded(executionErr, completionMap)
+	if buildOK {
 		successCount, cacheHits := completionMap.TargetSuccessCount()
 		logger.Infof("%s completed successfully. %s completed (%d cache hits).",
 			goal,
 			console.FCountTargets(successCount),
 			cacheHits)
-		releaseWorkspaceLock()
-		afterBuildErr = afterBuildSuccess()
-		calledAfterBuild = true
 	}
 
-	if afterBuildSuccess != nil && ctx.Err() == nil {
-		executor.WaitForAsyncWrites(ctx)
+	// Run the callback (e.g. `grog run` binaries) in parallel with any
+	// outstanding async cache writes.
+	var afterBuildErr error
+	if afterBuildSuccess != nil && buildOK {
+		releaseWorkspaceLock()
+		afterBuildErr = afterBuildSuccess()
 	}
+
+	executor.WaitForAsyncWrites(ctx)
 
 	// Write trace (synchronous — Parquet writes are fast for local FS,
 	// and we need to ensure the write completes before the process exits)
@@ -337,14 +338,7 @@ func RunBuildAndAfter(
 		os.Exit(1)
 	}
 
-	if executionErr == nil {
-		if !calledAfterBuild {
-			logger.Infof("%s completed successfully. %s completed (%d cache hits).",
-				goal,
-				console.FCountTargets(successCount),
-				cacheHits)
-		}
-	} else {
+	if executionErr != nil {
 		os.Exit(1)
 	}
 

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -88,12 +88,9 @@ func RunBuild(
 	RunBuildAndAfter(ctx, logger, targetPatterns, graph, testFilter, streamLogs, loadOutputsMode, nil, commandOverride...)
 }
 
-// RunBuildAndAfter runs the build, then (only on build success) invokes
-// afterBuildSuccess in parallel with any in-flight async cache writes. The
-// async cache wait, trace finalization, and elapsed-time logging all happen
-// after the callback returns, so the callback gets to run while uploads
-// continue in the background. If afterBuildSuccess is nil, behavior matches
-// RunBuild.
+// RunBuildAndAfter runs the build, then — on build success — invokes
+// afterBuildSuccess in parallel with any in-flight async cache writes.
+// afterBuildSuccess=nil is equivalent to RunBuild.
 func RunBuildAndAfter(
 	ctx context.Context,
 	logger *console.Logger,
@@ -169,10 +166,8 @@ func RunBuildAndAfter(
 	registry := output.NewRegistry(ctx, cas)
 
 	// Only lock the workspace once necessary, i.e., before we start building.
-	// The lock is released via releaseWorkspaceLock below. Callers that run a
-	// post-build step (e.g. `grog run` executing a user binary) release it
-	// before invoking the callback so the binary — which may itself shell out
-	// to `grog` — isn't blocked by a lock its parent process still holds.
+	// releaseWorkspaceLock is invoked explicitly before afterBuildSuccess so a
+	// user binary that itself shells out to grog doesn't deadlock on the lock.
 	releaseWorkspaceLock := func() {}
 	if config.Global.SkipWorkspaceLock {
 		logger.Warn("Skipping workspace lock. Concurrent grog executions may corrupt the cache or workspace state.")
@@ -215,12 +210,8 @@ func RunBuildAndAfter(
 		goal = "Build and test"
 	}
 
-	// When an after-build callback is supplied (e.g. `grog run`), print the
-	// build-success summary before invoking it so the user sees the build
-	// finished before any binary output appears, and so async cache writes
-	// run in parallel with the user's command. The workspace lock is released
-	// up front because the callback may run user binaries that themselves
-	// invoke `grog` — holding the lock across that would deadlock the child.
+	// Print the build summary before invoking the callback so the user sees
+	// the build finished before any binary output appears.
 	var afterBuildErr error
 	calledAfterBuild := false
 	if afterBuildSuccess != nil && buildSucceeded(executionErr, completionMap) {
@@ -234,9 +225,6 @@ func RunBuildAndAfter(
 		calledAfterBuild = true
 	}
 
-	// Block on outstanding async cache writes so the trace and elapsed time
-	// below report accurate numbers. WaitForAsyncWrites is a no-op if the
-	// build path already waited inside Execute.
 	if afterBuildSuccess != nil && ctx.Err() == nil {
 		executor.WaitForAsyncWrites(ctx)
 	}
@@ -350,8 +338,6 @@ func RunBuildAndAfter(
 	}
 
 	if executionErr == nil {
-		// Skip the success message if we already printed it before invoking
-		// the after-build callback above.
 		if !calledAfterBuild {
 			logger.Infof("%s completed successfully. %s completed (%d cache hits).",
 				goal,
@@ -367,8 +353,7 @@ func RunBuildAndAfter(
 	}
 }
 
-// buildSucceeded reports whether the build phase finished cleanly and it is
-// safe to run a dependent post-build step such as user binaries.
+// buildSucceeded reports whether it is safe to run a dependent post-build step.
 func buildSucceeded(executionErr error, completionMap dag.CompletionMap) bool {
 	if executionErr != nil {
 		return false

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -138,7 +138,14 @@ func buildAndRunTargets(ctx context.Context, logger *console.Logger, graph *dag.
 		targetPatterns = append(targetPatterns, pattern)
 	}
 
-	RunBuild(
+	afterBuildSuccess := func() error {
+		for _, runTarget := range runTargets {
+			loadDependencyOutputsIfNeeded(ctx, logger, graph, runTarget)
+		}
+		return runTargetBinaries(ctx, logger, runTargets, userCommandArgs)
+	}
+
+	RunBuildAndAfter(
 		ctx,
 		logger,
 		targetPatterns,
@@ -146,16 +153,9 @@ func buildAndRunTargets(ctx context.Context, logger *console.Logger, graph *dag.
 		selection.NonTestOnly,
 		config.Global.StreamLogs,
 		config.Global.GetLoadOutputsMode(),
+		afterBuildSuccess,
 		"run",
 	)
-
-	for _, runTarget := range runTargets {
-		loadDependencyOutputsIfNeeded(ctx, logger, graph, runTarget)
-	}
-
-	if err := runTargetBinaries(ctx, logger, runTargets, userCommandArgs); err != nil {
-		logger.Fatalf("%v", err)
-	}
 }
 
 func loadDependencyOutputsIfNeeded(ctx context.Context, logger *console.Logger, graph *dag.DirectedTargetGraph, runTarget *model.Target) {

--- a/internal/console/task_ui.go
+++ b/internal/console/task_ui.go
@@ -36,11 +36,8 @@ type TaskStateMsg struct {
 func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.Msg)) {
 	msgCh := make(chan tea.Msg, 100)
 
-	// uiDone signals that the bubble tea program is no longer consuming from
-	// msgCh. Producers (workers publishing status updates) must stop trying
-	// to send once this is closed — otherwise they'll block forever filling
-	// up msgCh after the UI has been torn down, which happens when the caller
-	// returns from Execute while async I/O workers are still running.
+	// Closed when the tea program stops consuming msgCh, so producers can
+	// drop messages instead of blocking on a full channel after teardown.
 	uiDone := make(chan struct{})
 
 	// Because bubble tea manages the interrupt we overwrite
@@ -79,8 +76,7 @@ func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.M
 		}
 	}()
 
-	// inspired by program.Send. Drops messages once the UI has shut down so
-	// that background producers never block on a full msgCh.
+	// inspired by program.Send
 	sendFunc := func(msg tea.Msg) {
 		select {
 		case <-wrappedCtx.Done():

--- a/internal/console/task_ui.go
+++ b/internal/console/task_ui.go
@@ -36,6 +36,13 @@ type TaskStateMsg struct {
 func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.Msg)) {
 	msgCh := make(chan tea.Msg, 100)
 
+	// uiDone signals that the bubble tea program is no longer consuming from
+	// msgCh. Producers (workers publishing status updates) must stop trying
+	// to send once this is closed — otherwise they'll block forever filling
+	// up msgCh after the UI has been torn down, which happens when the caller
+	// returns from Execute while async I/O workers are still running.
+	uiDone := make(chan struct{})
+
 	// Because bubble tea manages the interrupt we overwrite
 	// the default cancellation mechanism in cmd_setup.go
 	wrappedCtx, cancel := context.WithCancel(ctx)
@@ -52,6 +59,8 @@ func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.M
 	p := tea.NewProgram(initialModel(ctx, msgCh, cancel), opts...)
 
 	go func() {
+		defer close(uiDone)
+
 		errCh := make(chan error, 1)
 
 		go func() {
@@ -70,10 +79,12 @@ func StartTaskUI(ctx context.Context) (context.Context, *tea.Program, func(tea.M
 		}
 	}()
 
-	// inspired by program.Send
+	// inspired by program.Send. Drops messages once the UI has shut down so
+	// that background producers never block on a full msgCh.
 	sendFunc := func(msg tea.Msg) {
 		select {
 		case <-wrappedCtx.Done():
+		case <-uiDone:
 		case msgCh <- msg:
 		}
 	}

--- a/internal/execution/cache_writer.go
+++ b/internal/execution/cache_writer.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	"grog/internal/caching"
 	"grog/internal/console"
@@ -36,10 +37,11 @@ import (
 // to the target cache (the metadata index that maps input hashes to output hashes).
 // Cleanup() is called on every write plan regardless of outcome to remove staged temp files.
 type CacheWriter struct {
-	targetCache *caching.TargetResultCache
-	ioPool      *worker.TaskWorkerPool[struct{}]
-	asyncWrites bool
-	ioContext   context.Context
+	targetCache  *caching.TargetResultCache
+	ioPool       *worker.TaskWorkerPool[struct{}]
+	asyncWrites  bool
+	ioContext    context.Context
+	pendingCount atomic.Int64
 }
 
 func NewCacheWriter(
@@ -75,7 +77,9 @@ func (c *CacheWriter) PersistPreparedTarget(
 		return c.commit(ctx, targetLabel, preparedTarget, progress, true)
 	}
 
+	c.pendingCount.Add(1)
 	err := c.ioPool.RunFireAndForget(func(ioUpdate worker.StatusFunc) (struct{}, error) {
+		defer c.pendingCount.Add(-1)
 		progress := worker.NewProgressTracker(
 			fmt.Sprintf("%s: writing cache", targetLabel),
 			0,
@@ -87,6 +91,7 @@ func (c *CacheWriter) PersistPreparedTarget(
 		return struct{}{}, nil
 	})
 	if err != nil {
+		c.pendingCount.Add(-1)
 		c.cleanupPlans(ctx, preparedTarget.WritePlans)
 		return err
 	}
@@ -95,6 +100,11 @@ func (c *CacheWriter) PersistPreparedTarget(
 
 func (c *CacheWriter) Wait() {
 	c.ioPool.WaitForCompletion()
+}
+
+// HasPendingWrites reports whether any async cache writes are still in flight.
+func (c *CacheWriter) HasPendingWrites() bool {
+	return c.pendingCount.Load() > 0
 }
 
 func (c *CacheWriter) commit(

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -47,6 +47,7 @@ type Executor struct {
 	coordinator      *PoolCoordinator
 	cacheWriter      *CacheWriter
 	asyncWaitTime    time.Duration
+	deferAsyncWait   bool
 }
 
 func NewExecutor(
@@ -154,13 +155,44 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	// was not interrupted.  Async cache writes use a non-cancellable context
 	// so they can outlive the build, but we must not block an interrupted
 	// shutdown waiting for slow remote uploads to finish.
-	if ctx.Err() == nil {
+	//
+	// When deferAsyncWait is set, the caller is responsible for invoking
+	// WaitForAsyncWrites itself (e.g. `grog run` waits after the user's
+	// binary finishes so cache uploads run in parallel with it).
+	if ctx.Err() == nil && !e.deferAsyncWait {
+		// Inline wait — do not log a "waiting" message because for plain
+		// `grog build` this is just the normal end-of-build cache flush.
 		waitStart := time.Now()
 		e.cacheWriter.Wait()
 		e.asyncWaitTime = time.Since(waitStart)
 	}
 
 	return completionMap, err
+}
+
+// DeferAsyncWait disables the implicit cacheWriter.Wait() at the end of
+// Execute. The caller must invoke WaitForAsyncWrites once it is ready to
+// block on outstanding uploads.
+func (e *Executor) DeferAsyncWait() {
+	e.deferAsyncWait = true
+}
+
+// WaitForAsyncWrites blocks until all outstanding async cache writes complete
+// and records the elapsed time as AsyncWaitTime. Intended for callers that
+// invoked DeferAsyncWait and ran other work (e.g. user binaries) in parallel
+// with cache uploads. Logs a status message when writes are still in flight so
+// the user understands the delay between their command finishing and the
+// process exiting.
+func (e *Executor) WaitForAsyncWrites(ctx context.Context) {
+	if e.cacheWriter == nil {
+		return
+	}
+	if e.cacheWriter.HasPendingWrites() {
+		console.GetLogger(ctx).Infof("Waiting for cache writes to finish in the background...")
+	}
+	waitStart := time.Now()
+	e.cacheWriter.Wait()
+	e.asyncWaitTime = time.Since(waitStart)
 }
 
 // AsyncWaitTime returns the wall-clock time spent waiting for the async I/O

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -152,16 +152,11 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	completionMap, err := walker.Walk(ctx)
 
 	// Wait for I/O pool to drain before returning, but only if the build
-	// was not interrupted.  Async cache writes use a non-cancellable context
+	// was not interrupted. Async cache writes use a non-cancellable context
 	// so they can outlive the build, but we must not block an interrupted
-	// shutdown waiting for slow remote uploads to finish.
-	//
-	// When deferAsyncWait is set, the caller is responsible for invoking
-	// WaitForAsyncWrites itself (e.g. `grog run` waits after the user's
-	// binary finishes so cache uploads run in parallel with it).
+	// shutdown waiting for slow remote uploads to finish. When
+	// deferAsyncWait is set, the caller owns the wait via WaitForAsyncWrites.
 	if ctx.Err() == nil && !e.deferAsyncWait {
-		// Inline wait — do not log a "waiting" message because for plain
-		// `grog build` this is just the normal end-of-build cache flush.
 		waitStart := time.Now()
 		e.cacheWriter.Wait()
 		e.asyncWaitTime = time.Since(waitStart)
@@ -170,19 +165,15 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	return completionMap, err
 }
 
-// DeferAsyncWait disables the implicit cacheWriter.Wait() at the end of
-// Execute. The caller must invoke WaitForAsyncWrites once it is ready to
-// block on outstanding uploads.
+// DeferAsyncWait opts out of the implicit cache-write wait in Execute so the
+// caller can run other work in parallel with uploads.
 func (e *Executor) DeferAsyncWait() {
 	e.deferAsyncWait = true
 }
 
-// WaitForAsyncWrites blocks until all outstanding async cache writes complete
-// and records the elapsed time as AsyncWaitTime. Intended for callers that
-// invoked DeferAsyncWait and ran other work (e.g. user binaries) in parallel
-// with cache uploads. Logs a status message when writes are still in flight so
-// the user understands the delay between their command finishing and the
-// process exiting.
+// WaitForAsyncWrites blocks until all outstanding async cache writes complete,
+// recording the elapsed time as AsyncWaitTime. Logs a status line when writes
+// are still in flight so the user understands the wait.
 func (e *Executor) WaitForAsyncWrites(ctx context.Context) {
 	if e.cacheWriter == nil {
 		return

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -48,6 +48,7 @@ type Executor struct {
 	cacheWriter      *CacheWriter
 	asyncWaitTime    time.Duration
 	deferAsyncWait   bool
+	asyncDrained     bool
 }
 
 func NewExecutor(
@@ -151,39 +152,43 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	walker := dag.NewWalker(e.graph, walkCallback, e.failFast)
 	completionMap, err := walker.Walk(ctx)
 
-	// Wait for I/O pool to drain before returning, but only if the build
-	// was not interrupted. Async cache writes use a non-cancellable context
-	// so they can outlive the build, but we must not block an interrupted
-	// shutdown waiting for slow remote uploads to finish. When
-	// deferAsyncWait is set, the caller owns the wait via WaitForAsyncWrites.
+	// Drain the I/O pool before returning, but only if the build was not
+	// interrupted and the caller hasn't opted to wait itself. Async cache
+	// writes use a non-cancellable context so they can outlive the build,
+	// but we must not block an interrupted shutdown on slow remote uploads.
 	if ctx.Err() == nil && !e.deferAsyncWait {
-		waitStart := time.Now()
-		e.cacheWriter.Wait()
-		e.asyncWaitTime = time.Since(waitStart)
+		e.drainAsyncWrites()
 	}
 
 	return completionMap, err
 }
 
 // DeferAsyncWait opts out of the implicit cache-write wait in Execute so the
-// caller can run other work in parallel with uploads.
+// caller can run other work in parallel with uploads, then call
+// WaitForAsyncWrites when ready.
 func (e *Executor) DeferAsyncWait() {
 	e.deferAsyncWait = true
 }
 
 // WaitForAsyncWrites blocks until all outstanding async cache writes complete,
-// recording the elapsed time as AsyncWaitTime. Logs a status line when writes
-// are still in flight so the user understands the wait.
+// recording the elapsed time as AsyncWaitTime. Idempotent — safe to call
+// whether or not Execute already waited. Logs a status line when writes are
+// still in flight so the user understands the wait.
 func (e *Executor) WaitForAsyncWrites(ctx context.Context) {
-	if e.cacheWriter == nil {
+	if e.asyncDrained || e.cacheWriter == nil || ctx.Err() != nil {
 		return
 	}
 	if e.cacheWriter.HasPendingWrites() {
 		console.GetLogger(ctx).Infof("Waiting for cache writes to finish in the background...")
 	}
+	e.drainAsyncWrites()
+}
+
+func (e *Executor) drainAsyncWrites() {
 	waitStart := time.Now()
 	e.cacheWriter.Wait()
 	e.asyncWaitTime = time.Since(waitStart)
+	e.asyncDrained = true
 }
 
 // AsyncWaitTime returns the wall-clock time spent waiting for the async I/O


### PR DESCRIPTION
## Summary

- `grog run` no longer waits for async cache uploads before invoking the target binary — uploads continue in the background while the user's command runs.
- If the binary exits before uploads finish, grog logs `Waiting for cache writes to finish in the background...` and blocks until they complete.
- Closes #108.

## What changed

- **`CacheWriter`** tracks pending fire-and-forget writes via an atomic counter, exposed through `HasPendingWrites()` so the executor can decide whether to log a wait message.
- **`Executor`** gains `DeferAsyncWait()` (opt-in) and a public `WaitForAsyncWrites(ctx)` that records `AsyncWaitTime`. The implicit end-of-Execute wait used by `grog build` stays inline and silent so existing fixtures don't shift.
- **`RunBuildAndAfter`** wraps `RunBuild` with an `afterBuildSuccess func() error` callback invoked between build success and the cache wait. The "Build completed successfully" line is printed *before* the callback (preserving the existing log ordering observed by integration fixtures); trace finalization and elapsed-time logging happen *after* the wait so `AsyncWaitTime` reflects actual time spent waiting beyond the binary's runtime.
- **`grog run`** now wraps `loadDependencyOutputsIfNeeded` + `runTargetBinaries` into the callback, so binaries start as soon as the build is done.

`RunBuild` is preserved as a thin wrapper for `build` / `test` / `build-and-test` and the integration profiling test.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/...` — all unit tests pass
- [x] `go test ./integration/...` — full suite passes (Run_multiple_binaries, Binary_outputs/run_command_*, Load_minimal_outputs/load_minimal_outputs_run_target, Grog_scripts/run_*, etc.)
- [x] Manual smoke on `run_multiple` repo: cache hit, fresh build (cache miss with async writes overlapping binaries), and binary failure paths all behave correctly

## Reviewer notes

- Trace `AsyncWaitTime` for `grog run` now reflects only the time spent waiting *after* the binary finishes, which is the meaningful number for that command.
- Bubble Tea is shut down via the existing `defer program.Quit()` inside `Execute`, so the user's binary inherits stdin/stdout/stderr cleanly when it starts.
- The `--load-outputs=minimal` + `grog run` path was checked: when async writes are slow and a dep's cache entry isn't published yet, `LoadDependencyOutputs` already has a fallback that re-runs the dep — same behavior as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)