### PR TITLE
fix(execution): run target commands from a script file to avoid argv size limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,10 @@ jobs:
         with:
           name: pkl-package
           path: pkl/.out/**/*
+          # pkl writes to the hidden `.out` directory; upload-artifact@v4
+          # excludes hidden files by default, which silently dropped the
+          # package (warning only, so the job still "succeeded").
+          include-hidden-files: true
 
   publish:
     name: Publish release

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -120,14 +120,19 @@ func runTargetCommand(
 		return nil, err
 	}
 
-	// Build shell arguments. When extra args are present (from "grog test
-	// //target -- -k foo"), they are passed as positional parameters to the
-	// shell so that $@ expands to them inside the target command.
-	shellArgs := []string{"-c", templatedCommand}
-	if extraArgs := ExtraArgsFromContext(ctx); len(extraArgs) > 0 {
-		shellArgs = append(shellArgs, "--")
-		shellArgs = append(shellArgs, extraArgs...)
+	// Execute the rendered script as a file rather than `sh -c "<script>"`: a
+	// single argv element is capped at MAX_ARG_STRLEN (128 KB), which the
+	// per-dependency output prelude can exceed ("argument list too long").
+	// `sh` reads the file as data, so it needs no execute bit.
+	scriptPath, cleanup, err := writeCommandScript(templatedCommand)
+	if err != nil {
+		return nil, err
 	}
+	defer cleanup()
+
+	// Extra args (from "grog test //target -- -k foo") follow the script path so
+	// they expand to $@. With a script file $0 is the path, so no placeholder.
+	shellArgs := append([]string{scriptPath}, ExtraArgsFromContext(ctx)...)
 	cmd := exec.CommandContext(ctx, "sh", shellArgs...)
 	cmd.WaitDelay = 1 * time.Second // cancellation grace time
 
@@ -172,6 +177,28 @@ func runTargetCommand(
 		return buffer.Bytes(), cmdErr
 	}
 	return buffer.Bytes(), nil
+}
+
+// writeCommandScript writes the rendered shell script to a temp file and returns
+// its path plus a cleanup func. Running a file avoids the per-argument size limit
+// (MAX_ARG_STRLEN) that large dependency-output preludes can exceed under `sh -c`.
+func writeCommandScript(script string) (string, func(), error) {
+	noop := func() {}
+	f, err := os.CreateTemp("", "grog-cmd-*.sh")
+	if err != nil {
+		return "", noop, fmt.Errorf("failed to create command script file: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(f.Name()) }
+	if _, err := f.WriteString(script); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", noop, fmt.Errorf("failed to write command script file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("failed to close command script file: %w", err)
+	}
+	return f.Name(), cleanup, nil
 }
 
 func GetExtendedTargetEnv(ctx context.Context, target *model.Target) []string {

--- a/internal/execution/execute_target_test.go
+++ b/internal/execution/execute_target_test.go
@@ -243,6 +243,40 @@ func TestRunTargetCommandForwardsExtraArgs(t *testing.T) {
 	}
 }
 
+// TestRunTargetCommandHandlesLargeScript verifies that a rendered command
+// exceeding the kernel's single-argument limit (MAX_ARG_STRLEN, 128 KB on
+// Linux) still executes. Passing such a script via `sh -c` fails with
+// "argument list too long"; writing it to a file does not.
+func TestRunTargetCommandHandlesLargeScript(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{
+		WorkspaceRoot:            tmpDir,
+		DisableDefaultShellFlags: true,
+	}
+	t.Cleanup(func() { config.Global = prev })
+
+	os.MkdirAll(tmpDir+"/pkg", 0755)
+	os.MkdirAll(tmpDir+"/logs/pkg", 0755)
+
+	target := &model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "test"},
+	}
+
+	// A comment far larger than MAX_ARG_STRLEN. As a single `sh -c` argument
+	// this overflows execve; as a script file it runs fine.
+	command := "# " + strings.Repeat("x", 256*1024) + "\necho OK"
+
+	output, err := runTargetCommand(context.Background(), target, nil, nil, nil, nil, command, false)
+	if err != nil {
+		t.Fatalf("expected large script to execute, got %v\noutput: %s", err, string(output))
+	}
+	if !strings.Contains(string(output), "OK") {
+		t.Errorf("expected output to contain OK, got: %s", string(output))
+	}
+}
+
 // TestRunTargetCommandWithoutExtraArgs verifies that $@ expands to empty when
 // no extra args are set in the context.
 func TestRunTargetCommandWithoutExtraArgs(t *testing.T) {


### PR DESCRIPTION
## Problem

Target commands run as `sh -c "<rendered script>"`, so the **entire** rendered script is passed as a single `argv` element. A single argument is bounded by the kernel's `MAX_ARG_STRLEN` (128 KB on Linux), and the dependency-output prelude grows with the dependency graph:

- `output()` emits one `case` arm per **direct** dependency (label + shorthand alias + absolute output paths)
- `transitive_outputs()` / `transitive_outputs_by_tag()` emit one `echo` per **transitive** output

A target with enough dependencies overflows the limit and crashes in 0s, before the user command runs:

```
fork/exec /.../sh: argument list too long
```

This surfaced downstream on a dbt target with ~150 per-model codegen dependencies after upgrading grog: `transitive_outputs*` (added in #137) stacked onto the existing per-dependency `output()` block and pushed the single argument past `MAX_ARG_STRLEN`.

## Fix

Write the rendered script to a temp file and run `sh <file>` instead of `sh -c "<script>"`. A script file has no size limit, and `sh` reads it as data so it needs no execute bit (a `noexec` `/tmp` is fine). `runTargetCommand` is the single exec path for both target commands and output checks, so the fix is centralized there.

### `$@` is preserved

Extra args (`grog test //t -- -k foo`) now follow the script path. With a script file `$0` is the script path automatically, so the previous `--` `$0` placeholder is dropped and `$@` expands identically. The existing extra-args tests cover this.

## Why a file and not, say, deduping the prelude

Trimming the rendered text only lowers the constant factor — the prelude is still `O(deps)` and would overflow again as graphs grow. Executing a file removes the per-argument kernel limit entirely, for any dependency count. (The prelude is still `O(deps)` in *size*, but that's now only shell parse time, not an exec failure. Making the prelude `O(1)` by externalizing the output maps into a manifest file is a reasonable follow-up, kept out of this PR.)

## Tests

- New `TestRunTargetCommandHandlesLargeScript`: a script exceeding `MAX_ARG_STRLEN` executes successfully (would fail under `sh -c`).
- Existing `$@` tests (`TestRunTargetCommandForwardsExtraArgs`, `TestRunTargetCommandWithoutExtraArgs`) still pass, confirming positional-arg behavior is unchanged.

`go build ./...`, `go vet`, `gofmt`, and the full `internal/execution` package tests pass.

### Local repro of the mechanism

Same 1.5 MB payload, single arg vs file:

```
$ sh -c "$(cat payload.txt)"   # → argument list too long: sh
$ sh payload.txt               # → RAN_OK
```