### PR TITLE
fix(cmd): allow `grog completion` to run outside a workspace

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,7 +24,7 @@ var RootCmd = &cobra.Command{
 	// PersistentPreRunE runs before any subcommand's Run, after flags are parsed.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("help") || cmd.Flags().Changed("version") ||
-			cmd.Name() == "help" || cmd.Name() == "completion" {
+			cmd.Name() == "help" || isCompletionCmd(cmd) {
 			return nil
 		}
 
@@ -50,6 +50,17 @@ var RootCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// isCompletionCmd reports whether cmd is the `completion` command or one of
+// its subcommands (bash, zsh, fish, powershell).
+func isCompletionCmd(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Name() == "completion" {
+			return true
+		}
+	}
+	return false
 }
 
 // Stamp sets the data for the version command


### PR DESCRIPTION
## Summary
- `grog completion bash|zsh|fish|powershell` failed outside a grog workspace with `grog.toml not found in any parent directory`.
- The pre-run hook bailed out when `cmd.Name() == "completion"`, but cobra's `completion` command has subcommands — for `grog completion bash` the leaf cmd's name is `bash`, so the check was bypassed.
- Walk the parent chain via `isCompletionCmd` so any completion subcommand is recognized.

## Test plan
- [x] `grog completion bash` from `/tmp` prints the bash completion script
- [x] `grog completion zsh` from `/tmp` prints the zsh completion script
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)