### PR TITLE
fix(analysis): suppress 'run only once' warning for fingerprinted targets

### DIFF
--- a/integration/fixtures/build_output_helper.txt
+++ b/integration/fixtures/build_output_helper.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 2 targets configured.
-WARN: target //:produce_outputs has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:produce_outputs has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (0 cache hits).

--- a/integration/fixtures/builds_logs_target.txt
+++ b/integration/fixtures/builds_logs_target.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 1 target configured.
-WARN: target //:logs has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:logs has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/dep_platform_mismatch_should_fail.txt
+++ b/integration/fixtures/dep_platform_mismatch_should_fail.txt
@@ -1,6 +1,6 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 FATAL: target selection failed: could not select node //:bar because it depends on //:os_guard, which does not match the platform test-os/test-arch

--- a/integration/fixtures/early_cutoff_initial_build.txt
+++ b/integration/fixtures/early_cutoff_initial_build.txt
@@ -1,4 +1,4 @@
 INFO: 2 packages loaded, 2 targets configured.
-WARN: target //dep:dep has no inputs, dependencies or output checks causing it to run only once
+WARN: target //dep:dep has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (0 cache hits).

--- a/integration/fixtures/early_cutoff_rebuild_changed_output.txt
+++ b/integration/fixtures/early_cutoff_rebuild_changed_output.txt
@@ -1,4 +1,4 @@
 INFO: 2 packages loaded, 2 targets configured.
-WARN: target //dep:dep has no inputs, dependencies or output checks causing it to run only once
+WARN: target //dep:dep has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (0 cache hits).

--- a/integration/fixtures/early_cutoff_rebuild_same_output.txt
+++ b/integration/fixtures/early_cutoff_rebuild_same_output.txt
@@ -1,4 +1,4 @@
 INFO: 2 packages loaded, 2 targets configured.
-WARN: target //dep:dep has no inputs, dependencies or output checks causing it to run only once
+WARN: target //dep:dep has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (1 cache hits).

--- a/integration/fixtures/load_minimal_outputs_build_all.txt
+++ b/integration/fixtures/load_minimal_outputs_build_all.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:target_a has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:target_a has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 4 targets.
 INFO: Build completed successfully. 4 targets completed (0 cache hits).

--- a/integration/fixtures/load_minimal_outputs_rebuild_all.txt
+++ b/integration/fixtures/load_minimal_outputs_rebuild_all.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:target_a has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:target_a has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 4 targets.
 INFO: Build completed successfully. 4 targets completed (4 cache hits).

--- a/integration/fixtures/load_minimal_outputs_rebuild_tainted.txt
+++ b/integration/fixtures/load_minimal_outputs_rebuild_tainted.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:target_a has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:target_a has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 3 targets.
 INFO: Build completed successfully. 3 targets completed (2 cache hits).

--- a/integration/fixtures/load_minimal_outputs_run_target.txt
+++ b/integration/fixtures/load_minimal_outputs_run_target.txt
@@ -1,5 +1,5 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:target_a has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:target_a has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 3 targets.
 INFO: Build completed successfully. 3 targets completed (3 cache hits).
 INFO: Loading outputs of direct dependencies due to load_outputs=minimal

--- a/integration/fixtures/output_not_created.txt
+++ b/integration/fixtures/output_not_created.txt
@@ -1,5 +1,5 @@
 INFO: 1 package loaded, 1 target configured.
-WARN: target //:output_not_created has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:output_not_created has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 ERROR: Build failed. 0 targets completed (0 cache hits), 1 failed:
 ---------------------------------

--- a/integration/fixtures/run_any_script.txt
+++ b/integration/fixtures/run_any_script.txt
@@ -1,5 +1,5 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:a_build_target has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:a_build_target has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (0 cache hits).
 INFO: Running //dir:minimal.sh -> minimal.sh with args [bar]

--- a/integration/fixtures/run_command_fails.txt
+++ b/integration/fixtures/run_command_fails.txt
@@ -1,5 +1,5 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (1 cache hits).
 INFO: Running //:creates_bin_tool -> dist/bin with args []

