### PR TITLE
fix(docker): keep loopback registry alive until async cache writes drain

### DIFF
--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -230,6 +230,13 @@ func RunBuildAndAfter(
 
 	executor.WaitForAsyncWrites(ctx)
 
+	// Close output handlers (notably the loopback docker registry) only after
+	// async writes have drained. Closing earlier would tear the proxy down
+	// while the docker daemon is still streaming layers to it.
+	if err := registry.Close(); err != nil {
+		logger.Warnf("failed to close output registry: %v", err)
+	}
+
 	// Write trace (synchronous — Parquet writes are fast for local FS,
 	// and we need to ensure the write completes before the process exits)
 	if traceCollector != nil && completionMap != nil {

--- a/internal/output/handlers/docker_output_handler.go
+++ b/internal/output/handlers/docker_output_handler.go
@@ -293,6 +293,17 @@ func (d *dockerImageWritePlan) Execute(ctx context.Context, tracker *worker.Prog
 	return nil
 }
 
+// Close shuts down the in-process loopback registry, if one was started.
+// Must be called only after all async cache writes that push through the
+// proxy have drained — otherwise the daemon's mid-push HTTP requests will
+// fail with "connection refused" once the listener is torn down.
+func (d *DockerOutputHandler) Close() error {
+	if d.proxy == nil {
+		return nil
+	}
+	return d.proxy.Close()
+}
+
 func (d *dockerImageWritePlan) Cleanup(ctx context.Context) error {
 	if _, err := d.dockerClient.ImageRemove(ctx, d.loopbackRef, image.RemoveOptions{}); err != nil && !errdefs.IsNotFound(err) {
 		console.GetLogger(ctx).Warnf("failed to remove loopback tag %q: %v", d.loopbackRef, err)

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"grog/internal/caching"
 	"grog/internal/config"
@@ -12,6 +13,7 @@ import (
 	"grog/internal/output/handlers"
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
+	"io"
 	"runtime"
 	"slices"
 	"sync"
@@ -70,6 +72,27 @@ func NewRegistry(
 		r.Register(handlers.NewDockerOutputHandler(ctx, cas))
 	}
 	return r
+}
+
+// Close releases resources held by output handlers (notably the in-process
+// loopback Docker registry). Must be called only after all async cache writes
+// have drained — otherwise an in-flight `docker push` may race the proxy
+// shutdown and fail with "connection refused".
+func (r *Registry) Close() error {
+	r.handlerMutex.RLock()
+	defer r.handlerMutex.RUnlock()
+
+	var errs []error
+	for _, h := range r.handlers {
+		closer, ok := h.(io.Closer)
+		if !ok {
+			continue
+		}
+		if err := closer.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // Register adds a new output handler to the registry


### PR DESCRIPTION
## Summary
- Closes [#128](https://github.com/chrismatix/grog/issues/128). The in-process docker loopback registry was torn down with the process while the daemon was still streaming layers during async cache writes, producing `connection refused` warnings.
- Adds `Close()` on `DockerOutputHandler` (delegates to `dockerproxy.Registry.Close`) and a `Close()` on the output `Registry` that fans out to any handler implementing `io.Closer`.
- Calls `registry.Close()` in `RunBuildAndAfter` immediately after `executor.WaitForAsyncWrites(ctx)` so the proxy outlives every push it serves.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/output/... ./internal/cmd/...`
- [x] `go test ./internal/output/... ./internal/dockerproxy/...`
- [ ] Manual: confirm the warning is gone on a docker target build with the default `async_cache_writes = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)