### PR TITLE
fix(ci): publish pkl package by including hidden files in artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
         with:
           name: pkl-package
           path: pkl/.out/**/*
+          # pkl writes to the hidden `.out` directory; upload-artifact@v4
+          # excludes hidden files by default, which silently dropped the
+          # package (warning only, so the job still "succeeded").
+          include-hidden-files: true
 
   publish:
     name: Publish release


### PR DESCRIPTION
## Problem

The pkl package has not been published with releases since **v0.33.0**. Releases through v0.32.0 include `grog@<version>.zip`; v0.33.0 onward do not.

## Root cause

The v0.33.0 release-workflow refactor moved pkl packaging into its own `release-pkl` job that uploads via `actions/upload-artifact@v4`. `pkl project package` writes to the **hidden** `pkl/.out/` directory, and `upload-artifact@v4` (since v4.4) excludes hidden files by default. The upload silently matched nothing:

```
##[warning]No files were found with the provided path: pkl/.out/**/*. No artifacts will be uploaded.
```

It's only a warning, so every release run still reported success — masking the breakage.

## Fix

Set `include-hidden-files: true` on the "Upload pkl artifact" step. The downstream `publish` job globs the extracted, non-hidden `artifacts/pkl-package/**/*` paths, so it picks up the files once the artifact actually contains them.

## Verification

This can only be fully verified by cutting a new tag. The diagnosis was confirmed against the live release assets (pkl assets present ≤ v0.32.0, absent ≥ v0.33.0) and the workflow run logs showing the no-files-found warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)