--- a/integration/fixtures/run_command_in_package_works.txt
+++ b/integration/fixtures/run_command_in_package_works.txt
@@ -1,5 +1,5 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (1 cache hits).
 INFO: Running //pkg:foo -> bin.sh with args [] in package directory

--- a/integration/fixtures/run_command_works.txt
+++ b/integration/fixtures/run_command_works.txt
@@ -1,5 +1,5 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (1 cache hits).
 INFO: Running //:creates_bin_tool -> dist/bin with args [foo]

--- a/integration/fixtures/run_command_works_declared_bin_tool.txt
+++ b/integration/fixtures/run_command_works_declared_bin_tool.txt
@@ -1,5 +1,5 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (0 cache hits).
 INFO: Running //:declares_bin_tool -> bin_tool.sh with args [bar]

--- a/integration/fixtures/run_command_works_rel_path.txt
+++ b/integration/fixtures/run_command_works_rel_path.txt
@@ -1,5 +1,5 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (1 cache hits).
 INFO: Running //:creates_bin_tool -> dist/bin with args [foo]

--- a/integration/fixtures/run_grog_sh_target.txt
+++ b/integration/fixtures/run_grog_sh_target.txt
@@ -1,5 +1,5 @@
 INFO: 1 package loaded, 4 targets configured.
-WARN: target //:a_build_target has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:a_build_target has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (0 cache hits).
 INFO: Running //:run.grog.sh -> run.grog.sh with args []

--- a/integration/fixtures/run_multiple_commands.txt
+++ b/integration/fixtures/run_multiple_commands.txt
@@ -1,7 +1,7 @@
 INFO: 1 package loaded, 3 targets configured.
-WARN: target //:fails_runner has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:fast_runner has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:slow_runner has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:fails_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:fast_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:slow_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (0 cache hits).
 INFO: Running //:fast_runner -> dist/fast_runner.sh with args []

--- a/integration/fixtures/run_multiple_commands_failure.txt
+++ b/integration/fixtures/run_multiple_commands_failure.txt
@@ -1,7 +1,7 @@
 INFO: 1 package loaded, 3 targets configured.
-WARN: target //:fails_runner has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:fast_runner has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:slow_runner has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:fails_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:fast_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:slow_runner has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 2 targets.
 INFO: Build completed successfully. 2 targets completed (1 cache hits).
 INFO: Running //:slow_runner -> dist/slow_runner.sh with args []

--- a/integration/fixtures/select_by_arch.txt
+++ b/integration/fixtures/select_by_arch.txt
@@ -1,7 +1,7 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/select_by_both_arch_and_os.txt
+++ b/integration/fixtures/select_by_both_arch_and_os.txt
@@ -1,7 +1,7 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 3 targets (2 targets not matching made-up-os/default-arch host).
 INFO: Build completed successfully. 3 targets completed (1 cache hits).

--- a/integration/fixtures/select_by_os.txt
+++ b/integration/fixtures/select_by_os.txt
@@ -1,7 +1,7 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/select_by_platform_flag.txt
+++ b/integration/fixtures/select_by_platform_flag.txt
@@ -1,7 +1,7 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 3 targets (2 targets not matching made-up-os/default-arch host).
 INFO: Build completed successfully. 3 targets completed (3 cache hits).

--- a/integration/fixtures/skip_if_platform_no_match.txt
+++ b/integration/fixtures/skip_if_platform_no_match.txt
@@ -1,7 +1,7 @@
 INFO: 2 packages loaded, 5 targets configured.
-WARN: target //:arch_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:os_guard has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
-WARN: target //pkg:foo_platform has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:arch_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:os_guard has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //pkg:foo_platform has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target (1 target not matching test-os/test-arch host).
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/target_timeout.txt
+++ b/integration/fixtures/target_timeout.txt
@@ -1,5 +1,5 @@
 INFO: 1 package loaded, 1 target configured.
-WARN: target //:sleep_target has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:sleep_target has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 ERROR: Build failed. 0 targets completed (0 cache hits), 1 failed:
 ---------------------------------

