### PR TITLE
fix(locking): create workspace prefix dir before acquiring lockfile

### DIFF
--- a/internal/locking/workspace_locker.go
+++ b/internal/locking/workspace_locker.go
@@ -37,10 +37,14 @@ func (wl *WorkspaceLocker) Lock(ctx context.Context) error {
 	lockData := []byte(buildLockFileContents(os.Getpid(), os.Args))
 	waitPrinted := false
 
+	if err := os.MkdirAll(filepath.Dir(wl.lockFilePath), 0755); err != nil {
+		return fmt.Errorf("could not create workspace lock directory: %w", err)
+	}
+
 	for {
 		logger.Debugf("Attempting to acquire workspace lock at %s", wl.lockFilePath)
 		file, err := os.OpenFile(wl.lockFilePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
-		if err == nil || errors.Is(err, os.ErrNotExist) {
+		if err == nil {
 			_, writeErr := file.Write(lockData)
 			file.Close()
 			if writeErr != nil {

--- a/internal/locking/workspace_locker_test.go
+++ b/internal/locking/workspace_locker_test.go
@@ -43,6 +43,30 @@ func TestWorkspaceLockerBasic(t *testing.T) {
 	}
 }
 
+func TestWorkspaceLockerCreatesParentDir(t *testing.T) {
+	root := t.TempDir()
+	config.Global.Root = root
+	config.Global.WorkspaceRoot = root
+	dir := config.Global.GetWorkspaceRootDir()
+	if dir == root {
+		t.Skip("workspace root dir matches grog root; nothing to create")
+	}
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected workspace prefix dir to not exist, got: %v", err)
+	}
+
+	locker := NewWorkspaceLocker()
+	if err := locker.Lock(context.Background()); err != nil {
+		t.Fatalf("lock failed: %v", err)
+	}
+	t.Cleanup(func() { _ = locker.Unlock() })
+
+	lockPath := filepath.Join(dir, "lockfile")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file: %v", err)
+	}
+}
+
 func TestWorkspaceLockerWaitsAndReleases(t *testing.T) {
 	lockPath := setupTestWorkspace(t)
 


### PR DESCRIPTION
## Summary
- Closes #127. `NewWorkspaceLocker` opens a lockfile at `$GROG_ROOT/<workspace-prefix>/lockfile`, but since #120 moved the cache out of that directory nothing was creating it, causing `O_CREATE|O_EXCL` to fail with "invalid argument" / "no such file or directory" on fresh CI runners.
- `Lock()` now `MkdirAll`s the parent before opening the lockfile.
- Dropped the unreachable `errors.Is(err, os.ErrNotExist)` branch on the `OpenFile` result — on that path `file` is nil, so the subsequent `file.Write` would have panicked.

## Test plan
- [x] `go test ./internal/locking/...` (incl. new `TestWorkspaceLockerCreatesParentDir` regression covering the missing-prefix-dir case)
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)