### PR TITLE
feat: make dot-directory traversal configurable

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -194,6 +194,7 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetDefault("cache.s3.shared_cache", true)
 	viper.SetDefault("cache.azure.shared_cache", true)
 	viper.SetDefault("hash_algorithm", config.HashAlgorithmXXH3)
+	viper.SetDefault("include_hidden", false)
 	viper.SetDefault("environment_variables", make(map[string]string))
 	viper.SetDefault("traces.enabled", false)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,12 @@ type WorkspaceConfig struct {
 	// NumIOWorkers sets the number of I/O workers used for async cache writes.
 	// Only relevant when AsyncCacheWrites is true. Defaults to 3 * num_workers.
 	NumIOWorkers int `mapstructure:"num_io_workers"`
+	// IncludeHidden controls whether the package loader descends into hidden
+	// files and directories (names starting with a dot, e.g. ".github"). By
+	// default these are skipped, matching the behavior of most code tools.
+	// Set to true to allow BUILD files and source inputs inside dot-directories
+	// to be discovered.
+	IncludeHidden bool `mapstructure:"include_hidden"`
 
 	// Logging
 	LogLevel      string `mapstructure:"log_level"`

--- a/internal/loading/load.go
+++ b/internal/loading/load.go
@@ -24,6 +24,7 @@ func LoadPackages(ctx context.Context, startDir string) ([]*model.Package, error
 	fileListQueue := make(chan *gocodewalker.File, 100)
 
 	fileWalker := gocodewalker.NewParallelFileWalker([]string{startDir}, fileListQueue)
+	fileWalker.IncludeHidden = config.Global.IncludeHidden
 	go fileWalker.Start()
 
 	packageLoader := NewPackageLoader(logger)


### PR DESCRIPTION
## Summary
- Grog currently skips dot-prefixed directories (`.github`, `.vscode`, etc.) during package discovery because `internal/loading/load.go` uses `gocodewalker` with its default `IncludeHidden=false`. This was not configurable.
- Adds an `include_hidden` workspace setting (env `GROG_INCLUDE_HIDDEN`) on `WorkspaceConfig` that plumbs through to the walker. Default stays `false`, so existing behavior is preserved; users who keep BUILD files or source inputs under dot-directories can set `include_hidden = true` in `grog.toml` to have them discovered.
- Note: gocodewalker's flag also governs hidden files, but in practice BUILD files are never dot-prefixed, so the directory filter is what this actually changes.

## Test plan
- [ ] `go build ./...` and `go vet ./...` (done locally)
- [ ] With `include_hidden = false` (default), packages inside a `.foo/` directory are not discovered
- [ ] With `include_hidden = true`, the same packages are discovered
- [ ] `GROG_INCLUDE_HIDDEN=true` env var overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)