### PR TITLE
feat(loading): expose GROG_ENV_FILE predeclared variable

### DIFF
--- a/integration/fixtures/file_env.txt
+++ b/integration/fixtures/file_env.txt
@@ -1,4 +1,4 @@
-INFO: 1 package loaded, 4 targets configured.
+INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
 INFO: //:file_env DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/grog_env_file_predeclared.txt
+++ b/integration/fixtures/grog_env_file_predeclared.txt
@@ -1,4 +1,4 @@
 INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
-INFO: //:inline_overrides_file DONE
+INFO: //:grog_env_file_predeclared DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/quoted_env.txt
+++ b/integration/fixtures/quoted_env.txt
@@ -1,4 +1,4 @@
-INFO: 1 package loaded, 4 targets configured.
+INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
 INFO: //:quoted_env DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/fixtures/starlark_predeclared.txt
+++ b/integration/fixtures/starlark_predeclared.txt
@@ -1,4 +1,4 @@
-INFO: 1 package loaded, 4 targets configured.
+INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
 INFO: //:starlark_predeclared DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).

--- a/integration/test_repos/environment_variables_file/BUILD.star
+++ b/integration/test_repos/environment_variables_file/BUILD.star
@@ -46,3 +46,15 @@ target(
         },
     ],
 )
+
+# Test that GROG_ENV_FILE is available as a predeclared variable
+# containing the absolute path to the configured environment variables file.
+target(
+    name = "grog_env_file_predeclared",
+    output_checks = [
+        {
+            # Verify GROG_ENV_FILE is an absolute path ending with env.vars
+            "command": 'echo "%s" | grep -q "/env.vars$" && test "%s" != ""' % (GROG_ENV_FILE, GROG_ENV_FILE),
+        },
+    ],
+)

--- a/integration/test_scenarios/environment_variables_file.yaml
+++ b/integration/test_scenarios/environment_variables_file.yaml
@@ -17,3 +17,7 @@ cases:
     grog_args:
       - build
       - :starlark_predeclared
+  - name: grog_env_file_predeclared
+    grog_args:
+      - build
+      - :grog_env_file_predeclared

--- a/internal/loading/pkl_loader.go
+++ b/internal/loading/pkl_loader.go
@@ -39,6 +39,7 @@ func (pl *PklLoader) getEvaluator(ctx context.Context) (pkl.Evaluator, error) {
 					"GROG_ARCH":          config.Global.Arch,
 					"GROG_PLATFORM":      config.Global.GetPlatform(),
 					"GROG_PLATFORM_TAGS": strings.Join(config.Global.PlatformTags, ","),
+					"GROG_ENV_FILE":      resolvedEnvironmentVariablesFilePath(),
 				}),
 				withEnv(config.Global.EnvironmentVariables),
 			)
@@ -50,6 +51,7 @@ func (pl *PklLoader) getEvaluator(ctx context.Context) (pkl.Evaluator, error) {
 					"GROG_ARCH":          config.Global.Arch,
 					"GROG_PLATFORM":      config.Global.GetPlatform(),
 					"GROG_PLATFORM_TAGS": strings.Join(config.Global.PlatformTags, ","),
+					"GROG_ENV_FILE":      resolvedEnvironmentVariablesFilePath(),
 				}),
 				withEnv(config.Global.EnvironmentVariables),
 			)

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -62,6 +62,7 @@ func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO,
 		"GROG_ARCH":          starlark.String(config.Global.Arch),
 		"GROG_PLATFORM":      starlark.String(config.Global.GetPlatform()),
 		"GROG_PLATFORM_TAGS": platformTagsStarlarkList(),
+		"GROG_ENV_FILE":      starlark.String(resolvedEnvironmentVariablesFilePath()),
 		"json":               json.Module,
 		"math":               math.Module,
 		"time":               time.Module,
