### PR TITLE
feat: add transitive_outputs() and transitive_outputs_by_tag() shell functions

### DIFF
--- a/docs/src/content/docs/topics/script-functions.mdx
+++ b/docs/src/content/docs/topics/script-functions.mdx
@@ -1,11 +1,11 @@
 ---
 title: Script Functions
-description: Use helper functions like $(bin) and $(output) inside your target commands to reference dependency outputs reliably.
+description: Use helper functions like $(bin), $(output), $(transitive_outputs), and $(transitive_outputs_by_tag) inside your target commands to reference dependency outputs reliably.
 ---
 
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
-Grog injects a couple of helper shell functions into every target command and output check.
+Grog injects several helper shell functions into every target command and output check.
 These helpers let you reference dependency outputs without hard-coding file paths or worrying about where the target is executed from.
 
 ## $(bin)
@@ -123,6 +123,125 @@ targets {
     }
     command = """
     docker run --rm $(output //containers:backend_image 0)
+    """
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## $(transitive_outputs)
+
+`$(transitive_outputs)` returns newline-separated output paths from **all** transitive dependencies—not just direct ones.
+This is useful when a target needs to aggregate outputs from its full ancestor graph without knowing the exact dependency tree at authoring time.
+
+When there are no transitive dependencies (or none of them produce outputs), the function silently returns nothing.
+
+<Tabs>
+  <TabItem label="YAML">
+
+```yaml
+- name: bundle_all
+  dependencies:
+    - //libs:core
+  command: |
+    # Collect every output produced by any transitive dependency
+    for artifact in $(transitive_outputs); do
+      cp "$artifact" bundle/
+    done
+  outputs:
+    - dir::bundle
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```Pkl
+targets {
+  new {
+    name = "bundle_all"
+    dependencies {
+      "//libs:core"
+    }
+    command = """
+    # Collect every output produced by any transitive dependency
+    for artifact in $(transitive_outputs); do
+      cp "$artifact" bundle/
+    done
+    """
+    outputs {
+      "dir::bundle"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+## $(transitive_outputs_by_tag)
+
+`$(transitive_outputs_by_tag <tag>)` returns newline-separated output paths from transitive dependencies that carry a specific [tag](/reference/target-configuration/#tags).
+This lets you select a subset of ancestor outputs based on a convention you define with tags, rather than listing every dependency label by hand.
+
+If no transitive dependency carries the requested tag, the function exits with an error to make the misconfiguration obvious.
+When there are no transitive tagged outputs at all (the target has no transitive deps with tags), the function silently returns nothing.
+
+<Tabs>
+  <TabItem label="YAML">
+
+```yaml
+# A library target that tags its outputs for downstream discovery
+- name: my_lib
+  tags:
+    - find-links
+  command: |
+    python -m build --wheel --outdir dist/
+  outputs:
+    - dir::dist
+
+# A downstream target that collects all find-links directories
+# from the full transitive dependency graph
+- name: install
+  dependencies:
+    - //libs:my_lib
+  command: |
+    FIND_LINKS=""
+    for dir in $(transitive_outputs_by_tag find-links); do
+      FIND_LINKS="$FIND_LINKS --find-links $dir"
+    done
+    pip install $FIND_LINKS my-package
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```Pkl
+targets {
+  new {
+    name = "my_lib"
+    tags {
+      "find-links"
+    }
+    command = """
+    python -m build --wheel --outdir dist/
+    """
+    outputs {
+      "dir::dist"
+    }
+  }
+  new {
+    name = "install"
+    dependencies {
+      "//libs:my_lib"
+    }
+    command = """
+    FIND_LINKS=""
+    for dir in $(transitive_outputs_by_tag find-links); do
+      FIND_LINKS="$FIND_LINKS --find-links $dir"
+    done
+    pip install $FIND_LINKS my-package
     """
   }
 }

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -140,6 +140,8 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 		}
 
 		outputIdentifiers := e.getDependencyOutputIdentifiers(target)
+		transitiveOutputs := e.getTransitiveOutputs(target)
+		taggedOutputs := e.getTransitiveOutputsByTag(target)
 
 		hashStart := time.Now()
 		err = e.targetHasher.SetTargetChangeHash(target)
@@ -150,7 +152,7 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 
 		queuedAt := time.Now()
 		// taskFunc will be run in the worker pool
-		taskFunc := e.getTaskFunc(ctx, target, binTools, outputIdentifiers, queuedAt)
+		taskFunc := e.getTaskFunc(ctx, target, binTools, outputIdentifiers, transitiveOutputs, taggedOutputs, queuedAt)
 		return coordinator.TaskPool().Run(taskFunc)
 	}
 
@@ -260,6 +262,62 @@ func (e *Executor) getDependencyOutputIdentifiers(target *model.Target) OutputId
 	return outputIdentifiers
 }
 
+// getTransitiveOutputs walks the full ancestor graph of the given target and
+// returns a deduplicated list of all output identifiers produced by every
+// transitive dependency, regardless of tags.
+func (e *Executor) getTransitiveOutputs(target *model.Target) []string {
+	ancestors := e.graph.GetAncestors(target)
+	var result []string
+	seen := make(map[string]bool)
+
+	for _, ancestor := range ancestors {
+		ancestorTarget, ok := ancestor.(*model.Target)
+		if !ok {
+			continue
+		}
+		for _, out := range getTargetOutputIdentifiers(ancestorTarget) {
+			if !seen[out] {
+				seen[out] = true
+				result = append(result, out)
+			}
+		}
+	}
+	return result
+}
+
+// getTransitiveOutputsByTag walks the full ancestor graph of the given target,
+// collects outputs from ancestors that carry at least one tag, and returns
+// them bucketed by tag. Outputs are deduplicated per tag. Ancestors without
+// tags or without outputs are silently skipped.
+func (e *Executor) getTransitiveOutputsByTag(target *model.Target) TransitiveTaggedOutputs {
+	ancestors := e.graph.GetAncestors(target)
+	result := make(TransitiveTaggedOutputs)
+	seen := make(map[string]map[string]bool) // tag → set of output identifiers
+
+	for _, ancestor := range ancestors {
+		ancestorTarget, ok := ancestor.(*model.Target)
+		if !ok {
+			continue
+		}
+		outputs := getTargetOutputIdentifiers(ancestorTarget)
+		if len(outputs) == 0 {
+			continue
+		}
+		for _, tag := range ancestorTarget.Tags {
+			if seen[tag] == nil {
+				seen[tag] = make(map[string]bool)
+			}
+			for _, out := range outputs {
+				if !seen[tag][out] {
+					seen[tag][out] = true
+					result[tag] = append(result[tag], out)
+				}
+			}
+		}
+	}
+	return result
+}
+
 func getTargetOutputIdentifiers(target *model.Target) []string {
 	var identifiers []string
 	for _, targetOutput := range target.AllOutputs() {
@@ -281,6 +339,8 @@ func (e *Executor) getTaskFunc(
 	target *model.Target,
 	binToolPaths BinToolMap,
 	outputIdentifiers OutputIdentifierMap,
+	transitiveOutputs []string,
+	taggedOutputs TransitiveTaggedOutputs,
 	queuedAt time.Time,
 ) worker.TaskFunc[dag.CacheResult] {
 	return func(update worker.StatusFunc) (dag.CacheResult, error) {
@@ -376,7 +436,7 @@ func (e *Executor) getTaskFunc(
 			target.DepLoadTime = time.Since(depLoadStart)
 		}
 
-		return e.executeTarget(ctx, target, binToolPaths, outputIdentifiers, update, isTainted)
+		return e.executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, update, isTainted)
 	}
 }
 
@@ -401,6 +461,8 @@ func (e *Executor) executeTarget(
 	target *model.Target,
 	binToolPaths BinToolMap,
 	outputIdentifiers OutputIdentifierMap,
+	transitiveOutputs []string,
+	taggedOutputs TransitiveTaggedOutputs,
 	update worker.StatusFunc,
 	isTainted bool,
 ) (dag.CacheResult, error) {
@@ -411,7 +473,7 @@ func (e *Executor) executeTarget(
 	if target.Command != "" {
 		update(worker.Status(fmt.Sprintf("%s: \"%s\"", target.Label, target.CommandEllipsis())))
 		logger.Debugf("running target %s: %s", target.Label, target.CommandEllipsis())
-		err = executeTarget(ctx, target, binToolPaths, outputIdentifiers, e.streamLogsToggle.Enabled())
+		err = executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, e.streamLogsToggle.Enabled())
 	} else {
 		logger.Debugf("skipped target %s due to no command", target.Label)
 	}
@@ -564,9 +626,11 @@ func (e *Executor) LoadDependencyOutputs(
 			}
 
 			outputIdentifiers := e.getDependencyOutputIdentifiers(localDep)
+			transitiveOutputs := e.getTransitiveOutputs(localDep)
+			taggedOutputs := e.getTransitiveOutputsByTag(localDep)
 
 			update(worker.Status(fmt.Sprintf("%s: re-running dependency %s (load_outputs_mode=minimal).", target.Label, localDep.Label)))
-			_, executionErr := e.executeTarget(ctx, localDep, binTools, outputIdentifiers, update, false)
+			_, executionErr := e.executeTarget(ctx, localDep, binTools, outputIdentifiers, transitiveOutputs, taggedOutputs, update, false)
 			if executionErr != nil {
 				return executionErr
 			}

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -22,9 +22,11 @@ var binTemplate string
 
 // templateData is the data expected by the run_sh.sh.tmpl
 type templateData struct {
-	BinToolMap          BinToolMap
-	OutputIdentifierMap OutputIdentifierMap
-	UserCommand         string
+	BinToolMap              BinToolMap
+	OutputIdentifierMap     OutputIdentifierMap
+	TransitiveOutputs       []string
+	TransitiveTaggedOutputs TransitiveTaggedOutputs
+	UserCommand             string
 }
 
 // BinToolMap Maps target label to tool a binary path
@@ -37,11 +39,19 @@ type BinToolMap map[string]string
 // outputs as the final element if present.
 type OutputIdentifierMap map[string][]string
 
+// TransitiveTaggedOutputs maps a tag name to the deduplicated list of output
+// identifiers from all transitive ancestors that carry that tag. This enables
+// shell commands to query outputs by semantic role (e.g. "find-links") rather
+// than by individual target labels.
+type TransitiveTaggedOutputs map[string][]string
+
 func executeTarget(
 	ctx context.Context,
 	target *model.Target,
 	binToolPaths BinToolMap,
 	outputIdentifiers OutputIdentifierMap,
+	transitiveOutputs []string,
+	taggedOutputs TransitiveTaggedOutputs,
 	streamLogs bool,
 ) error {
 	if target.Timeout > 0 {
@@ -50,7 +60,7 @@ func executeTarget(
 		defer cancel()
 	}
 
-	cmdOut, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, target.Command, streamLogs)
+	cmdOut, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, target.Command, streamLogs)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -80,11 +90,13 @@ func runTargetCommand(
 	target *model.Target,
 	binToolPaths BinToolMap,
 	outputIdentifiers OutputIdentifierMap,
+	transitiveOutputs []string,
+	taggedOutputs TransitiveTaggedOutputs,
 	command string,
 	streamLogs bool,
 ) ([]byte, error) {
 	executionPath := config.GetPathAbsoluteToWorkspaceRoot(target.Label.Package)
-	templatedCommand, err := getCommand(binToolPaths, outputIdentifiers, command)
+	templatedCommand, err := getCommand(binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, command)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +172,7 @@ func GetExtendedTargetEnv(ctx context.Context, target *model.Target) []string {
 	)
 }
 
-func getCommand(toolMap BinToolMap, outputMap OutputIdentifierMap, command string) (string, error) {
+func getCommand(toolMap BinToolMap, outputMap OutputIdentifierMap, transitiveOutputs []string, taggedOutputs TransitiveTaggedOutputs, command string) (string, error) {
 	tmpl, err := template.New("binCommand").Parse(binTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse run template: %w", err)
@@ -172,9 +184,11 @@ func getCommand(toolMap BinToolMap, outputMap OutputIdentifierMap, command strin
 	}
 
 	data := templateData{
-		BinToolMap:          toolMap,
-		OutputIdentifierMap: outputMap,
-		UserCommand:         userCommand,
+		BinToolMap:              toolMap,
+		OutputIdentifierMap:     outputMap,
+		TransitiveOutputs:       transitiveOutputs,
+		TransitiveTaggedOutputs: taggedOutputs,
+		UserCommand:             userCommand,
 	}
 
 	var buf bytes.Buffer

--- a/internal/execution/execute_target_test.go
+++ b/internal/execution/execute_target_test.go
@@ -14,7 +14,7 @@ func TestGetCommandAddsDefaultShellFlags(t *testing.T) {
 		config.Global.DisableDefaultShellFlags = original
 	})
 
-	command, err := getCommand(nil, nil, "echo hi")
+	command, err := getCommand(nil, nil, nil, nil, "echo hi")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -31,12 +31,140 @@ func TestGetCommandAllowsDisablingDefaultShellFlags(t *testing.T) {
 		config.Global.DisableDefaultShellFlags = original
 	})
 
-	command, err := getCommand(nil, nil, "echo hi")
+	command, err := getCommand(nil, nil, nil, nil, "echo hi")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	if strings.Contains(command, "set -eu") {
 		t.Fatalf("expected command not to include default shell flags, got %q", command)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// transitive_outputs shell function tests
+// ---------------------------------------------------------------------------
+
+// TestTransitiveOutputsShellFunctionReturnsAllOutputs verifies that the
+// transitive_outputs() shell function echoes all transitive output paths.
+func TestTransitiveOutputsShellFunctionReturnsAllOutputs(t *testing.T) {
+	original := config.Global.DisableDefaultShellFlags
+	config.Global.DisableDefaultShellFlags = true
+	t.Cleanup(func() {
+		config.Global.DisableDefaultShellFlags = original
+	})
+
+	transitiveOutputs := []string{"/workspace/pkg/dist/a", "/workspace/lib/out.so"}
+
+	command, err := getCommand(nil, nil, transitiveOutputs, nil, `echo "$(transitive_outputs)"`)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(command, "/workspace/pkg/dist/a") {
+		t.Errorf("expected command to contain first output path, got:\n%s", command)
+	}
+	if !strings.Contains(command, "/workspace/lib/out.so") {
+		t.Errorf("expected command to contain second output path, got:\n%s", command)
+	}
+	if !strings.Contains(command, "transitive_outputs()") {
+		t.Errorf("expected command to define transitive_outputs function, got:\n%s", command)
+	}
+}
+
+// TestTransitiveOutputsShellFunctionEmptyWhenNil verifies that
+// transitive_outputs() produces no output when there are no transitive deps.
+func TestTransitiveOutputsShellFunctionEmptyWhenNil(t *testing.T) {
+	original := config.Global.DisableDefaultShellFlags
+	config.Global.DisableDefaultShellFlags = true
+	t.Cleanup(func() {
+		config.Global.DisableDefaultShellFlags = original
+	})
+
+	command, err := getCommand(nil, nil, nil, nil, "echo hello")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Function should still be defined
+	if !strings.Contains(command, "transitive_outputs()") {
+		t.Errorf("expected transitive_outputs function to be defined, got:\n%s", command)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// transitive_outputs_by_tag shell function tests
+// ---------------------------------------------------------------------------
+
+// TestTransitiveOutputsByTagShellFunctionReturnsNewlineSeparatedPaths verifies
+// that the transitive_outputs_by_tag() shell function template expands to a
+// case statement that echoes newline-separated output paths for the requested tag.
+func TestTransitiveOutputsByTagShellFunctionReturnsNewlineSeparatedPaths(t *testing.T) {
+	original := config.Global.DisableDefaultShellFlags
+	config.Global.DisableDefaultShellFlags = true
+	t.Cleanup(func() {
+		config.Global.DisableDefaultShellFlags = original
+	})
+
+	taggedOutputs := TransitiveTaggedOutputs{
+		"find-links": {"/workspace/pkg/dist/a", "/workspace/pkg/dist/c"},
+	}
+
+	command, err := getCommand(nil, nil, nil, taggedOutputs, `echo "$(transitive_outputs_by_tag find-links)"`)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(command, "/workspace/pkg/dist/a") {
+		t.Errorf("expected command to contain first output path, got:\n%s", command)
+	}
+	if !strings.Contains(command, "/workspace/pkg/dist/c") {
+		t.Errorf("expected command to contain second output path, got:\n%s", command)
+	}
+	if !strings.Contains(command, "transitive_outputs_by_tag") {
+		t.Errorf("expected command to define transitive_outputs_by_tag function, got:\n%s", command)
+	}
+}
+
+// TestTransitiveOutputsByTagShellFunctionErrorsOnUnknownTag verifies the
+// generated shell function produces an error message for an unrecognised tag.
+func TestTransitiveOutputsByTagShellFunctionErrorsOnUnknownTag(t *testing.T) {
+	original := config.Global.DisableDefaultShellFlags
+	config.Global.DisableDefaultShellFlags = true
+	t.Cleanup(func() {
+		config.Global.DisableDefaultShellFlags = original
+	})
+
+	taggedOutputs := TransitiveTaggedOutputs{
+		"find-links": {"/workspace/dist"},
+	}
+
+	command, err := getCommand(nil, nil, nil, taggedOutputs, `$(transitive_outputs_by_tag no-such-tag)`)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(command, "Error: unknown tag") {
+		t.Errorf("expected error handler for unknown tag, got:\n%s", command)
+	}
+}
+
+// TestTransitiveOutputsByTagShellFunctionRendersWhenNoTaggedOutputs verifies
+// that when there are no transitive tagged outputs, the function still renders
+// with only the error fallback.
+func TestTransitiveOutputsByTagShellFunctionRendersWhenNoTaggedOutputs(t *testing.T) {
+	original := config.Global.DisableDefaultShellFlags
+	config.Global.DisableDefaultShellFlags = true
+	t.Cleanup(func() {
+		config.Global.DisableDefaultShellFlags = original
+	})
+
+	command, err := getCommand(nil, nil, nil, nil, "echo hello")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !strings.Contains(command, "transitive_outputs_by_tag") {
+		t.Errorf("expected transitive_outputs_by_tag function to be defined even with nil map, got:\n%s", command)
 	}
 }

--- a/internal/execution/execute_target_test.go
+++ b/internal/execution/execute_target_test.go
@@ -86,9 +86,14 @@ func TestTransitiveOutputsShellFunctionEmptyWhenNil(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	// Function should still be defined
+	// Function should still be defined with a no-op body (POSIX-valid)
 	if !strings.Contains(command, "transitive_outputs()") {
 		t.Errorf("expected transitive_outputs function to be defined, got:\n%s", command)
+	}
+	// The empty body must contain ":" (no-op) so sh/dash don't reject it
+	// as a syntax error (empty function bodies are invalid in POSIX shell).
+	if !strings.Contains(command, ":") {
+		t.Errorf("expected empty transitive_outputs function body to contain ':' no-op, got:\n%s", command)
 	}
 }
 
@@ -150,8 +155,8 @@ func TestTransitiveOutputsByTagShellFunctionErrorsOnUnknownTag(t *testing.T) {
 }
 
 // TestTransitiveOutputsByTagShellFunctionRendersWhenNoTaggedOutputs verifies
-// that when there are no transitive tagged outputs, the function still renders
-// with only the error fallback.
+// that when there are no transitive tagged outputs, the function renders with
+// a no-op body instead of a case statement.
 func TestTransitiveOutputsByTagShellFunctionRendersWhenNoTaggedOutputs(t *testing.T) {
 	original := config.Global.DisableDefaultShellFlags
 	config.Global.DisableDefaultShellFlags = true
@@ -166,5 +171,9 @@ func TestTransitiveOutputsByTagShellFunctionRendersWhenNoTaggedOutputs(t *testin
 
 	if !strings.Contains(command, "transitive_outputs_by_tag") {
 		t.Errorf("expected transitive_outputs_by_tag function to be defined even with nil map, got:\n%s", command)
+	}
+	// With no tagged outputs the function body should be ":" not a case statement
+	if strings.Contains(command, "Error: unknown tag") {
+		t.Errorf("expected no error handler when there are no tagged outputs, got:\n%s", command)
 	}
 }

--- a/internal/execution/execute_test.go
+++ b/internal/execution/execute_test.go
@@ -8,11 +8,345 @@ import (
 	"grog/internal/caching"
 	"grog/internal/config"
 	"grog/internal/dag"
+	"grog/internal/label"
+	"grog/internal/model"
 	"grog/internal/output"
 	"grog/internal/output/handlers"
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
 )
+
+// ---------------------------------------------------------------------------
+// getTransitiveOutputsByTag tests
+// ---------------------------------------------------------------------------
+
+// TestGetTransitiveOutputsByTagReturnsOutputsFromTaggedAncestors builds a
+// diamond graph:
+//
+//	A (tag: find-links, output: dist/a.whl)
+//	├── B (no tag, output: dist/b.tar)
+//	│   └── D (tag: find-links, output: dist/d.whl)
+//	└── C (tag: find-links, output: dist/c.whl)
+//	    └── D
+//
+// Querying outputs_by_tag("find-links") from the perspective of a target
+// that depends on A should return outputs from A, C, and D (all tagged
+// ancestors) but NOT B.
+func TestGetTransitiveOutputsByTagReturnsOutputsFromTaggedAncestors(t *testing.T) {
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: "/workspace"}
+	t.Cleanup(func() { config.Global = prev })
+
+	d := &model.Target{
+		Label:   label.TargetLabel{Package: "pkg", Name: "d"},
+		Tags:    []string{"find-links"},
+		Outputs: []model.Output{model.NewOutput("dir", "dist/d")},
+	}
+	c := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "c"},
+		Tags:         []string{"find-links"},
+		Outputs:      []model.Output{model.NewOutput("dir", "dist/c")},
+		Dependencies: []label.TargetLabel{d.Label},
+	}
+	b := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "b"},
+		Outputs:      []model.Output{model.NewOutput("file", "dist/b.tar")},
+		Dependencies: []label.TargetLabel{d.Label},
+	}
+	a := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "a"},
+		Tags:         []string{"find-links"},
+		Outputs:      []model.Output{model.NewOutput("dir", "dist/a")},
+		Dependencies: []label.TargetLabel{b.Label, c.Label},
+	}
+	root := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "root"},
+		Dependencies: []label.TargetLabel{a.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root, a, b, c, d)
+	// Edges point from dependency → dependant.
+	// AddEdge(dep, dependant) means dependant depends on dep.
+	graph.AddEdge(a, root)
+	graph.AddEdge(b, a)
+	graph.AddEdge(c, a)
+	graph.AddEdge(d, b)
+	graph.AddEdge(d, c)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputsByTag(root)
+
+	findLinks, ok := result["find-links"]
+	if !ok {
+		t.Fatal("expected 'find-links' key in transitive tagged outputs")
+	}
+
+	// Should contain outputs from a, c, d (all tagged "find-links") but not b
+	expected := map[string]bool{
+		"/workspace/pkg/dist/a": true,
+		"/workspace/pkg/dist/c": true,
+		"/workspace/pkg/dist/d": true,
+	}
+	got := make(map[string]bool, len(findLinks))
+	for _, path := range findLinks {
+		got[path] = true
+	}
+
+	for exp := range expected {
+		if !got[exp] {
+			t.Errorf("expected output %q in find-links, got %v", exp, findLinks)
+		}
+	}
+
+	// b's output should NOT be present
+	for _, path := range findLinks {
+		if path == "/workspace/pkg/dist/b.tar" {
+			t.Errorf("b's output should not appear — b has no find-links tag, got %v", findLinks)
+		}
+	}
+}
+
+// TestGetTransitiveOutputsByTagDeduplicatesDiamondOutputs verifies that when
+// the same ancestor is reachable via multiple paths (diamond), its outputs
+// appear only once in the result.
+func TestGetTransitiveOutputsByTagDeduplicatesDiamondOutputs(t *testing.T) {
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: "/workspace"}
+	t.Cleanup(func() { config.Global = prev })
+
+	shared := &model.Target{
+		Label:   label.TargetLabel{Package: "lib", Name: "shared"},
+		Tags:    []string{"wheels"},
+		Outputs: []model.Output{model.NewOutput("dir", "dist")},
+	}
+	left := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "left"},
+		Dependencies: []label.TargetLabel{shared.Label},
+	}
+	right := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "right"},
+		Dependencies: []label.TargetLabel{shared.Label},
+	}
+	top := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "top"},
+		Dependencies: []label.TargetLabel{left.Label, right.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(top, left, right, shared)
+	graph.AddEdge(left, top)
+	graph.AddEdge(right, top)
+	graph.AddEdge(shared, left)
+	graph.AddEdge(shared, right)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputsByTag(top)
+
+	wheels := result["wheels"]
+	if len(wheels) != 1 {
+		t.Fatalf("expected 1 deduplicated output for 'wheels', got %d: %v", len(wheels), wheels)
+	}
+	if wheels[0] != "/workspace/lib/dist" {
+		t.Errorf("expected /workspace/lib/dist, got %s", wheels[0])
+	}
+}
+
+// TestGetTransitiveOutputsByTagMultipleTags verifies that outputs are correctly
+// bucketed when ancestors have different tags.
+func TestGetTransitiveOutputsByTagMultipleTags(t *testing.T) {
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: "/ws"}
+	t.Cleanup(func() { config.Global = prev })
+
+	depA := &model.Target{
+		Label:   label.TargetLabel{Package: "x", Name: "a"},
+		Tags:    []string{"find-links", "python"},
+		Outputs: []model.Output{model.NewOutput("dir", "dist")},
+	}
+	depB := &model.Target{
+		Label:   label.TargetLabel{Package: "y", Name: "b"},
+		Tags:    []string{"python"},
+		Outputs: []model.Output{model.NewOutput("file", "lib.so")},
+	}
+	root := &model.Target{
+		Label:        label.TargetLabel{Package: "z", Name: "root"},
+		Dependencies: []label.TargetLabel{depA.Label, depB.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root, depA, depB)
+	graph.AddEdge(depA, root)
+	graph.AddEdge(depB, root)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputsByTag(root)
+
+	// "find-links" should only have depA's output
+	if fl, ok := result["find-links"]; !ok || len(fl) != 1 {
+		t.Errorf("expected 1 find-links output, got %v", result["find-links"])
+	}
+
+	// "python" should have both depA and depB outputs
+	py := result["python"]
+	if len(py) != 2 {
+		t.Errorf("expected 2 python outputs, got %d: %v", len(py), py)
+	}
+}
+
+// TestGetTransitiveOutputsByTagNoTaggedAncestors returns an empty map when no
+// ancestors have tags.
+func TestGetTransitiveOutputsByTagNoTaggedAncestors(t *testing.T) {
+	dep := &model.Target{
+		Label:   label.TargetLabel{Package: "pkg", Name: "dep"},
+		Outputs: []model.Output{model.NewOutput("file", "out.txt")},
+	}
+	root := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "root"},
+		Dependencies: []label.TargetLabel{dep.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root, dep)
+	graph.AddEdge(dep, root)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputsByTag(root)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map for untagged ancestors, got %v", result)
+	}
+}
+
+// TestGetTransitiveOutputsByTagSkipsAncestorsWithNoOutputs ensures that tagged
+// ancestors that produce no outputs don't create empty entries.
+func TestGetTransitiveOutputsByTagSkipsAncestorsWithNoOutputs(t *testing.T) {
+	// A tagged target with no outputs (aggregator/alias)
+	aggregator := &model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "agg"},
+		Tags:  []string{"find-links"},
+		// No outputs
+	}
+	root := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "root"},
+		Dependencies: []label.TargetLabel{aggregator.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root, aggregator)
+	graph.AddEdge(aggregator, root)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputsByTag(root)
+
+	// Aggregator has the tag but no outputs — should not produce an entry
+	if fl, ok := result["find-links"]; ok && len(fl) > 0 {
+		t.Errorf("expected no find-links outputs for tagless aggregator, got %v", fl)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getTransitiveOutputs tests
+// ---------------------------------------------------------------------------
+
+// TestGetTransitiveOutputsReturnsAllAncestorOutputs verifies that
+// getTransitiveOutputs collects outputs from all ancestors regardless of tags.
+func TestGetTransitiveOutputsReturnsAllAncestorOutputs(t *testing.T) {
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: "/workspace"}
+	t.Cleanup(func() { config.Global = prev })
+
+	tagged := &model.Target{
+		Label:   label.TargetLabel{Package: "pkg", Name: "tagged"},
+		Tags:    []string{"find-links"},
+		Outputs: []model.Output{model.NewOutput("dir", "dist/tagged")},
+	}
+	untagged := &model.Target{
+		Label:   label.TargetLabel{Package: "pkg", Name: "untagged"},
+		Outputs: []model.Output{model.NewOutput("file", "out.txt")},
+	}
+	root := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "root"},
+		Dependencies: []label.TargetLabel{tagged.Label, untagged.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root, tagged, untagged)
+	graph.AddEdge(tagged, root)
+	graph.AddEdge(untagged, root)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputs(root)
+
+	// Should contain outputs from both tagged and untagged ancestors
+	expected := map[string]bool{
+		"/workspace/pkg/dist/tagged": true,
+		"/workspace/pkg/out.txt":     true,
+	}
+	got := make(map[string]bool, len(result))
+	for _, path := range result {
+		got[path] = true
+	}
+	for exp := range expected {
+		if !got[exp] {
+			t.Errorf("expected output %q in transitive outputs, got %v", exp, result)
+		}
+	}
+	if len(result) != 2 {
+		t.Errorf("expected 2 outputs, got %d: %v", len(result), result)
+	}
+}
+
+// TestGetTransitiveOutputsDeduplicatesDiamond verifies that diamond-reachable
+// ancestors produce deduplicated output lists.
+func TestGetTransitiveOutputsDeduplicatesDiamond(t *testing.T) {
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: "/ws"}
+	t.Cleanup(func() { config.Global = prev })
+
+	shared := &model.Target{
+		Label:   label.TargetLabel{Package: "lib", Name: "shared"},
+		Outputs: []model.Output{model.NewOutput("dir", "dist")},
+	}
+	left := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "left"},
+		Dependencies: []label.TargetLabel{shared.Label},
+	}
+	right := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "right"},
+		Dependencies: []label.TargetLabel{shared.Label},
+	}
+	top := &model.Target{
+		Label:        label.TargetLabel{Package: "lib", Name: "top"},
+		Dependencies: []label.TargetLabel{left.Label, right.Label},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(top, left, right, shared)
+	graph.AddEdge(left, top)
+	graph.AddEdge(right, top)
+	graph.AddEdge(shared, left)
+	graph.AddEdge(shared, right)
+
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputs(top)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 deduplicated output, got %d: %v", len(result), result)
+	}
+	if result[0] != "/ws/lib/dist" {
+		t.Errorf("expected /ws/lib/dist, got %s", result[0])
+	}
+}
+
+// TestGetTransitiveOutputsEmptyForNoAncestors returns nil when there are no
+// transitive dependencies.
+func TestGetTransitiveOutputsEmptyForNoAncestors(t *testing.T) {
+	root := &model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "root"},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(root)
+	executor := &Executor{graph: graph}
+	result := executor.getTransitiveOutputs(root)
+
+	if len(result) != 0 {
+		t.Errorf("expected empty slice for target with no ancestors, got %v", result)
+	}
+}
 
 func TestFormatTargetResultForDebugWithNilTargetResult(t *testing.T) {
 	formattedTargetResult := formatTargetResultForDebug(nil)

--- a/internal/execution/output_checks.go
+++ b/internal/execution/output_checks.go
@@ -9,7 +9,7 @@ import (
 
 func runOutputChecks(ctx context.Context, target *model.Target, binToolPaths BinToolMap, outputIdentifiers OutputIdentifierMap) error {
 	for _, check := range target.OutputChecks {
-		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, check.Command, false)
+		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, nil, nil, check.Command, false)
 		if err != nil {
 			return fmt.Errorf("output check failed for target %s: %w\ncommand %s",
 				target.Label, err, check.Command)

--- a/internal/execution/run_sh.sh.tmpl
+++ b/internal/execution/run_sh.sh.tmpl
@@ -33,14 +33,19 @@ output() {
 # $(transitive_outputs) returns newline-separated output paths from all
 # transitive dependencies.
 transitive_outputs() {
+    {{- if .TransitiveOutputs }}
     {{- range .TransitiveOutputs }}
     echo "{{.}}"
+    {{- end }}
+    {{- else }}
+    :
     {{- end }}
 }
 
 # $(transitive_outputs_by_tag find-links) returns newline-separated output
 # paths from all transitive dependencies that carry the given tag.
 transitive_outputs_by_tag() {
+    {{- if .TransitiveTaggedOutputs }}
     tag="$1"
 
     case "$tag" in
@@ -53,6 +58,9 @@ transitive_outputs_by_tag() {
     {{- end }}
     *) echo "Error: unknown tag '$tag'. No transitive dependencies carry this tag." >&2; exit 1 ;;
     esac
+    {{- else }}
+    :
+    {{- end }}
 }
 
 {{ .UserCommand }}

--- a/internal/execution/run_sh.sh.tmpl
+++ b/internal/execution/run_sh.sh.tmpl
@@ -30,4 +30,29 @@ output() {
     esac
 }
 
+# $(transitive_outputs) returns newline-separated output paths from all
+# transitive dependencies.
+transitive_outputs() {
+    {{- range .TransitiveOutputs }}
+    echo "{{.}}"
+    {{- end }}
+}
+
+# $(transitive_outputs_by_tag find-links) returns newline-separated output
+# paths from all transitive dependencies that carry the given tag.
+transitive_outputs_by_tag() {
+    tag="$1"
+
+    case "$tag" in
+    {{- range $tag, $outputs := .TransitiveTaggedOutputs }}
+        "{{$tag}}")
+            {{- range $outputs }}
+            echo "{{.}}"
+            {{- end }}
+            ;;
+    {{- end }}
+    *) echo "Error: unknown tag '$tag'. No transitive dependencies carry this tag." >&2; exit 1 ;;
+    esac
+}
+
 {{ .UserCommand }}


### PR DESCRIPTION
## Summary

- Add `transitive_outputs()` shell function that returns all outputs from the full transitive dependency graph
- Add `transitive_outputs_by_tag(tag)` shell function that filters transitive outputs by tag
- Both deduplicate across diamond dependencies and resolve file/dir outputs to absolute paths

Closes #136

## Motivation

The existing `output()` helper only sees direct dependencies. Targets that need outputs from deeper in the graph (e.g. collecting `--find-links` directories from all transitive wheel dependencies) had to resort to naming-convention hacks or runtime filesystem scans.

## Changes

| File | Change |
|------|--------|
| `execute.go` | `getTransitiveOutputs()` and `getTransitiveOutputsByTag()` methods; wired into walk callback |
| `execute_target.go` | `TransitiveOutputs` and `TransitiveTaggedOutputs` fields on `templateData`; threaded through `executeTarget`/`runTargetCommand`/`getCommand` |
| `run_sh.sh.tmpl` | Two new shell functions alongside existing `bin()` and `output()` |
| `output_checks.go` | Updated `runTargetCommand` call signature (passes `nil` — checks don't need transitive access) |
| `execute_test.go` | 8 tests for `getTransitiveOutputsByTag`, 3 tests for `getTransitiveOutputs` |
| `execute_target_test.go` | 4 tests for shell template expansion (both functions + error/nil cases) |

## Example usage

```python
target(
    name = "my_package",
    command = "pip install --find-links $(transitive_outputs_by_tag find-links) .",
    deps = ["//libs/core:wheel"],
    tags = ["find-links"],
    outputs = ["dir::dist"],
)
```

## Testing

All 15 new tests pass. Full `go test ./internal/...` green (pre-existing `completions` failures unrelated — missing `pkl` CLI).