--- a/integration/fixtures/test_output_fail.txt
+++ b/integration/fixtures/test_output_fail.txt
@@ -1,6 +1,6 @@
 INFO: 1 package loaded, 2 targets configured.
-WARN: target //:failing_test has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:passing_test has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:failing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:passing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: //:failing_test FAILED
 ERROR: Test failed. 0 targets completed (0 cache hits), 1 failed:

--- a/integration/fixtures/test_output_pass.txt
+++ b/integration/fixtures/test_output_pass.txt
@@ -1,6 +1,6 @@
 INFO: 1 package loaded, 2 targets configured.
-WARN: target //:failing_test has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:passing_test has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:failing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:passing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: //:passing_test PASSED
 INFO: Test completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/test_output_pass_cached.txt
+++ b/integration/fixtures/test_output_pass_cached.txt
@@ -1,6 +1,6 @@
 INFO: 1 package loaded, 2 targets configured.
-WARN: target //:failing_test has no inputs, dependencies or output checks causing it to run only once
-WARN: target //:passing_test has no inputs, dependencies or output checks causing it to run only once
+WARN: target //:failing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
+WARN: target //:passing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 1 target.
 INFO: //:passing_test PASSED (cached)
 INFO: Test completed successfully. 1 target completed (1 cache hits).

--- a/integration/fixtures/using_bin_tool_works.txt
+++ b/integration/fixtures/using_bin_tool_works.txt
@@ -1,4 +1,4 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 4 targets.
 INFO: Build completed successfully. 4 targets completed (0 cache hits).

--- a/integration/fixtures/using_bin_tool_works_with_cache.txt
+++ b/integration/fixtures/using_bin_tool_works_with_cache.txt
@@ -1,4 +1,4 @@
 INFO: 2 packages loaded, 4 targets configured.
-WARN: target //pkg:foo has no inputs, dependencies or output checks causing it to run only once
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
 INFO: Selected 4 targets.
 INFO: Build completed successfully. 4 targets completed (3 cache hits).

--- a/internal/analysis/target_constraints.go
+++ b/internal/analysis/target_constraints.go
@@ -43,8 +43,8 @@ func CheckTargetConstraints(logger *console.Logger, nodeMap model.BuildNodeMap) 
 			errs = append(errs, fmt.Errorf("target %s is a test target but has no command", target.Label))
 		}
 
-		if len(target.Inputs) == 0 && len(target.Dependencies) == 0 && len(target.OutputChecks) == 0 {
-			logger.Warnf("target %s has no inputs, dependencies or output checks causing it to run only once", target.Label)
+		if len(target.Inputs) == 0 && len(target.Dependencies) == 0 && len(target.OutputChecks) == 0 && len(target.Fingerprint) == 0 {
+			logger.Warnf("target %s has no inputs, dependencies, output checks or fingerprint causing it to run only once", target.Label)
 		}
 	}
 

--- a/internal/analysis/target_constraints_test.go
+++ b/internal/analysis/target_constraints_test.go
@@ -76,6 +76,17 @@ func TestCheckPathConstraints(t *testing.T) {
 			expectErrorCount:   0,
 		},
 		{
+			name: "target with only a fingerprint does not generate a warning",
+			targetMap: model.BuildNodeMap{
+				label.TL("", "target1"): &model.Target{
+					Label:       label.TL("", "target1"),
+					Fingerprint: map[string]string{"version": "1.0.0"},
+				},
+			},
+			expectWarningCount: 0,
+			expectErrorCount:   0,
+		},
+		{
 			name: "target inputs include an absolute path",
 			targetMap: model.BuildNodeMap{
 				label.TL("", "target1"): &model.Target{


### PR DESCRIPTION
## Summary
- Exclude targets with a non-empty `fingerprint` from the `grog check` warning about targets that "run only once". Fingerprint values are already hashed into the target definition hash, so they invalidate the cache just like inputs/dependencies/output_checks.
- Update the warning message to mention `fingerprint` alongside the other signals.
- Add a test covering the fingerprint-only case.

Fixes #116

## Test plan
- [x] `go test ./internal/analysis/ -run TestCheckPathConstraints -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)