@@ -145,6 +146,7 @@ func (sl StarlarkLoader) loadModule(thread *starlark.Thread, module string, curr
 		"GROG_ARCH":          starlark.String(config.Global.Arch),
 		"GROG_PLATFORM":      starlark.String(config.Global.GetPlatform()),
 		"GROG_PLATFORM_TAGS": platformTagsStarlarkList(),
+		"GROG_ENV_FILE":      starlark.String(resolvedEnvironmentVariablesFilePath()),
 		"json":               json.Module,
 		"math":               math.Module,
 		"time":               time.Module,
@@ -473,4 +475,18 @@ func starlarkListToOutputChecks(list *starlark.List) ([]model.OutputCheck, error
 		})
 	}
 	return result, nil
+}
+
+// resolvedEnvironmentVariablesFilePath returns the absolute path to the
+// configured environment variables file. If EnvironmentVariablesFile is empty,
+// it returns an empty string. Relative paths are resolved against WorkspaceRoot.
+func resolvedEnvironmentVariablesFilePath() string {
+	environmentVariablesFilePath := config.Global.EnvironmentVariablesFile
+	if environmentVariablesFilePath == "" {
+		return ""
+	}
+	if !filepath.IsAbs(environmentVariablesFilePath) {
+		environmentVariablesFilePath = filepath.Join(config.Global.WorkspaceRoot, environmentVariablesFilePath)
+	}
+	return filepath.Clean(environmentVariablesFilePath)
 }

--- a/internal/loading/starlark_loader_test.go
+++ b/internal/loading/starlark_loader_test.go
@@ -139,6 +139,217 @@ shared_func("target_b")
 	// The shared module should have been cached (though we can't directly observe this without instrumentation)
 }
 
