### PR TITLE
fix(ci): update credential-gated fixtures for terse output mode

### DIFF
--- a/integration/fixtures/build_after_taint_gcs.txt
+++ b/integration/fixtures/build_after_taint_gcs.txt
@@ -1,3 +1,5 @@
 INFO: 1 package loaded, 2 targets configured.
 INFO: Selected 2 targets.
+INFO: //:dir DONE (cached)
+INFO: //:foo DONE
 INFO: Build completed successfully. 2 targets completed (1 cache hits).

--- a/integration/fixtures/creates_docker_registry_output.txt
+++ b/integration/fixtures/creates_docker_registry_output.txt
@@ -1,3 +1,4 @@
 INFO: 1 package loaded, 1 target configured.
 INFO: Selected 1 target.
+INFO: //:docker_output DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/loads_docker_registry_output.txt
+++ b/integration/fixtures/loads_docker_registry_output.txt
@@ -1,3 +1,4 @@
 INFO: 1 package loaded, 1 target configured.
 INFO: Selected 1 target.
+INFO: //:docker_output DONE (cached)
 INFO: Build completed successfully. 1 target completed (1 cache hits).

--- a/integration/fixtures/loads_remote_docker_registry_output.txt
+++ b/integration/fixtures/loads_remote_docker_registry_output.txt
@@ -1,3 +1,4 @@
 INFO: 1 package loaded, 1 target configured.
 INFO: Selected 1 target.
+INFO: //:docker_output DONE (cached)
 INFO: Build completed successfully. 1 target completed (1 cache hits).

--- a/integration/fixtures/should_restore_from_gcs.txt
+++ b/integration/fixtures/should_restore_from_gcs.txt
@@ -1,3 +1,5 @@
 INFO: 1 package loaded, 2 targets configured.
 INFO: Selected 2 targets.
+INFO: //:dir DONE (cached)
+INFO: //:foo DONE (cached)
 INFO: Build completed successfully. 2 targets completed (2 cache hits).

--- a/integration/fixtures/should_write_to_gcs.txt
+++ b/integration/fixtures/should_write_to_gcs.txt
@@ -1,3 +1,5 @@
 INFO: 1 package loaded, 2 targets configured.
 INFO: Selected 2 targets.
+INFO: //:dir DONE
+INFO: //:foo DONE
 INFO: Build completed successfully. 2 targets completed (0 cache hits).


### PR DESCRIPTION
## Problem

The `Test` workflow is failing on `main` (run [26304058796](https://github.com/proschel/grog/actions/runs/26304058796)) with 9 integration test failures in two groups:

- `TestCliScenarios/GCS_backend` — `should_write_to_gcs`, `should_restore_from_gcs`, `build_after_taint_gcs`
- `TestCliScenarios/Docker_Registry_Outputs` — `creates_docker_registry_output`, `loads_docker_registry_output`, `loads_remote_docker_registry_output`

## Root cause

PR #145 (terse/detailed build output modes) made the default build output emit per-target `INFO: //:target DONE` lines and regenerated the integration fixtures. But the `GCS_backend` and `Docker_Registry_Outputs` scenarios are marked `requires_credentials: true` and only run in CI — so the local `-update` pass that refreshed every other fixture never touched these, leaving them stale.

## Fix

Update the six credential-gated fixtures to include the per-target `DONE` / `DONE (cached)` lines, matching the exact output produced by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)