### PR TITLE
feat: introduce platform tags

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -22,6 +22,7 @@ hash_algorithm = "xxh3" # default
 
 # Target Selection
 all_platforms = false
+# platform_tag = ["gpu-runner"] # custom platform tags this host opts into
 
 # Logging Settings
 stream_logs = true
@@ -82,6 +83,7 @@ For instance, to set or override the `fail_fast` option set `GROG_FAIL_FAST=fals
   - `minimal`: Only load outputs of a target if a **direct dependant** needs to be re-built. This setting is useful to save bandwidth and disk space in CI settings.
 - **hash_algorithm**: Selects the hash function used for cache keys and change detection. [`xxh3`](https://xxhash.com/) (default) offers extremely fast, 128-bit hashes with a negligible collision probability for typical builds, while `sha256` is slower but cryptographically strong—use it if you are hashing untrusted inputs or want a vanishingly small risk of collisions despite the performance cost.
 - **all_platforms**: When set to `true` skips the platform selection step and builds all targets for all platforms ([read more](/topics/querying)).
+- **platform_tag**: A list of custom [platform tags](/topics/multi-platform-builds#platform-tags) the host opts into. Tags participate in target matching alongside the host's auto-detected `os/arch` and are included in the cache key (unless the target carries the `multiplatform-cache` tag). Can also be set via `GROG_PLATFORM_TAG=a,b` or `--platform-tag` (repeatable).
 - **async_cache_writes**: When `true` (default), cache writes are offloaded to a dedicated I/O worker pool, freeing task workers to start downstream targets sooner. Output hashes are still computed synchronously so dependency chains and cache keys stay correct. The I/O pool is drained before the build returns, and its progress is shown alongside running targets in the build UI. Write failures are non-fatal warnings — the build result is unaffected. Set to `false` to run cache writes inline on task workers (the pre-0.18 behaviour).
 - **num_io_workers**: Number of I/O workers for async cache writes. Only relevant when `async_cache_writes` is `true`. Defaults to `3 * num_workers`.
 - **skip_workspace_lock**: When `true`, Grog does not acquire a workspace-level lock before executing. **Warning:** Running multiple grog instances without locking can corrupt the workspace or cache.

--- a/docs/src/content/docs/reference/target-configuration.mdx
+++ b/docs/src/content/docs/reference/target-configuration.mdx
@@ -59,6 +59,7 @@ Grog also injects the following environment variables into the target's environm
 | `GROG_OS`       | The grog binary's target operating system. E.g. `linux`.            |
 | `GROG_ARCH`     | The grog binary's target architecture. E.g. `amd64`.                |
 | `GROG_PLATFORM` | The grog binary's target platform. E.g. `linux/amd64`.              |
+| `GROG_PLATFORM_TAGS` | Comma-joined list of active custom platform tags. E.g. `gpu-runner,release`. Empty when none are set. |
 | `GROG_PACKAGE`  | The path to the package directory. E.g. `path/to/package`.          |
 | `GROG_GIT_HASH` | The output of `git rev-parse HEAD`. Useful for tagging artifacts.   |
 
@@ -113,13 +114,16 @@ Other targets that must be built before this one, specified as labels. Labels ca
 
 ### platforms
 
-A list of platform identifiers (`os/arch`) that restrict where this target can be executed.
+A list of platform identifiers that restrict where this target can be executed.
+Each entry is either an `os/arch` identifier (e.g. `linux/amd64`) or a custom
+**platform tag** (e.g. `gpu-runner`) that the host explicitly opts into.
 This is particularly useful for multi-platform builds (see [docs](/topics/multi-platform-builds)).
 
 When a target has platform constraints defined:
 
-1. Grog checks the current host's platform identifier (for example, `linux/amd64`)
-2. Targets that don't match the current platform are skipped
+1. Grog checks the current host's platform identifier (for example, `linux/amd64`) and any
+   active platform tags configured via `platform_tag` / `GROG_PLATFORM_TAG` / `--platform-tag`.
+2. Targets that don't match either are skipped.
 
 ### tags
 

--- a/docs/src/content/docs/topics/multi-platform-builds.mdx
+++ b/docs/src/content/docs/topics/multi-platform-builds.mdx
@@ -73,6 +73,66 @@ This allows you to define all platform variants in a single build file, but only
 There may be scenarios where you want to skip platform selectors.
 To do so, pass the `--all-platforms`, (shorthand: `-a`) flag to build and querying commands.
 
+## Platform Tags
+
+Beyond the auto-detected `os/arch` identifier, grog supports user-defined **platform tags**: free-form strings
+that a host explicitly opts into via configuration. They behave like an additional host platform for matching
+purposes — useful when runners share the same `os/arch` but differ in some capability (e.g. a GPU host, an
+internal-only build box, or a CI runner with privileged credentials).
+
+### Defining and matching
+
+Add a custom tag to a target's `platforms` list. A target with a tag-only `platforms` list is also valid.
+
+```yaml
+targets:
+  - name: gpu_train
+    command: python train.py
+    platforms:
+      - linux/amd64        # auto-detected platform identifier
+      - gpu-runner         # custom platform tag
+    inputs:
+      - train.py
+    outputs:
+      - model.pt
+
+  - name: secrets_publish
+    command: ./publish.sh
+    # Only ever runs on hosts that opt into the "release" tag.
+    platforms:
+      - release
+    inputs:
+      - publish.sh
+```
+
+`gpu_train` will run on any `linux/amd64` host **or** on any host with the `gpu-runner` platform tag enabled.
+`secrets_publish` runs only on hosts that explicitly enable the `release` tag.
+
+### Enabling tags on the host
+
+Platform tags are off by default and have to be set explicitly. There are three ways to enable them:
+
+```toml
+# grog.toml
+platform_tag = ["gpu-runner"]
+```
+
+```bash
+# Environment
+export GROG_PLATFORM_TAG=gpu-runner,release
+
+# CLI (repeatable)
+grog build //... --platform-tag=gpu-runner --platform-tag=release
+```
+
+<Aside type="caution">
+  Platform tags participate in the cache key — a target built with `--platform-tag=gpu-runner` caches
+  separately from the same target built without it. Targets tagged `multiplatform-cache` opt out of this
+  separation (just as they do for `os/arch`).
+</Aside>
+
+Inside target commands, the active tags are also exposed as `GROG_PLATFORM_TAGS` (comma-joined).
+
 ### Handling Dependencies with Platform Selectors
 
 When a target depends on a platform-specific target, Grog enforces platform compatibility:

--- a/integration/fixtures/error_platform_flag_and_all_platforms.txt
+++ b/integration/fixtures/error_platform_flag_and_all_platforms.txt
@@ -24,6 +24,7 @@ Global Flags:
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -37,6 +37,7 @@ Flags:
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -125,6 +125,10 @@ func init() {
 	RootCmd.PersistentFlags().String("platform", "", "Force a specific platform in the form os/arch")
 	err = viper.BindPFlag("platform", RootCmd.PersistentFlags().Lookup("platform"))
 
+	// platform_tag
+	RootCmd.PersistentFlags().StringSlice("platform-tag", []string{}, "Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.")
+	err = viper.BindPFlag("platform_tag", RootCmd.PersistentFlags().Lookup("platform-tag"))
+
 	// stream_logs
 	RootCmd.PersistentFlags().Bool("stream-logs", false, "Forward all target build/test logs to stdout/-err")
 	err = viper.BindPFlag("stream_logs", RootCmd.PersistentFlags().Lookup("stream-logs"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,11 @@ type WorkspaceConfig struct {
 
 	// Matching
 	AllPlatforms bool `mapstructure:"all_platforms"`
+	// PlatformTags are user-defined platform identifiers the host opts into.
+	// They behave like an additional host platform for target matching: a target
+	// whose `platforms` list contains a tag also enabled here will match,
+	// regardless of the host's auto-detected os/arch.
+	PlatformTags []string `mapstructure:"platform_tag"`
 
 	// Caching
 	EnableCache bool        `mapstructure:"enable_cache"`

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -154,6 +155,7 @@ func GetExtendedTargetEnv(ctx context.Context, target *model.Target) []string {
 		"GROG_OS="+config.Global.OS,
 		"GROG_ARCH="+config.Global.Arch,
 		"GROG_PLATFORM="+config.Global.GetPlatform(),
+		"GROG_PLATFORM_TAGS="+strings.Join(config.Global.PlatformTags, ","),
 		"GROG_PACKAGE="+target.Label.Package,
 		"GROG_WORKSPACE_ROOT="+config.Global.WorkspaceRoot,
 		"GROG_GIT_HASH="+gitHash,

--- a/internal/hashing/hash_target.go
+++ b/internal/hashing/hash_target.go
@@ -42,6 +42,10 @@ func hashTargetDefinition(target model.Target, dependencyHashes []string) (strin
 	// the target has a multiplatform-cache tag
 	if !target.IsMultiplatformCache() {
 		_, err = hasher.WriteString(config.Global.GetPlatform())
+		if len(config.Global.PlatformTags) > 0 {
+			tags := slices.Clone(config.Global.PlatformTags)
+			_, err = hasher.WriteString(sorted(tags))
+		}
 	}
 
 	// Include the docker backend in the hash for targets with docker outputs

--- a/internal/hashing/hash_target_test.go
+++ b/internal/hashing/hash_target_test.go
@@ -80,6 +80,72 @@ func TestHashTargetDefinition_DockerBackendDoesNotAffectNonDockerTargets(t *test
 	}
 }
 
+func TestHashTargetDefinition_PlatformTagsAffectHash(t *testing.T) {
+	target := model.Target{
+		Label:   label.TL("pkg", "target"),
+		Command: "echo hi",
+	}
+
+	defer func() { config.Global.PlatformTags = nil }()
+
+	config.Global.PlatformTags = nil
+	hashEmpty, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	config.Global.PlatformTags = []string{"qa-runner"}
+	hashWithTag, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	if hashEmpty == hashWithTag {
+		t.Fatalf("expected hash to change when platform tags differ: %s", hashWithTag)
+	}
+
+	// Tag order should not matter.
+	config.Global.PlatformTags = []string{"a", "b"}
+	hashAB, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+	config.Global.PlatformTags = []string{"b", "a"}
+	hashBA, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+	if hashAB != hashBA {
+		t.Fatalf("expected platform tag order to be irrelevant for hashing: %s vs %s", hashAB, hashBA)
+	}
+}
+
+func TestHashTargetDefinition_PlatformTagsIgnoredForMultiplatformCache(t *testing.T) {
+	target := model.Target{
+		Label:   label.TL("pkg", "target"),
+		Command: "echo hi",
+		Tags:    []string{model.TagMultiplatformCache},
+	}
+
+	defer func() { config.Global.PlatformTags = nil }()
+
+	config.Global.PlatformTags = nil
+	hashEmpty, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	config.Global.PlatformTags = []string{"qa-runner"}
+	hashWithTag, err := hashTargetDefinition(target, nil)
+	if err != nil {
+		t.Fatalf("hashTargetDefinition returned error: %v", err)
+	}
+
+	if hashEmpty != hashWithTag {
+		t.Fatalf("expected multiplatform-cache target hash to be stable across platform tags: %s vs %s", hashEmpty, hashWithTag)
+	}
+}
+
 func TestHashTargetDefinition_IgnoresUnrelatedFields(t *testing.T) {
 	base := model.Target{
 		Label:       label.TL("pkg", "target"),

--- a/internal/loading/pkl_loader.go
+++ b/internal/loading/pkl_loader.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/apple/pkl-go/pkl"
@@ -34,9 +35,10 @@ func (pl *PklLoader) getEvaluator(ctx context.Context) (pkl.Evaluator, error) {
 				&url.URL{Scheme: "file", Path: config.Global.WorkspaceRoot},
 				pkl.PreconfiguredOptions,
 				withEnv(map[string]string{
-					"GROG_OS":       config.Global.OS,
-					"GROG_ARCH":     config.Global.Arch,
-					"GROG_PLATFORM": config.Global.GetPlatform(),
+					"GROG_OS":            config.Global.OS,
+					"GROG_ARCH":          config.Global.Arch,
+					"GROG_PLATFORM":      config.Global.GetPlatform(),
+					"GROG_PLATFORM_TAGS": strings.Join(config.Global.PlatformTags, ","),
 				}),
 				withEnv(config.Global.EnvironmentVariables),
 			)
@@ -44,9 +46,10 @@ func (pl *PklLoader) getEvaluator(ctx context.Context) (pkl.Evaluator, error) {
 			pl.evaluator, pl.evaluatorErr = pkl.NewEvaluator(ctx,
 				pkl.PreconfiguredOptions,
 				withEnv(map[string]string{
-					"GROG_OS":       config.Global.OS,
-					"GROG_ARCH":     config.Global.Arch,
-					"GROG_PLATFORM": config.Global.GetPlatform(),
+					"GROG_OS":            config.Global.OS,
+					"GROG_ARCH":          config.Global.Arch,
+					"GROG_PLATFORM":      config.Global.GetPlatform(),
+					"GROG_PLATFORM_TAGS": strings.Join(config.Global.PlatformTags, ","),
 				}),
 				withEnv(config.Global.EnvironmentVariables),
 			)

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -57,12 +57,13 @@ func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO,
 		"target":        starlark.NewBuiltin("target", collector.targetBuiltin),
 		"alias":         starlark.NewBuiltin("alias", collector.aliasBuiltin),
 		"environment":   starlark.NewBuiltin("environment", collector.environmentBuiltin),
-		"GROG_OS":       starlark.String(config.Global.OS),
-		"GROG_ARCH":     starlark.String(config.Global.Arch),
-		"GROG_PLATFORM": starlark.String(config.Global.GetPlatform()),
-		"json":          json.Module,
-		"math":          math.Module,
-		"time":          time.Module,
+		"GROG_OS":            starlark.String(config.Global.OS),
+		"GROG_ARCH":          starlark.String(config.Global.Arch),
+		"GROG_PLATFORM":      starlark.String(config.Global.GetPlatform()),
+		"GROG_PLATFORM_TAGS": platformTagsStarlarkList(),
+		"json":               json.Module,
+		"math":               math.Module,
+		"time":               time.Module,
 	}
 
 	// Add environment variables to predeclared
@@ -139,12 +140,13 @@ func (sl StarlarkLoader) loadModule(thread *starlark.Thread, module string, curr
 		"target":        starlark.NewBuiltin("target", collector.targetBuiltin),
 		"alias":         starlark.NewBuiltin("alias", collector.aliasBuiltin),
 		"environment":   starlark.NewBuiltin("environment", collector.environmentBuiltin),
-		"GROG_OS":       starlark.String(config.Global.OS),
-		"GROG_ARCH":     starlark.String(config.Global.Arch),
-		"GROG_PLATFORM": starlark.String(config.Global.GetPlatform()),
-		"json":          json.Module,
-		"math":          math.Module,
-		"time":          time.Module,
+		"GROG_OS":            starlark.String(config.Global.OS),
+		"GROG_ARCH":          starlark.String(config.Global.Arch),
+		"GROG_PLATFORM":      starlark.String(config.Global.GetPlatform()),
+		"GROG_PLATFORM_TAGS": platformTagsStarlarkList(),
+		"json":               json.Module,
+		"math":               math.Module,
+		"time":               time.Module,
 	}
 
 	// Add environment variables
@@ -364,6 +366,16 @@ func (c *starlarkPackageCollector) environmentBuiltin(thread *starlark.Thread, f
 }
 
 // Helper functions to convert Starlark types to Go types
+
+func platformTagsStarlarkList() *starlark.List {
+	values := make([]starlark.Value, 0, len(config.Global.PlatformTags))
+	for _, tag := range config.Global.PlatformTags {
+		values = append(values, starlark.String(tag))
+	}
+	list := starlark.NewList(values)
+	list.Freeze()
+	return list
+}
 
 func starlarkListToStringSlice(list *starlark.List) ([]string, error) {
 	result := make([]string, 0, list.Len())

--- a/internal/selection/build_selection.go
+++ b/internal/selection/build_selection.go
@@ -62,6 +62,10 @@ func (s *Selector) selectAllAncestorsForBuild(
 		nextChain := append(append([]string{}, depChain...), ancestor.GetLabel().String())
 		if !nodeMatchesPlatform(ancestor) {
 			depChainStr := strings.Join(nextChain[1:], " -> ")
+			if len(config.Global.PlatformTags) > 0 {
+				return fmt.Errorf("could not select node %s because it depends on %s, which does not match the platform %s (active platform tags: %v)",
+					depChain[0], depChainStr, config.Global.GetPlatform(), config.Global.PlatformTags)
+			}
 			return fmt.Errorf("could not select node %s because it depends on %s, which does not match the platform %s",
 				depChain[0], depChainStr, config.Global.GetPlatform())
 		}

--- a/internal/selection/build_selection_test.go
+++ b/internal/selection/build_selection_test.go
@@ -210,6 +210,104 @@ func TestSelectTargetsForBuild(t *testing.T) {
 			t.Errorf("Expected 0 platform-skipped targets, got %d", skipped)
 		}
 	})
+	t.Run("platform tag matching", func(t *testing.T) {
+		defer func() { config.Global.PlatformTags = nil }()
+
+		graph := dag.NewDirectedGraph()
+
+		// tagOnlyTarget is gated solely by a custom platform tag.
+		tagOnlyTarget := &model.Target{
+			Label: label.TargetLabel{
+				Name:    "tag_only",
+				Package: "pkg",
+			},
+			Tags:      []string{testTag},
+			Platforms: []string{"qa-runner"},
+		}
+		// mixedTarget lists both an os/arch and a custom tag.
+		mixedTarget := &model.Target{
+			Label: label.TargetLabel{
+				Name:    "mixed",
+				Package: "pkg",
+			},
+			Tags:      []string{testTag},
+			Platforms: []string{"linux/arm64", "qa-runner"},
+		}
+
+		graph.AddNode(tagOnlyTarget)
+		graph.AddNode(mixedTarget)
+
+		selector := New([]label.TargetPattern{pattern}, []string{testTag}, []string{}, NonTestOnly)
+
+		// Without any platform tag enabled, both should be skipped on darwin/amd64.
+		config.Global.PlatformTags = nil
+		selected, skipped, err := selector.SelectTargetsForBuild(graph)
+		if err != nil {
+			t.Fatalf("SelectTargetsForBuild returned unexpected error: %v", err)
+		}
+		if selected != 0 {
+			t.Errorf("Expected 0 selected, got %d", selected)
+		}
+		if skipped != 2 {
+			t.Errorf("Expected 2 platform-skipped, got %d", skipped)
+		}
+
+		// Reset selection state.
+		tagOnlyTarget.IsSelected = false
+		mixedTarget.IsSelected = false
+
+		// With the tag enabled, both should be selected.
+		config.Global.PlatformTags = []string{"qa-runner"}
+		selected, skipped, err = selector.SelectTargetsForBuild(graph)
+		if err != nil {
+			t.Fatalf("SelectTargetsForBuild returned unexpected error: %v", err)
+		}
+		if selected != 2 {
+			t.Errorf("Expected 2 selected with platform tag, got %d", selected)
+		}
+		if skipped != 0 {
+			t.Errorf("Expected 0 skipped with platform tag, got %d", skipped)
+		}
+	})
+
+	t.Run("dependency platform tag mismatch error mentions active tags", func(t *testing.T) {
+		defer func() { config.Global.PlatformTags = nil }()
+
+		graph := dag.NewDirectedGraph()
+
+		root := &model.Target{
+			Label: label.TargetLabel{
+				Name:    "tag_root",
+				Package: "pkg",
+			},
+			Tags: []string{testTag},
+		}
+		dep := &model.Target{
+			Label: label.TargetLabel{
+				Name:    "tag_dep",
+				Package: "pkg",
+			},
+			Tags:      []string{testTag},
+			Platforms: []string{"qa-runner"},
+		}
+
+		graph.AddNode(root)
+		graph.AddNode(dep)
+		if err := graph.AddEdge(dep, root); err != nil {
+			t.Fatalf("Unexpected error adding edge: %v", err)
+		}
+
+		config.Global.PlatformTags = []string{"other-tag"}
+		selector := New([]label.TargetPattern{pattern}, []string{testTag}, []string{}, NonTestOnly)
+		_, _, err := selector.SelectTargetsForBuild(graph)
+		if err == nil {
+			t.Fatal("Expected error due to dependency platform mismatch, but got nil")
+		}
+		if !strings.Contains(err.Error(), "active platform tags") {
+			t.Errorf("Expected error to surface active platform tags, got: %v", err)
+		}
+	})
+
 	t.Run("filtering by exclude tags", func(t *testing.T) {
 		graph := dag.NewDirectedGraph()
 

--- a/internal/selection/target_matchers.go
+++ b/internal/selection/target_matchers.go
@@ -20,11 +20,17 @@ func nodeMatchesPlatform(node model.BuildNode) bool {
 		return true
 	}
 
-	if !slices.Contains(target.Platforms, config.Global.GetPlatform()) {
-		return false
+	if slices.Contains(target.Platforms, config.Global.GetPlatform()) {
+		return true
 	}
 
-	return true
+	for _, tag := range config.Global.PlatformTags {
+		if slices.Contains(target.Platforms, tag) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func TargetMatchesTypeSelection(target *model.Target, targetType TargetTypeSelection) bool {


### PR DESCRIPTION
## Summary

- Adds **platform tags**: free-form identifiers that a host opts into via `platform_tag` (toml), `GROG_PLATFORM_TAG`, or `--platform-tag` (repeatable). A target's `platforms` list now matches when the host's auto-detected `os/arch` is in the list **or** when any enabled tag is. Tags-only `platforms` lists (e.g. `["gpu-runner"]`) are valid.
- Enabled tags participate in the target hash next to the host `os/arch`, so builds with different tag sets cache separately. The `multiplatform-cache` tag opts out of both — same as today.
- Exposes the active tags as `GROG_PLATFORM_TAGS` (comma-joined env var; frozen list in starlark) to loaders and target commands.
- No pkl schema change needed — `platforms: Listing<String>` already accepts free-form strings.

## Test plan

- [x] `go test ./internal/...` passes (new subtests cover tag-only matching, mixed os/arch+tag matching, the dependency-mismatch error path, hash separation, and `multiplatform-cache` opt-out).
- [ ] End-to-end smoke: target with `platforms: ["custom-tag"]` is skipped without `--platform-tag=custom-tag` and built (with a different cache key) when the flag/env/toml entry is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)