+func TestStarlarkLoader_GrogEnvFile(t *testing.T) {
+	t.Run("set to resolved absolute path when env file is configured", func(t *testing.T) {
+		// Bug caught: GROG_ENV_FILE not injected as a predeclared variable,
+		// leaving Starlark scripts unable to reference the environment
+		// variables file path.
+		tmpDir := t.TempDir()
+
+		oldConfig := config.Global
+		defer func() { config.Global = oldConfig }()
+
+		config.Global.WorkspaceRoot = tmpDir
+		config.Global.EnvironmentVariablesFile = "env.vars"
+
+		// The env file doesn't need to contain anything for the path test,
+		// but create it so the workspace is realistic.
+		envFilePath := filepath.Join(tmpDir, "env.vars")
+		if err := os.WriteFile(envFilePath, []byte("FOO=bar\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// BUILD.star captures GROG_ENV_FILE into a target command.
+		buildFile := filepath.Join(tmpDir, "BUILD.star")
+		script := `target(name = "test", command = GROG_ENV_FILE)`
+		if err := os.WriteFile(buildFile, []byte(script), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		loader := StarlarkLoader{}
+		pkg, matched, err := loader.Load(context.Background(), buildFile)
+		if err != nil {
+			t.Fatalf("Load() returned error: %v", err)
+		}
+		if !matched {
+			t.Fatal("expected loader to match BUILD.star")
+		}
+
+		expectedPath := filepath.Join(tmpDir, "env.vars")
+		if len(pkg.Targets) != 1 {
+			t.Fatalf("expected 1 target, got %d", len(pkg.Targets))
+		}
+		if pkg.Targets[0].Command != expectedPath {
+			t.Errorf("GROG_ENV_FILE = %q, want %q", pkg.Targets[0].Command, expectedPath)
+		}
+	})
+
+	t.Run("absolute path passed through unchanged", func(t *testing.T) {
+		// Bug caught: absolute EnvironmentVariablesFile paths double-joined
+		// with WorkspaceRoot, producing an incorrect GROG_ENV_FILE value.
+		tmpDir := t.TempDir()
+
+		oldConfig := config.Global
+		defer func() { config.Global = oldConfig }()
+
+		absoluteEnvPath := filepath.Join(tmpDir, "absolute", "env.vars")
+		config.Global.WorkspaceRoot = tmpDir
+		config.Global.EnvironmentVariablesFile = absoluteEnvPath
+
+		buildFile := filepath.Join(tmpDir, "BUILD.star")
+		script := `target(name = "test", command = GROG_ENV_FILE)`
+		if err := os.WriteFile(buildFile, []byte(script), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		loader := StarlarkLoader{}
+		pkg, _, err := loader.Load(context.Background(), buildFile)
+		if err != nil {
+			t.Fatalf("Load() returned error: %v", err)
+		}
+
+		if len(pkg.Targets) != 1 {
+			t.Fatalf("expected 1 target, got %d", len(pkg.Targets))
+		}
+		if pkg.Targets[0].Command != absoluteEnvPath {
+			t.Errorf("GROG_ENV_FILE = %q, want %q", pkg.Targets[0].Command, absoluteEnvPath)
+		}
+	})
+
+	t.Run("empty string when env file is not configured", func(t *testing.T) {
+		// Bug caught: GROG_ENV_FILE undefined (Starlark error) instead of
+		// being set to "" when no environment_variables_file is configured.
+		tmpDir := t.TempDir()
+
+		oldConfig := config.Global
+		defer func() { config.Global = oldConfig }()
+
+		config.Global.WorkspaceRoot = tmpDir
+		config.Global.EnvironmentVariablesFile = ""
+
+		buildFile := filepath.Join(tmpDir, "BUILD.star")
+		// Use string concatenation so we can verify the value is truly empty.
+		script := `target(name = "test", command = "prefix:" + GROG_ENV_FILE + ":suffix")`
+		if err := os.WriteFile(buildFile, []byte(script), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		loader := StarlarkLoader{}
+		pkg, _, err := loader.Load(context.Background(), buildFile)
+		if err != nil {
+			t.Fatalf("Load() returned error: %v", err)
+		}
+
+		if len(pkg.Targets) != 1 {
+			t.Fatalf("expected 1 target, got %d", len(pkg.Targets))
+		}
+		if pkg.Targets[0].Command != "prefix::suffix" {
+			t.Errorf("GROG_ENV_FILE should be empty, got command %q, want %q",
+				pkg.Targets[0].Command, "prefix::suffix")
+		}
+	})
+
+	t.Run("existing predeclared variables remain unchanged", func(t *testing.T) {
+		// Bug caught: adding GROG_ENV_FILE accidentally overwrites or removes
+		// existing predeclared variables like GROG_OS or GROG_ARCH.
+		tmpDir := t.TempDir()
+
+		oldConfig := config.Global
+		defer func() { config.Global = oldConfig }()
+
+		config.Global.WorkspaceRoot = tmpDir
+		config.Global.OS = "linux"
+		config.Global.Arch = "amd64"
+		config.Global.EnvironmentVariablesFile = "env.vars"
+
+		envFilePath := filepath.Join(tmpDir, "env.vars")
+		if err := os.WriteFile(envFilePath, []byte("FOO=bar\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		buildFile := filepath.Join(tmpDir, "BUILD.star")
+		script := `target(name = "env_file", command = GROG_ENV_FILE)
+target(name = "os", command = GROG_OS)
+target(name = "arch", command = GROG_ARCH)
+`
+		if err := os.WriteFile(buildFile, []byte(script), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		loader := StarlarkLoader{}
+		pkg, _, err := loader.Load(context.Background(), buildFile)
+		if err != nil {
+			t.Fatalf("Load() returned error: %v", err)
+		}
+
+		targetsByName := make(map[string]*TargetDTO)
+		for _, target := range pkg.Targets {
+			targetsByName[target.Name] = target
+		}
+
+		if targetsByName["os"].Command != "linux" {
+			t.Errorf("GROG_OS = %q, want %q", targetsByName["os"].Command, "linux")
+		}
+		if targetsByName["arch"].Command != "amd64" {
+			t.Errorf("GROG_ARCH = %q, want %q", targetsByName["arch"].Command, "amd64")
+		}
+		expectedPath := filepath.Join(tmpDir, "env.vars")
+		if targetsByName["env_file"].Command != expectedPath {
+			t.Errorf("GROG_ENV_FILE = %q, want %q", targetsByName["env_file"].Command, expectedPath)
+		}
+	})
+
+	t.Run("available in loaded star modules", func(t *testing.T) {
+		// Bug caught: GROG_ENV_FILE injected into the main BUILD.star predeclared
+		// dict but not into the loadModule predeclared dict, making it undefined
+		// in load()'d modules.
+		tmpDir := t.TempDir()
+
+		oldConfig := config.Global
+		defer func() { config.Global = oldConfig }()
+
+		config.Global.WorkspaceRoot = tmpDir
+		config.Global.EnvironmentVariablesFile = "env.vars"
+
+		envFilePath := filepath.Join(tmpDir, "env.vars")
+		if err := os.WriteFile(envFilePath, []byte("FOO=bar\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Module that accesses GROG_ENV_FILE
+		modulePath := filepath.Join(tmpDir, "helpers.star")
+		moduleScript := `def create_target():
+    target(name = "from_module", command = GROG_ENV_FILE)
+`
+		if err := os.WriteFile(modulePath, []byte(moduleScript), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		buildFile := filepath.Join(tmpDir, "BUILD.star")
+		buildScript := `load("//helpers.star", "create_target")
+create_target()
+`
+		if err := os.WriteFile(buildFile, []byte(buildScript), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		loader := StarlarkLoader{}
+		pkg, _, err := loader.Load(context.Background(), buildFile)
+		if err != nil {
+			t.Fatalf("Load() returned error: %v", err)
+		}
+
+		expectedPath := filepath.Join(tmpDir, "env.vars")
+		if len(pkg.Targets) != 1 {
+			t.Fatalf("expected 1 target, got %d", len(pkg.Targets))
+		}
+		if pkg.Targets[0].Command != expectedPath {
+			t.Errorf("GROG_ENV_FILE in module = %q, want %q",
+				pkg.Targets[0].Command, expectedPath)
+		}
+	})
+}
+
 func TestStarlarkLoader_StdlibModules(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Adds `GROG_ENV_FILE` as a predeclared Starlark variable and PKL environment variable containing the resolved absolute path to the configured `environment_variables_file`. This implements **Option 2** from #141.

## Motivation

BUILD.star scripts that construct docker commands need to reference the environment variables file path for `--env-file` flags. Without a predeclared variable, users must hardcode the path or duplicate the resolution logic that grog already performs internally.

## Changes

- **`internal/loading/starlark_loader.go`**: Inject `GROG_ENV_FILE` into both `Load()` and `loadModule()` predeclared dicts. Add `resolvedEnvironmentVariablesFilePath()` helper that resolves relative paths against `WorkspaceRoot` and normalizes with `filepath.Clean`.
- **`internal/loading/pkl_loader.go`**: Add `GROG_ENV_FILE` to both PKL evaluator branches (project and non-project).
- **`internal/loading/starlark_loader_test.go`**: 5 unit tests covering relative path resolution, absolute path passthrough, empty config, coexistence with existing predeclared variables, and availability in loaded modules.
- **`integration/`**: New test scenario and target for end-to-end verification.

## Behavior

| Config state | `GROG_ENV_FILE` value |
|---|---|
| `environment_variables_file: "env.vars"` | `/absolute/path/to/workspace/env.vars` |
| `environment_variables_file: "/absolute/path/env.vars"` | `/absolute/path/env.vars` |
| (not configured) | `""` (empty string) |

## Usage example

```python
# BUILD.star
target(
    name = "run",
    command = "docker run --env-file " + GROG_ENV_FILE + " myimage",
)
```

## Testing

- 5 unit tests (all passing)
- Integration test scenario added
- `go vet ./...` clean, `gofmt` clean
- No regressions in `go test ./internal/...`

Closes #141