### PR TITLE
fix(execution): restore bin_output executable bit on cache hits

### DIFF
--- a/integration/fixtures/run_after_cache_restore_preserves_exec_bit.txt
+++ b/integration/fixtures/run_after_cache_restore_preserves_exec_bit.txt
@@ -1,0 +1,6 @@
+INFO: 2 packages loaded, 4 targets configured.
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+INFO: Selected 1 target.
+INFO: //:creates_bin_tool DONE (cached)
+INFO: Build completed successfully. 1 target completed (1 cache hits).
+INFO: Running //:creates_bin_tool -> dist/bin with args [foo]

--- a/integration/test_scenarios/binary_output.yaml
+++ b/integration/test_scenarios/binary_output.yaml
@@ -9,6 +9,18 @@ cases:
     grog_args:
       - build
 
+  # Regression for chrismatix/grog#155: when the bin_output file is missing
+  # the cache restore must put it back AND keep the executable bit so the
+  # binary can be invoked. Without the fix, dist/bin is restored as 0644
+  # and `grog run` fails with EACCES.
+  - name: run_after_cache_restore_preserves_exec_bit
+    setup_command: rm -f dist/bin
+    grog_args:
+      - run
+      - //:creates_bin_tool
+      - --
+      - foo
+
   - name: run_command_fails
     grog_args:
       - run

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -418,6 +418,12 @@ func (e *Executor) getTaskFunc(
 				// Don't return so that we instead break out and continue executing the target
 				logger.Errorf("%s re-running due to output loading failure: %v", target.Label, loadingErr)
 			} else {
+				// The CAS doesn't track file mode, so a restored bin_output
+				// comes back 0644. Re-apply the executable bit to match a
+				// fresh build (issue #155).
+				if err := markBinOutputExecutable(target); err != nil {
+					return dag.CacheMiss, err
+				}
 				// Log the cached execution time recorded when the target was
 				// originally built, not the (near-zero) cache-load time.
 				logTargetCached(ctx, logger, target, float64(targetResult.ExecutionDurationMillis)/1000)
@@ -674,6 +680,11 @@ func (e *Executor) LoadDependencyOutputs(
 				update,
 			)
 			loadErr = e.registry.LoadOutputs(ctx, localDep, targetResult, progress)
+			if loadErr == nil {
+				// Restored files come back without an executable bit; bin_output
+				// must stay executable across cache hits (issue #155).
+				loadErr = markBinOutputExecutable(localDep)
+			}
 		} else {
 			// Target cache not available (e.g. async cache write not yet complete).
 			// Treat as a load failure so the dependency is re-built below.

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -15,7 +15,6 @@ import (
 	"grog/internal/output/handlers"
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -530,12 +529,6 @@ func (e *Executor) executeTarget(
 		return dag.CacheMiss, outputCheckErr
 	}
 
-	// If the target produced a bin output automatically mark it as executable
-	err = markBinOutputExecutable(target)
-	if err != nil {
-		return dag.CacheMiss, err
-	}
-
 	// Write outputs to the cache:
 	logger.Debugf("writing outputs for target %s", target.Label)
 	update(worker.Status(fmt.Sprintf("%s: writing outputs", target.Label)))
@@ -697,20 +690,6 @@ func (e *Executor) LoadDependencyOutputs(
 				return rerunError
 			}
 		}
-	}
-
-	return nil
-}
-
-func markBinOutputExecutable(target *model.Target) error {
-	if !target.HasBinOutput() {
-		return nil
-	}
-
-	binOutputPath := config.GetPathAbsoluteToWorkspaceRoot(filepath.Join(target.Label.Package, target.BinOutput.Identifier))
-	err := os.Chmod(binOutputPath, 0755)
-	if err != nil {
-		return fmt.Errorf("failed to mark binary output as executable for target %s: %w", target.Label, err)
 	}
 
 	return nil

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -418,12 +418,6 @@ func (e *Executor) getTaskFunc(
 				// Don't return so that we instead break out and continue executing the target
 				logger.Errorf("%s re-running due to output loading failure: %v", target.Label, loadingErr)
 			} else {
-				// The CAS doesn't track file mode, so a restored bin_output
-				// comes back 0644. Re-apply the executable bit to match a
-				// fresh build (issue #155).
-				if err := markBinOutputExecutable(target); err != nil {
-					return dag.CacheMiss, err
-				}
 				// Log the cached execution time recorded when the target was
 				// originally built, not the (near-zero) cache-load time.
 				logTargetCached(ctx, logger, target, float64(targetResult.ExecutionDurationMillis)/1000)
@@ -680,11 +674,6 @@ func (e *Executor) LoadDependencyOutputs(
 				update,
 			)
 			loadErr = e.registry.LoadOutputs(ctx, localDep, targetResult, progress)
-			if loadErr == nil {
-				// Restored files come back without an executable bit; bin_output
-				// must stay executable across cache hits (issue #155).
-				loadErr = markBinOutputExecutable(localDep)
-			}
 		} else {
 			// Target cache not available (e.g. async cache write not yet complete).
 			// Treat as a load failure so the dependency is re-built below.

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -192,6 +192,10 @@ func (r *Registry) PrepareOutputs(
 		return nil, err
 	}
 
+	if err := ensureBinOutputExecutable(target); err != nil {
+		return nil, err
+	}
+
 	logger.Debugf("%s: outputs written", target.Label)
 
 	return &PreparedTargetResult{
@@ -233,6 +237,10 @@ func (r *Registry) GetNoCacheOutputHash(ctx context.Context, target *model.Targe
 		if err := task.Wait(); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := ensureBinOutputExecutable(target); err != nil {
+		return nil, err
 	}
 
 	return &gen.TargetResult{
@@ -283,22 +291,31 @@ func (r *Registry) LoadOutputs(
 		}
 	}
 
-	// The CAS doesn't track file mode, so a restored bin_output comes back
-	// 0644. Re-apply 0755 here — at the restore boundary — so any caller of
-	// LoadOutputs ends up with the same on-disk state as a fresh build
-	// (issue #155).
-	if target.HasBinOutput() {
-		binOutputPath := config.GetPathAbsoluteToWorkspaceRoot(
-			filepath.Join(target.Label.Package, target.BinOutput.Identifier),
-		)
-		if err := os.Chmod(binOutputPath, 0755); err != nil {
-			return fmt.Errorf("failed to mark bin_output executable for %s: %w", target.Label, err)
-		}
+	if err := ensureBinOutputExecutable(target); err != nil {
+		return err
 	}
 
 	logger.Debugf("%s: outputs loaded", target.Label)
 	target.OutputsLoaded = true
 	target.OutputHash = targetResult.OutputHash
+	return nil
+}
+
+// ensureBinOutputExecutable marks a target's bin_output 0755 on disk.
+// The CAS doesn't track file mode, and a user's build command may not chmod
+// the binary itself, so the Registry guarantees this post-condition at every
+// boundary that produces outputs (fresh build, no-cache build, cache restore)
+// — see issue #155.
+func ensureBinOutputExecutable(target *model.Target) error {
+	if !target.HasBinOutput() {
+		return nil
+	}
+	binOutputPath := config.GetPathAbsoluteToWorkspaceRoot(
+		filepath.Join(target.Label.Package, target.BinOutput.Identifier),
+	)
+	if err := os.Chmod(binOutputPath, 0755); err != nil {
+		return fmt.Errorf("failed to mark bin_output executable for %s: %w", target.Label, err)
+	}
 	return nil
 }
 

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -14,6 +14,8 @@ import (
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
 	"io"
+	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"sync"
@@ -278,6 +280,19 @@ func (r *Registry) LoadOutputs(
 	for _, task := range tasks {
 		if err := task.Wait(); err != nil {
 			return err
+		}
+	}
+
+	// The CAS doesn't track file mode, so a restored bin_output comes back
+	// 0644. Re-apply 0755 here — at the restore boundary — so any caller of
+	// LoadOutputs ends up with the same on-disk state as a fresh build
+	// (issue #155).
+	if target.HasBinOutput() {
+		binOutputPath := config.GetPathAbsoluteToWorkspaceRoot(
+			filepath.Join(target.Label.Package, target.BinOutput.Identifier),
+		)
+		if err := os.Chmod(binOutputPath, 0755); err != nil {
+			return fmt.Errorf("failed to mark bin_output executable for %s: %w", target.Label, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixes #155: `bin_output` files lost the `0755` mode when restored from the cache because the CAS doesn't track file mode and `markBinOutputExecutable` only ran inside `executeTarget` (fresh-build path), never after `LoadOutputs`.
- Re-applies the executable bit after a successful `LoadOutputs` in both the main cache-hit path and the `LoadDependencyOutputs` (load_outputs=minimal) path so cached and freshly built bin_outputs behave identically.
- Adds a regression integration case `run_after_cache_restore_preserves_exec_bit` that deletes `dist/bin` between cases to force a real CAS restore, then `grog run`s the binary. Without the fix this fails with `fork/exec dist/bin: permission denied`; existing cases didn't catch the bug because `FileOutputHandler.Load` short-circuits when the on-disk hash already matches.

## Test plan
- [x] `go test ./integration/... -run 'TestCliScenarios/Binary_outputs'` — all 8 cases pass
- [x] `go test ./internal/execution/... ./internal/output/...` — unit tests pass
- [x] New case fails on `main` (permission denied), passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)