### PR TITLE
fix(dag): start node routines before fanning out in Walker

### DIFF
--- a/internal/dag/graph_walker.go
+++ b/internal/dag/graph_walker.go
@@ -106,7 +106,9 @@ func (w *Walker) Walk(
 	ctx, cancelFunc := context.WithCancel(ctx)
 	w.allCancel = cancelFunc
 
-	// populate info map
+	// Populate nodeInfoMap fully before starting any node: a node started mid-loop
+	// could finish and startNode a dependant not yet in the map, racing this
+	// unlocked write against startNode's locked read.
 	for _, node := range w.graph.nodes {
 		if !node.GetIsSelected() {
 			// skip unselected targets
@@ -126,8 +128,13 @@ func (w *Walker) Walk(
 		w.wait.Add(1)
 		// start all routines
 		go w.nodeRoutine(ctx, node, w.nodeInfoMap[node.GetLabel()])
+	}
 
-		// start all routines with no dependencies immediately
+	// Map is fully populated; now start the no-dependency nodes.
+	for _, node := range w.graph.nodes {
+		if !node.GetIsSelected() {
+			continue
+		}
 		if len(w.graph.inEdges[node.GetLabel()]) == 0 {
 			w.startNode(node)
 		}

--- a/internal/dag/graph_walker_test.go
+++ b/internal/dag/graph_walker_test.go
@@ -3,6 +3,7 @@ package dag
 import (
 	"context"
 	"errors"
+	"fmt"
 	"grog/internal/label"
 	"grog/internal/model"
 	"sync"
@@ -358,6 +359,51 @@ func TestWalkerEdgeCases(t *testing.T) {
 			t.Errorf("Expected error, got nil")
 		}
 	})
+}
+
+// Regression test for the populate/start race: a no-dependency node that
+// completes immediately (cache hit) must be able to start its dependant even
+// while the rest of the graph is still being registered. Before the fix, Walk
+// populated nodeInfoMap and started no-dep nodes in a single loop, so a fast
+// node could call startNode on a dependant that was not yet in the map (the
+// start was silently dropped, hanging the walk) and the unlocked map write
+// raced startNode's locked read ("concurrent map read and map write").
+// Run with -race to also catch the data race.
+func TestWalkerNoDepStartsLaterDependant(t *testing.T) {
+	for iter := 0; iter < 200; iter++ {
+		const pairs = 50
+		graph := NewDirectedGraph()
+		for i := 0; i < pairs; i++ {
+			root := GetTarget(fmt.Sprintf("root-%d", i))
+			dep := GetTarget(fmt.Sprintf("dep-%d", i))
+			graph.AddNode(root)
+			graph.AddNode(dep)
+			_ = graph.AddEdge(root, dep) // dep depends on root
+		}
+
+		// Every node is an instant cache hit, maximizing the chance a no-dep
+		// root completes before the populate loop registers its dependant.
+		walkFunc := func(ctx context.Context, node model.BuildNode) (CacheResult, error) {
+			return CacheHit, nil
+		}
+
+		walker := NewWalker(graph, walkFunc, true)
+
+		done := make(chan CompletionMap, 1)
+		go func() {
+			cm, _ := walker.Walk(context.Background())
+			done <- cm
+		}()
+
+		select {
+		case cm := <-done:
+			if len(cm) != pairs*2 {
+				t.Fatalf("iter %d: expected %d completions, got %d", iter, pairs*2, len(cm))
+			}
+		case <-time.After(15 * time.Second):
+			t.Fatalf("iter %d: Walk deadlocked (a dependant was never started)", iter)
+		}
+	}
 }
 
 // Test that when two failing parents share a single child, cancelNode


### PR DESCRIPTION
## Problem

A Visia CI run crashed intermittently inside `grog build-and-test` with:

```
fatal error: concurrent map read and map write

goroutine 166 [running]:
grog/internal/dag.(*Walker).startNode(...)   graph_walker.go:177
grog/internal/dag.(*Walker).onComplete(...)  graph_walker.go:230
grog/internal/dag.(*Walker).nodeRoutine(...) graph_walker.go:265
created by grog/internal/dag.(*Walker).Walk in goroutine 1
                                             graph_walker.go:128
```

## Root cause

`Walker.Walk` used a single loop to both **write** each node's `nodeInfo` into
`w.nodeInfoMap` (no lock) and immediately **start** any node with no
dependencies. `startNode`/`cancelNode` read that map under `w.nodeMutex`, but the
populate write never took the mutex — so the lock guarded nothing against the
loop's own writes.

Two failures fall out of this:

1. **Data race / fatal crash.** A no-dependency node started inside the loop can
   complete instantly (cache hit) → `nodeRoutine` → `onComplete` →
   `startNode(dependant)`, which reads the map (line 177) while the same loop is
   still writing it (line 120). Go's runtime aborts the process.
2. **Lost-start deadlock (latent).** Map iteration order is random, so the
   dependant may not be in `nodeInfoMap` yet when `onComplete` tries to start it.
   `startNode`'s `if info, ok := ...; ok` is then false, the start is silently
   dropped, the dependant's routine blocks forever on `ready`, and
   `w.wait.Wait()` never returns.

It's rare because it needs a no-dep node iterated early *and* completing (cache
hit) before its dependant is registered.

## Fix

Split `Walk` into two phases:

1. Populate `nodeInfoMap` and start every `nodeRoutine` (they block on
   `ready`/`cancel`).
2. Once the map is fully populated, start all no-dependency nodes.

Every `startNode` (including those fanned out from `onComplete`) now runs after
the map is complete and never written again — the lookup always succeeds and
there is no concurrent read/write. Channel happens-before in `startNode` carries
the populate writes safely to the worker reads.

## Verification

- New `TestWalkerNoDepStartsLaterDependant` reproduces **both** failures on the
  old code: `WARNING: DATA RACE` at `startNode` line 177 vs the populate write at
  line 120 (matching the CI trace), and `Walk deadlocked`.
- `go test ./internal/dag/ -race -count=1` passes on the fix (~1.5s).
- `gofmt`, `go vet ./internal/dag/`, and `go build ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)