### PR TITLE
fix(console): line-buffer streamed logs to stop runaway blank lines

### DIFF
--- a/internal/console/tea_writer.go
+++ b/internal/console/tea_writer.go
@@ -1,45 +1,100 @@
 package console
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// TeaWriter small helper so that we can use a tea.Program as a sync for zap.
+// TeaWriter bridges a subprocess (or zap) byte stream into a tea.Program.
+//
+// It line-buffers: bytes are accumulated and only emitted on complete newline
+// boundaries, so a single logical line that the OS pipe splits across multiple
+// Write calls renders as one line instead of several. Carriage returns within a
+// line are collapsed to the final segment, so in-place progress animations
+// (download bars, etc.) render as one line rather than one line per redraw.
 type TeaWriter struct {
 	Program *tea.Program
-	isDone  bool
+
+	mu     sync.Mutex
+	buf    []byte
+	isDone bool
 }
 
 func NewTeaWriter(program *tea.Program) *TeaWriter {
 	w := &TeaWriter{
 		Program: program,
-		isDone:  false,
 	}
 
 	go func() {
 		w.Program.Wait()
+		w.mu.Lock()
 		w.isDone = true
+		w.mu.Unlock()
 	}()
 
 	return w
 }
 
-func (w TeaWriter) Write(b []byte) (int, error) {
-	outStr := strings.TrimRight(string(b), "\n")
-	if UseTea() && !w.isDone {
-		w.Program.Println(outStr)
-	} else {
-		// Log directly to stdout in non-tty (e.g. CI) environments
-		fmt.Println(outStr)
-	}
+func (w *TeaWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
+	w.buf = append(w.buf, b...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(w.buf[:i])
+		w.buf = w.buf[i+1:]
+		w.emit(collapseCarriageReturns(line))
+	}
 	return len(b), nil
 }
-func (w TeaWriter) Sync() error { return nil }
+
+// Flush emits any buffered partial line (one without a trailing newline). Call
+// after the producing stream has closed so trailing output is not lost.
+func (w *TeaWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(w.buf) == 0 {
+		return
+	}
+	line := string(w.buf)
+	w.buf = w.buf[:0]
+	w.emit(collapseCarriageReturns(line))
+}
+
+// emit writes a single newline-free line. Callers must hold w.mu.
+func (w *TeaWriter) emit(line string) {
+	if UseTea() && !w.isDone {
+		w.Program.Println(line)
+	} else {
+		// Log directly to stdout in non-tty (e.g. CI) environments
+		fmt.Println(line)
+	}
+}
+
+func (w *TeaWriter) Sync() error {
+	w.Flush()
+	return nil
+}
+
+// collapseCarriageReturns reduces a line redrawn in place via carriage returns
+// to the text that would remain visible: the segment after the last \r.
+func collapseCarriageReturns(line string) string {
+	line = strings.TrimRight(line, "\r")
+	if i := strings.LastIndexByte(line, '\r'); i >= 0 {
+		line = line[i+1:]
+	}
+	return line
+}
 
 // StreamToggleWriter writes to the underlying writer only when the toggle is enabled.
 type StreamToggleWriter struct {

--- a/internal/console/tea_writer_test.go
+++ b/internal/console/tea_writer_test.go
@@ -1,0 +1,85 @@
+package console
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCollapseCarriageReturns(t *testing.T) {
+	cases := map[string]string{
+		"plain":             "plain",
+		"10%\r20%\r100%":    "100%",
+		"10%\r20%\r100%\r":  "100%",
+		"\rfoo":             "foo",
+		"prefix\roverwrite": "overwrite",
+		"":                  "",
+	}
+	for in, want := range cases {
+		if got := collapseCarriageReturns(in); got != want {
+			t.Errorf("collapseCarriageReturns(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// captureStdout runs fn with os.Stdout redirected and returns what was written.
+// UseTea() is false under test (stdout is a pipe), so TeaWriter.emit uses
+// fmt.Println and never touches its (nil) tea.Program.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		b, _ := io.ReadAll(bufio.NewReader(r))
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+func TestTeaWriterReassemblesFragmentedLines(t *testing.T) {
+	out := captureStdout(t, func() {
+		w := &TeaWriter{}
+		// A single logical line split across writes must emit as one line.
+		_, _ = w.Write([]byte("hello "))
+		_, _ = w.Write([]byte("world\n"))
+		// Multiple lines in one write split correctly.
+		_, _ = w.Write([]byte("a\nb\n"))
+		// Carriage-return progress collapses to one line, not many.
+		_, _ = w.Write([]byte("10%\r20%\r100%\n"))
+		// Trailing partial line stays buffered until Flush.
+		_, _ = w.Write([]byte("no newline yet"))
+		w.Flush()
+	})
+
+	want := []string{"hello world", "a", "b", "100%", "no newline yet"}
+	got := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines %q, want %d %q", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTeaWriterFlushNoopWhenEmpty(t *testing.T) {
+	out := captureStdout(t, func() {
+		w := &TeaWriter{}
+		_, _ = w.Write([]byte("done\n"))
+		w.Flush() // nothing buffered; must not emit a blank line
+	})
+	if out != "done\n" {
+		t.Errorf("got %q, want %q", out, "done\n")
+	}
+}

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -148,17 +148,18 @@ func runTargetCommand(
 	defer logWriter.Close()
 
 	var buffer bytes.Buffer
+	var teaWriter *console.TeaWriter
 
 	if program := console.GetTeaProgram(ctx); program != nil {
 		toggle := console.GetStreamLogsToggle(ctx)
 		if toggle != nil {
-			teaWriter := console.NewTeaWriter(program)
+			teaWriter = console.NewTeaWriter(program)
 			toggleWriter := console.NewStreamToggleWriter(teaWriter, toggle)
 			multiOut := io.MultiWriter(logWriter, toggleWriter, &buffer)
 			cmd.Stdout = multiOut
 			cmd.Stderr = multiOut
 		} else if streamLogs {
-			teaWriter := console.NewTeaWriter(program)
+			teaWriter = console.NewTeaWriter(program)
 			multiOut := io.MultiWriter(logWriter, teaWriter, &buffer)
 			cmd.Stdout = multiOut
 			cmd.Stderr = multiOut
@@ -173,7 +174,12 @@ func runTargetCommand(
 		cmd.Stderr = multiOut
 	}
 
-	if cmdErr := cmd.Run(); cmdErr != nil {
+	cmdErr := cmd.Run()
+	// Emit any buffered partial line now that the stream has closed.
+	if teaWriter != nil {
+		teaWriter.Flush()
+	}
+	if cmdErr != nil {
 		return buffer.Bytes(), cmdErr
 	}
 	return buffer.Bytes(), nil


### PR DESCRIPTION
## Summary
- When streaming Docker (and other) build logs through the Bubble Tea UI, the stream sometimes flooded with blank lines and went blank. Root cause was in `TeaWriter` (`internal/console/tea_writer.go`): it emitted one `tea.Program.Println` per `Write` call and only trimmed trailing `\n`.
  - OS pipes split subprocess output at arbitrary byte boundaries, so a single log line became multiple `Println`s, each forcing its own newline.
  - Carriage returns (`\r`) were never handled, so in-place progress bars (pip/npm/apt/docker downloads that redraw one line via `\r`) turned every redraw into a separate line — one animated line exploding into hundreds.
- Rewrote `TeaWriter` as a line-buffering writer: accumulates bytes, emits only on complete `\n` boundaries (mutex-guarded since stdout+stderr share one instance), and collapses carriage returns to the final visible segment.
- `Sync()` now flushes (correct for the zap sink in `logger.go`); added `Flush()`, called after `cmd.Run()` in `execute_target.go`, so a trailing newline-less line isn't lost.

## Test plan
- [x] `go test ./internal/console/ ./internal/execution/`
- [x] New `tea_writer_test.go`: carriage-return collapsing, fragmented-line reassembly, empty-flush no-op
- [x] `gofmt` / `treefmt` clean
- [ ] Manual: build a Docker image with progress output and confirm the log stream stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)