### PR TITLE
feat(oci): declared-repo Docker layer cache with content-addressed tags

### DIFF
--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -57,6 +57,7 @@ Reference for the `grog` CLI.
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -65,24 +66,26 @@ Reference for the `grog` CLI.
 
 ### See also
 
-- [`grog build`](#grog-build) - Loads the user configuration and executes build targets.
-- [`grog build-and-test`](#grog-build-and-test) - Loads the user configuration and executes build and test targets.
-- [`grog changes`](#grog-changes) - Lists targets whose inputs have been modified since a given commit.
-- [`grog check`](#grog-check) - Loads the build graph and runs basic consistency checks.
-- [`grog clean`](#grog-clean) - Removes all cached artifacts.
-- [`grog deps`](#grog-deps) - Lists (transitive) dependencies of a target.
-- [`grog explain-changes`](#grog-explain-changes) - Renders the chain of targets affected by changes since a git ref as a tree.
-- [`grog graph`](#grog-graph) - Outputs the target dependency graph.
-- [`grog info`](#grog-info) - Prints information about the grog cli and workspace.
-- [`grog list`](#grog-list) - Lists targets by pattern.
-- [`grog logs`](#grog-logs) - Print the latest log file for the given target.
-- [`grog owners`](#grog-owners) - Lists targets that own the specified files as inputs.
-- [`grog rdeps`](#grog-rdeps) - Lists (transitive) dependants (reverse dependencies) of a target.
-- [`grog run`](#grog-run) - Builds and runs one or more targets' binary outputs.
-- [`grog taint`](#grog-taint) - Taints targets by pattern to force execution regardless of cache status.
-- [`grog test`](#grog-test) - Loads the user configuration and executes test targets.
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
-- [`grog version`](#grog-version) - Print the version info.
+* [`grog build`](#grog-build) - Loads the user configuration and executes build targets.
+* [`grog build-and-test`](#grog-build-and-test) - Loads the user configuration and executes build and test targets.
+* [`grog changes`](#grog-changes) - Lists targets whose inputs have been modified since a given commit.
+* [`grog check`](#grog-check) - Loads the build graph and runs basic consistency checks.
+* [`grog clean`](#grog-clean) - Removes all cached artifacts.
+* [`grog deps`](#grog-deps) - Lists (transitive) dependencies of a target.
+* [`grog explain-changes`](#grog-explain-changes) - Renders the chain of targets affected by changes since a git ref as a tree.
+* [`grog graph`](#grog-graph) - Outputs the target dependency graph.
+* [`grog info`](#grog-info) - Prints information about the grog cli and workspace.
+* [`grog list`](#grog-list) - Lists targets by pattern.
+* [`grog logs`](#grog-logs) - Print the latest log file for the given target.
+* [`grog owners`](#grog-owners) - Lists targets that own the specified files as inputs.
+* [`grog rdeps`](#grog-rdeps) - Lists (transitive) dependants (reverse dependencies) of a target.
+* [`grog run`](#grog-run) - Builds and runs one or more targets' binary outputs.
+* [`grog taint`](#grog-taint) - Taints targets by pattern to force execution regardless of cache status.
+* [`grog test`](#grog-test) - Loads the user configuration and executes test targets.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog version`](#grog-version) - Print the version info.
+
+
 
 ---
 
@@ -132,6 +135,7 @@ grog build [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -140,7 +144,9 @@ grog build [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -190,6 +196,7 @@ grog build-and-test [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -198,7 +205,9 @@ grog build-and-test [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -260,7 +269,9 @@ grog changes [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -308,6 +319,7 @@ grog check [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -316,7 +328,9 @@ grog check [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -367,6 +381,7 @@ grog clean [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -375,7 +390,9 @@ grog clean [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -429,6 +446,7 @@ grog deps [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -437,7 +455,9 @@ grog deps [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -511,7 +531,9 @@ grog explain-changes [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -566,6 +588,7 @@ grog graph [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -574,7 +597,9 @@ grog graph [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -623,6 +648,7 @@ grog info [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -631,7 +657,9 @@ grog info [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -683,6 +711,7 @@ grog list [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -691,7 +720,9 @@ grog list [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -742,6 +773,7 @@ grog logs [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -750,7 +782,9 @@ grog logs [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -800,6 +834,7 @@ grog owners [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -808,7 +843,9 @@ grog owners [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -862,6 +899,7 @@ grog rdeps [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -870,7 +908,9 @@ grog rdeps [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -922,6 +962,7 @@ grog run [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -930,7 +971,9 @@ grog run [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -982,6 +1025,7 @@ grog taint [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -990,7 +1034,9 @@ grog taint [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -1043,6 +1089,7 @@ grog test [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1051,7 +1098,9 @@ grog test [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ---
 
@@ -1089,6 +1138,7 @@ View, analyze, and export build execution traces for performance analysis and da
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1097,13 +1147,15 @@ View, analyze, and export build execution traces for performance analysis and da
 
 ### See also
 
-- [`grog`](#grog)
-- [`grog traces export`](#grog-traces-export) - Export traces for dashboard integration.
-- [`grog traces list`](#grog-traces-list) - List recent build traces.
-- [`grog traces prune`](#grog-traces-prune) - Delete traces older than a specified duration.
-- [`grog traces pull`](#grog-traces-pull) - Download remote traces to local cache for querying.
-- [`grog traces show`](#grog-traces-show) - Show details of a specific trace.
-- [`grog traces stats`](#grog-traces-stats) - Show aggregate statistics across recent traces.
+* [`grog`](#grog)
+* [`grog traces export`](#grog-traces-export) - Export traces for dashboard integration.
+* [`grog traces list`](#grog-traces-list) - List recent build traces.
+* [`grog traces prune`](#grog-traces-prune) - Delete traces older than a specified duration.
+* [`grog traces pull`](#grog-traces-pull) - Download remote traces to local cache for querying.
+* [`grog traces show`](#grog-traces-show) - Show details of a specific trace.
+* [`grog traces stats`](#grog-traces-stats) - Show aggregate statistics across recent traces.
+
+
 
 ---
 
@@ -1160,7 +1212,9 @@ grog traces export [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1219,7 +1273,9 @@ grog traces list [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1265,6 +1321,7 @@ grog traces prune [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1273,7 +1330,9 @@ grog traces prune [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1317,6 +1376,7 @@ grog traces pull [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1325,7 +1385,9 @@ grog traces pull [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1372,6 +1434,7 @@ grog traces show <trace-id> [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1380,7 +1443,9 @@ grog traces show <trace-id> [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1431,6 +1496,7 @@ grog traces stats [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1439,7 +1505,9 @@ grog traces stats [flags]
 
 ### See also
 
-- [`grog traces`](#grog-traces) - View and manage build execution traces.
+* [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+
 
 ---
 
@@ -1487,6 +1555,7 @@ grog version [flags]
       --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
       --profile string                Select a configuration profile to use
       --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --since string                  Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.
       --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
       --stream-logs                   Forward all target build/test logs to stdout/-err
       --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
@@ -1495,6 +1564,8 @@ grog version [flags]
 
 ### See also
 
-- [`grog`](#grog)
+* [`grog`](#grog)
+
+
 
 ###### Auto generated by spf13/cobra

--- a/docs/src/content/docs/topics/docker-outputs.mdx
+++ b/docs/src/content/docs/topics/docker-outputs.mdx
@@ -205,6 +205,33 @@ digest. `--push` applies transitively across the build selection, so a
 The `oci_push` map is **not** part of the cache key, so bumping the tag in
 your destination string reuses the cached image and only re-runs the push.
 
+### Layer cache reuse
+
+Declaring `oci_push` for an `oci::` output also changes how Grog **caches** that
+image, so that a `docker build` after a cache miss can reuse unchanged layers
+(`apt-get`, `pip install`, `npm ci`, …) from the previous build.
+
+- **Declared cache repository.** The cache image is stored in the repository
+  from the output's `oci_push` destination — the part before the tag. Grog tags
+  it with the build platform and the target's content hash,
+  `<repo>:<platform>-<change-hash>`, ignoring your deploy tag. Because the
+  repository is declared (not synthesised from the target label), the set of
+  cache repositories is explicit and enumerable — convenient when a registry
+  such as ECR requires repositories to be created ahead of time.
+- **Content-addressed identity.** The tag changes whenever an input changes, so
+  a stale image is never restored as the cache. An output **without** `oci_push`
+  keeps the default content-addressed naming (one repository per image digest).
+- **Seeding on a cache miss.** Before building, Grog pulls the image the same
+  target produced at an earlier commit and loads it into the local daemon so its
+  layers are available to `docker build`. The earlier commit is chosen by
+  `--since` (the same ref you pass to `grog changes`: `origin/<base>` on a pull
+  request, `HEAD~1` on a push to your default branch). When `--since` is omitted,
+  Grog auto-detects the merge-base with the upstream default branch and falls
+  back to `HEAD~1`. Seeding is best-effort: if the prior image cannot be found
+  (first build, shallow clone, no ref), the build simply runs without a warm
+  layer cache. The seed image only warms layers — it is never restored as the
+  build result — so a missed seed costs build time but never correctness.
+
 ### Insecure registries
 
 By default Grog pushes over HTTPS. To allow plain HTTP destinations (local

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -121,6 +121,10 @@ func configureRoot() bool {
 	RootCmd.PersistentFlags().Bool("push", false, "Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build")
 	_ = viper.BindPFlag("push", RootCmd.PersistentFlags().Lookup("push"))
 
+	// since (git ref for Docker layer-cache seeding)
+	RootCmd.PersistentFlags().String("since", "", "Git ref for Docker layer-cache seed-donor selection (e.g. HEAD~1 or origin/main). Empty auto-detects the merge-base with the upstream default branch.")
+	_ = viper.BindPFlag("since", RootCmd.PersistentFlags().Lookup("since"))
+
 	// skip_workspace_lock
 	RootCmd.PersistentFlags().Bool("skip-workspace-lock", false, "Skip the workspace level lock (DANGEROUS: may corrupt the cache)")
 	_ = viper.BindPFlag("skip_workspace_lock", RootCmd.PersistentFlags().Lookup("skip-workspace-lock"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,20 @@ func (w WorkspaceConfig) Validate() error {
 			w.OCI.Backend, OCIBackendFS, OCIBackendRegistry)
 	}
 
+	switch w.OCI.CacheMode {
+	case "", OCICacheModeContent, OCICacheModeTarget:
+	default:
+		return fmt.Errorf("invalid oci cache_mode: %s. Must be either %q or %q",
+			w.OCI.CacheMode, OCICacheModeContent, OCICacheModeTarget)
+	}
+
+	// prebuild_layer_fetch requires target-based naming to have a stable
+	// image to pull.
+	if w.OCI.PrebuildLayerFetch != nil && *w.OCI.PrebuildLayerFetch &&
+		w.OCI.CacheMode != OCICacheModeTarget {
+		return fmt.Errorf("prebuild_layer_fetch requires cache_mode = %q", OCICacheModeTarget)
+	}
+
 	// assert that tags and exclude tags do not overlap
 	for _, tag := range w.Tags {
 		if slices.Contains(w.ExcludeTags, tag) {
@@ -337,6 +351,25 @@ type OCIConfig struct {
 
 	// CacheMode controls how registry cache images are named.
 	// "content" (default): one repo per unique image digest.
-	// "target": one repo per target label, enabling Docker layer cache reuse.
+	// "target": one repo per target label, producing stable, predictable
+	// registry repository names.
 	CacheMode string `mapstructure:"cache_mode"`
+
+	// PrebuildLayerFetch controls whether grog pulls the previous image
+	// for a target into the local Docker daemon before building, so that
+	// Docker's layer cache can reuse unchanged layers. Only effective when
+	// CacheMode is "target". Defaults to true when CacheMode is "target".
+	// Set to false if you handle layer caching yourself (e.g. via
+	// --cache-from in your build command).
+	PrebuildLayerFetch *bool `mapstructure:"prebuild_layer_fetch"`
+}
+
+// IsPrebuildLayerFetchEnabled returns whether layer cache seeding is active.
+// When PrebuildLayerFetch is nil (unset), it defaults to true in target mode.
+func (d OCIConfig) IsPrebuildLayerFetchEnabled() bool {
+	if d.PrebuildLayerFetch != nil {
+		return *d.PrebuildLayerFetch
+	}
+	// Default: enabled in target mode, disabled otherwise.
+	return d.CacheMode == OCICacheModeTarget
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,14 @@ type WorkspaceConfig struct {
 
 	Push bool `mapstructure:"push"`
 
+	// CacheSeedRef is an optional git ref used to locate Docker layer-cache
+	// seed donors. On a cache miss, grog recomputes a target's change hash as
+	// its inputs existed at this ref and pulls that immutable cache image to
+	// warm the build's layer cache. Empty means "auto-detect" (the merge-base
+	// with the upstream default branch, then HEAD~1). Set by the --since flag;
+	// CI typically passes the same ref it uses for `grog changes`.
+	CacheSeedRef string `mapstructure:"since"`
+
 	// Environment Variables
 	EnvironmentVariables     map[string]string `mapstructure:"environment_variables"`
 	EnvironmentVariablesFile string            `mapstructure:"environment_variables_file"`
@@ -192,20 +200,6 @@ func (w WorkspaceConfig) Validate() error {
 		(w.OCI.Backend != OCIBackendFS && w.OCI.Backend != OCIBackendRegistry) {
 		return fmt.Errorf("invalid oci backend: %s. Must be either %s or %s",
 			w.OCI.Backend, OCIBackendFS, OCIBackendRegistry)
-	}
-
-	switch w.OCI.CacheMode {
-	case "", OCICacheModeContent, OCICacheModeTarget:
-	default:
-		return fmt.Errorf("invalid oci cache_mode: %s. Must be either %q or %q",
-			w.OCI.CacheMode, OCICacheModeContent, OCICacheModeTarget)
-	}
-
-	// prebuild_layer_fetch requires target-based naming to have a stable
-	// image to pull.
-	if w.OCI.PrebuildLayerFetch != nil && *w.OCI.PrebuildLayerFetch &&
-		w.OCI.CacheMode != OCICacheModeTarget {
-		return fmt.Errorf("prebuild_layer_fetch requires cache_mode = %q", OCICacheModeTarget)
 	}
 
 	// assert that tags and exclude tags do not overlap
@@ -324,16 +318,6 @@ const (
 	OCIBackendRegistry = "registry"
 )
 
-const (
-	// OCICacheModeContent names cache images by content digest (default).
-	// Each unique image gets its own registry repo.
-	OCICacheModeContent = "content"
-
-	// OCICacheModeTarget names cache images by target label (stable).
-	// One registry repo per target, enabling Docker layer cache reuse across builds.
-	OCICacheModeTarget = "target"
-)
-
 type OCIConfig struct {
 	Backend string `mapstructure:"backend"`
 
@@ -348,28 +332,4 @@ type OCIConfig struct {
 	// docker daemon's insecure-registries config so a user already familiar
 	// with that knob has no new mental model.
 	InsecureRegistries []string `mapstructure:"insecure_registries"`
-
-	// CacheMode controls how registry cache images are named.
-	// "content" (default): one repo per unique image digest.
-	// "target": one repo per target label, producing stable, predictable
-	// registry repository names.
-	CacheMode string `mapstructure:"cache_mode"`
-
-	// PrebuildLayerFetch controls whether grog pulls the previous image
-	// for a target into the local Docker daemon before building, so that
-	// Docker's layer cache can reuse unchanged layers. Only effective when
-	// CacheMode is "target". Defaults to true when CacheMode is "target".
-	// Set to false if you handle layer caching yourself (e.g. via
-	// --cache-from in your build command).
-	PrebuildLayerFetch *bool `mapstructure:"prebuild_layer_fetch"`
-}
-
-// IsPrebuildLayerFetchEnabled returns whether layer cache seeding is active.
-// When PrebuildLayerFetch is nil (unset), it defaults to true in target mode.
-func (d OCIConfig) IsPrebuildLayerFetchEnabled() bool {
-	if d.PrebuildLayerFetch != nil {
-		return *d.PrebuildLayerFetch
-	}
-	// Default: enabled in target mode, disabled otherwise.
-	return d.CacheMode == OCICacheModeTarget
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -310,6 +310,16 @@ const (
 	OCIBackendRegistry = "registry"
 )
 
+const (
+	// OCICacheModeContent names cache images by content digest (default).
+	// Each unique image gets its own registry repo.
+	OCICacheModeContent = "content"
+
+	// OCICacheModeTarget names cache images by target label (stable).
+	// One registry repo per target, enabling Docker layer cache reuse across builds.
+	OCICacheModeTarget = "target"
+)
+
 type OCIConfig struct {
 	Backend string `mapstructure:"backend"`
 
@@ -324,4 +334,9 @@ type OCIConfig struct {
 	// docker daemon's insecure-registries config so a user already familiar
 	// with that knob has no new mental model.
 	InsecureRegistries []string `mapstructure:"insecure_registries"`
+
+	// CacheMode controls how registry cache images are named.
+	// "content" (default): one repo per unique image digest.
+	// "target": one repo per target label, enabling Docker layer cache reuse.
+	CacheMode string `mapstructure:"cache_mode"`
 }

--- a/internal/config/git.go
+++ b/internal/config/git.go
@@ -29,3 +29,65 @@ func GetGitBranch() (string, error) {
 	}
 	return strings.TrimSpace(out.String()), nil
 }
+
+// GetGitRoot returns the absolute path of the repository's top-level directory,
+// or an error if the working directory is not inside a git repository.
+func GetGitRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+// ResolveCacheSeedRef returns the git ref to use for Docker layer-cache
+// seed-donor selection, resolving the empty (auto-detect) case.
+//
+// When explicitRef is non-empty it is returned verbatim (callers pass the same
+// ref they use for `grog changes`: origin/<base-branch> on pull requests, HEAD~1
+// on push-to-default). When empty, the merge-base with the upstream default
+// branch is tried first (the natural predecessor for a feature branch), falling
+// back to HEAD~1. The returned boolean is false when no usable ref could be
+// resolved (e.g. a shallow clone with no parent), in which case seeding is
+// skipped entirely.
+func ResolveCacheSeedRef(explicitRef string) (string, bool) {
+	if explicitRef != "" {
+		return explicitRef, true
+	}
+
+	// Prefer the merge-base with the upstream default branch (origin/HEAD).
+	if base := gitMergeBaseWithUpstreamDefault(); base != "" {
+		return base, true
+	}
+
+	// Fall back to the immediate parent of HEAD.
+	if revExists("HEAD~1") {
+		return "HEAD~1", true
+	}
+
+	return "", false
+}
+
+// gitMergeBaseWithUpstreamDefault returns the merge-base commit between HEAD and
+// the remote's default branch (origin/HEAD), or "" if it cannot be determined.
+func gitMergeBaseWithUpstreamDefault() string {
+	// origin/HEAD points at the remote's default branch (e.g. origin/main).
+	if !revExists("origin/HEAD") {
+		return ""
+	}
+	cmd := exec.Command("git", "merge-base", "HEAD", "origin/HEAD")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// revExists reports whether rev resolves to a commit in the current repository.
+func revExists(rev string) bool {
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", rev+"^{commit}")
+	return cmd.Run() == nil
+}

--- a/internal/config/git_test.go
+++ b/internal/config/git_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func initGitRepoForRef(t *testing.T, dir string) func(args ...string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	return run
+}
+
+// chdir switches to dir for the duration of the test.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func TestResolveCacheSeedRef_ExplicitWins(t *testing.T) {
+	// An explicit ref is returned verbatim without consulting git.
+	ref, ok := ResolveCacheSeedRef("origin/release-1.2")
+	if !ok || ref != "origin/release-1.2" {
+		t.Fatalf("explicit ref: got (%q, %v), want (\"origin/release-1.2\", true)", ref, ok)
+	}
+}
+
+func TestResolveCacheSeedRef_AutoDetectFallsBackToHeadParent(t *testing.T) {
+	dir := t.TempDir()
+	git := initGitRepoForRef(t, dir)
+
+	// Two commits, no remote: origin/HEAD is absent, so resolution falls back
+	// to HEAD~1.
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-q", "-m", "one")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-q", "-m", "two")
+
+	chdir(t, dir)
+	ref, ok := ResolveCacheSeedRef("")
+	if !ok || ref != "HEAD~1" {
+		t.Fatalf("auto-detect: got (%q, %v), want (\"HEAD~1\", true)", ref, ok)
+	}
+}
+
+func TestResolveCacheSeedRef_NoParentReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	git := initGitRepoForRef(t, dir)
+
+	// A single commit has no parent and no remote default branch: resolution
+	// cannot find a usable seed ref.
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("only\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-q", "-m", "only")
+
+	chdir(t, dir)
+	if ref, ok := ResolveCacheSeedRef(""); ok {
+		t.Fatalf("single-commit repo should not resolve a seed ref, got (%q, %v)", ref, ok)
+	}
+}
+
+func TestGetGitRoot(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepoForRef(t, dir)
+	chdir(t, dir)
+
+	root, err := GetGitRoot()
+	if err != nil {
+		t.Fatalf("GetGitRoot: %v", err)
+	}
+	// Resolve symlinks because TempDir on macOS is under /var -> /private/var.
+	wantRoot, _ := filepath.EvalSymlinks(dir)
+	gotRoot, _ := filepath.EvalSymlinks(root)
+	if gotRoot != wantRoot {
+		t.Fatalf("GetGitRoot() = %q, want %q", gotRoot, wantRoot)
+	}
+}

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -16,6 +16,7 @@ import (
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
 	"path/filepath"
+	"sync"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -50,6 +51,15 @@ type Executor struct {
 	deferAsyncWait   bool
 	asyncDrained     bool
 	rerunGroup       singleflight.Group
+
+	// cacheSeedRef is the resolved git ref used to locate Docker layer-cache
+	// seed donors, and cacheSeedRefOK reports whether one was resolved. Both
+	// are computed once per Execute run (seedRefOnce) since they shell out to
+	// git. gitRoot is the repository root used to read input files at the ref.
+	seedRefOnce    sync.Once
+	cacheSeedRef   string
+	cacheSeedRefOK bool
+	gitRoot        string
 }
 
 func NewExecutor(
@@ -442,13 +452,61 @@ func (e *Executor) getTaskFunc(
 			target.DepLoadTime = time.Since(depLoadStart)
 		}
 
-		// Seed Docker layer caches before executing the build command.
-		// On a cache miss for a target with docker outputs, this pulls the
-		// previous image into the local daemon so its layers can be reused.
-		e.registry.SeedLayerCaches(ctx, target, update)
+		// Seed Docker layer caches before executing the build command. On a
+		// cache miss for a target with declared oci_push cache repos, this
+		// pulls the prior content-addressed image into the local daemon so its
+		// layers can be reused by `docker build`.
+		e.registry.SeedLayerCaches(ctx, target, e.priorChangeHashForSeed(ctx, target), update)
 
 		return e.executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, update, isTainted)
 	}
+}
+
+// priorChangeHashForSeed returns the change hash the target's inputs would have
+// produced at the configured seed ref, used to locate a Docker layer-cache seed
+// donor. It returns "" when seeding cannot apply: the target declares no
+// oci_push cache repos, no seed ref could be resolved (e.g. shallow clone), or
+// the recomputation fails. Seeding is best-effort, so all such cases simply skip
+// the seed rather than failing the build.
+func (e *Executor) priorChangeHashForSeed(ctx context.Context, target *model.Target) string {
+	if len(target.OciPush) == 0 {
+		return ""
+	}
+
+	seedRef, gitRoot, ok := e.resolveSeedRef(ctx)
+	if !ok {
+		return ""
+	}
+
+	priorHash, err := e.targetHasher.PriorChangeHashAtRef(target, gitRoot, seedRef)
+	if err != nil {
+		console.GetLogger(ctx).Debugf("%s: could not compute prior change hash at %s for seeding: %v",
+			target.Label, seedRef, err)
+		return ""
+	}
+	return priorHash
+}
+
+// resolveSeedRef resolves (once per run) the git ref and repository root used
+// for layer-cache seeding. The boolean is false when no usable ref or git root
+// could be determined, in which case callers skip seeding.
+func (e *Executor) resolveSeedRef(ctx context.Context) (string, string, bool) {
+	e.seedRefOnce.Do(func() {
+		gitRoot, err := config.GetGitRoot()
+		if err != nil {
+			console.GetLogger(ctx).Debugf("layer-cache seeding disabled: not a git repository: %v", err)
+			return
+		}
+		ref, ok := config.ResolveCacheSeedRef(config.Global.CacheSeedRef)
+		if !ok {
+			console.GetLogger(ctx).Debugf("layer-cache seeding disabled: could not resolve a seed ref")
+			return
+		}
+		e.gitRoot = gitRoot
+		e.cacheSeedRef = ref
+		e.cacheSeedRefOK = true
+	})
+	return e.cacheSeedRef, e.gitRoot, e.cacheSeedRefOK
 }
 
 func formatTargetResultForDebug(targetResult *gen.TargetResult) string {

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -442,6 +442,11 @@ func (e *Executor) getTaskFunc(
 			target.DepLoadTime = time.Since(depLoadStart)
 		}
 
+		// Seed Docker layer caches before executing the build command.
+		// On a cache miss for a target with docker outputs, this pulls the
+		// previous image into the local daemon so its layers can be reused.
+		e.registry.SeedLayerCaches(ctx, target, update)
+
 		return e.executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, update, isTainted)
 	}
 }

--- a/internal/hashing/hash_files_git.go
+++ b/internal/hashing/hash_files_git.go
@@ -1,0 +1,80 @@
+package hashing
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// HashFilesAtRef computes the combined hash of fileList as the files existed at
+// the given git ref, mirroring HashFiles byte-for-byte for identical content.
+//
+// Paths are interpreted relative to absolutePackagePath (the same contract as
+// HashFiles). Each file is read from git via `git cat-file` at gitRef rather
+// than from the working tree, so the result reproduces the ChangeHash a prior
+// build would have computed without checking the ref out. Files absent at the
+// ref are skipped, matching HashFiles' treatment of missing working-tree files,
+// so the two functions agree whenever the on-disk and at-ref contents agree.
+//
+// gitRoot is the absolute path of the repository root; it is needed to turn the
+// absolute file paths into repo-relative paths for git's pathspec.
+func HashFilesAtRef(gitRoot, gitRef, absolutePackagePath string, fileList []string) (string, error) {
+	combinedHasher := GetHasher()
+	// Match HashFiles' ordering so the combined hash is order-stable.
+	sorted := append([]string(nil), fileList...)
+	sort.Strings(sorted)
+
+	for _, file := range sorted {
+		absolutePath := filepath.Join(absolutePackagePath, file)
+		repoRelativePath, err := filepath.Rel(gitRoot, absolutePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to relativize %q against git root %q: %w", absolutePath, gitRoot, err)
+		}
+		// git uses forward slashes in pathspecs regardless of platform.
+		repoRelativePath = filepath.ToSlash(repoRelativePath)
+
+		content, exists, err := gitFileContents(gitRoot, gitRef, repoRelativePath)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			// Mirror HashFiles: a file missing at the ref is skipped.
+			continue
+		}
+		if _, err := combinedHasher.Write(content); err != nil {
+			return "", err
+		}
+	}
+
+	return combinedHasher.SumString(), nil
+}
+
+// gitFileContents returns the bytes of repoRelativePath at gitRef. The boolean
+// is false (with a nil error) when the path does not exist at that ref, which
+// callers treat as a skipped file rather than a failure.
+func gitFileContents(gitRoot, gitRef, repoRelativePath string) ([]byte, bool, error) {
+	// `git show <ref>:<path>` streams the blob at that path and revision.
+	cmd := exec.Command("git", "show", fmt.Sprintf("%s:%s", gitRef, repoRelativePath))
+	cmd.Dir = gitRoot
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// git exits non-zero when the path or ref is absent. Distinguish a
+		// genuinely-missing path (skip) from an unexpected git failure.
+		message := stderr.String()
+		if strings.Contains(message, "does not exist") ||
+			strings.Contains(message, "exists on disk, but not in") ||
+			strings.Contains(message, "unknown revision") ||
+			strings.Contains(message, "fatal: invalid object name") ||
+			strings.Contains(message, "fatal: path") {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("git show %s:%s failed: %w: %s", gitRef, repoRelativePath, err, strings.TrimSpace(message))
+	}
+	return stdout.Bytes(), true, nil
+}

--- a/internal/hashing/hash_files_git_test.go
+++ b/internal/hashing/hash_files_git_test.go
@@ -1,0 +1,136 @@
+package hashing
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initGitRepo creates a throwaway git repository rooted at dir and returns a
+// helper to run git commands within it.
+func initGitRepo(t *testing.T, dir string) func(args ...string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	return run
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHashFilesAtRef_MatchesWorkingTreeForSameContent(t *testing.T) {
+	dir := t.TempDir()
+	git := initGitRepo(t, dir)
+
+	pkgDir := filepath.Join(dir, "services", "api")
+	writeFile(t, filepath.Join(pkgDir, "a.txt"), "alpha\n")
+	writeFile(t, filepath.Join(pkgDir, "b.txt"), "bravo\n")
+	git("add", "-A")
+	git("commit", "-q", "-m", "initial")
+
+	inputs := []string{"a.txt", "b.txt"}
+
+	// The working-tree hash and the at-ref (HEAD) hash must agree because the
+	// committed content equals the on-disk content.
+	workingTreeHash, err := HashFiles(pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFiles: %v", err)
+	}
+	atRefHash, err := HashFilesAtRef(dir, "HEAD", pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFilesAtRef: %v", err)
+	}
+	if workingTreeHash != atRefHash {
+		t.Fatalf("at-ref hash should match working-tree hash for identical content:\n  working: %q\n  at-ref:  %q",
+			workingTreeHash, atRefHash)
+	}
+}
+
+func TestHashFilesAtRef_ReflectsPriorContent(t *testing.T) {
+	dir := t.TempDir()
+	git := initGitRepo(t, dir)
+
+	pkgDir := filepath.Join(dir, "pkg")
+	lockfile := filepath.Join(pkgDir, "lock.json")
+
+	writeFile(t, lockfile, "v1\n")
+	git("add", "-A")
+	git("commit", "-q", "-m", "v1")
+
+	inputs := []string{"lock.json"}
+	priorHash, err := HashFilesAtRef(dir, "HEAD", pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFilesAtRef (prior): %v", err)
+	}
+
+	// Change the lockfile and commit again.
+	writeFile(t, lockfile, "v2-with-more-deps\n")
+	git("add", "-A")
+	git("commit", "-q", "-m", "v2")
+
+	currentHash, err := HashFiles(pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFiles (current): %v", err)
+	}
+	priorAtHeadParent, err := HashFilesAtRef(dir, "HEAD~1", pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFilesAtRef (HEAD~1): %v", err)
+	}
+
+	// The prior commit's hash (captured before the change, and recomputed via
+	// HEAD~1) must equal each other and differ from the current content hash.
+	if priorHash != priorAtHeadParent {
+		t.Fatalf("prior hash mismatch:\n  captured: %q\n  HEAD~1:   %q", priorHash, priorAtHeadParent)
+	}
+	if priorHash == currentHash {
+		t.Fatalf("prior and current hashes must differ after a content change, both %q", priorHash)
+	}
+}
+
+func TestHashFilesAtRef_SkipsFilesAbsentAtRef(t *testing.T) {
+	dir := t.TempDir()
+	git := initGitRepo(t, dir)
+
+	pkgDir := filepath.Join(dir, "pkg")
+	writeFile(t, filepath.Join(pkgDir, "present.txt"), "here\n")
+	git("add", "-A")
+	git("commit", "-q", "-m", "only present.txt")
+
+	// "missing.txt" does not exist at HEAD; HashFilesAtRef must skip it exactly
+	// as HashFiles skips a missing working-tree file, so the two agree.
+	inputs := []string{"present.txt", "missing.txt"}
+
+	atRef, err := HashFilesAtRef(dir, "HEAD", pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFilesAtRef: %v", err)
+	}
+	// Only present.txt exists on disk too (missing.txt was never written).
+	working, err := HashFiles(pkgDir, inputs)
+	if err != nil {
+		t.Fatalf("HashFiles: %v", err)
+	}
+	if atRef != working {
+		t.Fatalf("skipping an absent file should match HashFiles:\n  at-ref:  %q\n  working: %q", atRef, working)
+	}
+}

--- a/internal/hashing/hash_target.go
+++ b/internal/hashing/hash_target.go
@@ -27,6 +27,41 @@ func GetTargetChangeHash(target model.Target, dependencyHashes []string, extraAr
 	return fmt.Sprintf("%s_%s", targetDefinitionHash, inputContentHash), err
 }
 
+// GetTargetChangeHashAtRef computes a target's change hash as its input files
+// existed at gitRef, reusing the supplied dependencyHashes for the definition
+// component. It reproduces GetTargetChangeHash exactly when the at-ref input
+// contents and the dependency hashes match those of a build at that ref, so the
+// result identifies the cache image a prior build would have produced.
+//
+// gitRoot is the repository root (for resolving repo-relative paths). The
+// dependency hashes are taken as given rather than recomputed at the ref: a
+// drifted dependency only changes which prior image is identified (a missed
+// seed, degrading to a cold build), never correctness, because this hash is
+// used solely to locate a layer-cache donor and never to restore a result.
+func GetTargetChangeHashAtRef(
+	target model.Target,
+	dependencyHashes []string,
+	extraArgs []string,
+	gitRoot string,
+	gitRef string,
+) (string, error) {
+	targetDefinitionHash, err := hashTargetDefinition(target, dependencyHashes, extraArgs)
+	if err != nil {
+		return "", err
+	}
+	if len(target.Inputs) == 0 {
+		return targetDefinitionHash, nil
+	}
+
+	absolutePackagePath := config.GetPathAbsoluteToWorkspaceRoot(target.Label.Package)
+	inputContentHash, err := HashFilesAtRef(gitRoot, gitRef, absolutePackagePath, target.Inputs)
+	if err != nil {
+		return "", fmt.Errorf("failed hashing input files %s for target %s at ref %s: %w",
+			strings.Join(target.Inputs, ","), target.Label, gitRef, err)
+	}
+	return fmt.Sprintf("%s_%s", targetDefinitionHash, inputContentHash), nil
+}
+
 // hashTargetDefinition computes the configured hash of a single file.
 func hashTargetDefinition(target model.Target, dependencyHashes []string, extraArgs []string) (string, error) {
 	hasher := GetHasher()

--- a/internal/hashing/target_hasher.go
+++ b/internal/hashing/target_hasher.go
@@ -65,3 +65,28 @@ func (t *TargetHasher) SetTargetChangeHash(target *model.Target) error {
 	target.ChangeHash = changeHash
 	return nil
 }
+
+// PriorChangeHashAtRef computes target's change hash as its input files existed
+// at gitRef, for locating a layer-cache seed donor. It reuses each dependency's
+// current OutputHash rather than recomputing the dependency graph at the ref:
+// the result is used solely to find a donor image to warm `docker build`'s
+// layer cache, so a drifted dependency or definition only misses the donor
+// (cold build), never restores an incorrect result.
+//
+// gitRoot is the repository root used to resolve repo-relative input paths.
+func (t *TargetHasher) PriorChangeHashAtRef(target *model.Target, gitRoot, gitRef string) (string, error) {
+	t.targetMutexMap.Lock(target.Label.String())
+	defer t.targetMutexMap.Unlock(target.Label.String())
+
+	dependencies := t.graph.GetDependencies(target)
+	dependencyHashes := make([]string, len(target.Dependencies))
+	for index, dependency := range dependencies {
+		targetDependency, ok := dependency.(*model.Target)
+		if !ok {
+			continue
+		}
+		dependencyHashes[index] = targetDependency.OutputHash
+	}
+
+	return GetTargetChangeHashAtRef(*target, dependencyHashes, t.extraArgs, gitRoot, gitRef)
+}

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -146,8 +146,27 @@ func (d *DockerRegistryOutputHandler) cacheImageName(target model.Target, digest
 		// Target names are validated to [a-zA-Z0-9_\-.]
 		// Package paths use / which we replace with -
 		sanitized := strings.ReplaceAll(target.Label.Package, "/", "-")
-		return fmt.Sprintf("%s/%s-%s-%s:latest",
-			d.config.Registry, workspacePrefix, sanitized, target.Label.Name)
+
+		// Qualify the tag with the build platform (os/arch) so concurrent
+		// multi-arch builds of the same target do not clobber one another.
+		// A single mutable ":latest" tag is shared by every architecture, so
+		// the last push wins: a different arch then seeds its layer cache from a
+		// wrong-arch image (or misses the cache entirely). grog already keys the
+		// target change hash by platform (see internal/hashing/hash_target.go),
+		// so the cache image name must be platform-qualified too. GetPlatform()
+		// returns "os/arch"; the "/" is replaced with "-" to keep the tag
+		// registry-safe.
+		//
+		// NOTE: This remains a best-effort, mutable tag per (target, platform).
+		// Two builds that produce different content for the same target and
+		// platform still race on the tag (last push wins), but that only changes
+		// the layer-cache hit rate, never build correctness. A digest-derived
+		// immutable tag would not fit this design: SeedLayerCache must compute
+		// this name to pull the previous image before the new image (and thus
+		// its digest) exists.
+		platformTag := strings.ReplaceAll(config.Global.GetPlatform(), "/", "-")
+		return fmt.Sprintf("%s/%s-%s-%s:%s",
+			d.config.Registry, workspacePrefix, sanitized, target.Label.Name, platformTag)
 	}
 
 	// Default: content-addressed (one repo per unique image digest)

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -124,58 +124,87 @@ func (d *DockerRegistryOutputHandler) lazyClient() (*client.Client, error) {
 // destination. Auth flows through the ambient docker keychain; either side
 // can be tagged plain-HTTP via oci.insecure_registries.
 func (d *DockerRegistryOutputHandler) PushImage(ctx context.Context, image *gen.OCIImageOutput, destination string, _ *worker.ProgressTracker) (bool, error) {
-	imageID := image.GetImageId()
-	if imageID == "" {
-		return false, fmt.Errorf("cache write did not populate image_id for push to %s", destination)
+	// The cache image reference grog produced in Write() is recorded on the
+	// output proto, so push reads it directly rather than re-deriving the name.
+	// This keeps push correct regardless of the cache-naming scheme (declared
+	// repo vs content-addressed) and survives a cache hit, where the proto is
+	// loaded from cache and no fresh name is computed.
+	src := image.GetRemoteTag()
+	if src == "" {
+		return false, fmt.Errorf("cache write did not record a remote tag for push to %s", destination)
 	}
-	// Push copies from the content-addressed cache image; target-mode naming
-	// does not apply here, so a zero target is sufficient.
-	src := d.cacheImageName(model.Target{}, imageID)
 	return oci_push.Copy(ctx, src, destination, oci_push.Options{
 		SourceInsecure:      matchesInsecureRegistry(src, d.config.InsecureRegistries),
 		DestinationInsecure: matchesInsecureRegistry(destination, d.config.InsecureRegistries),
 	})
 }
 
-func (d *DockerRegistryOutputHandler) cacheImageName(target model.Target, digest string) string {
-	workspaceDir := config.Global.WorkspaceRoot
-	workspacePrefix := config.GetWorkspaceCachePrefix(workspaceDir)
-
-	if d.config.CacheMode == config.OCICacheModeTarget {
-		// Stable name: one repo per target, enabling Docker layer cache reuse.
-		// Target names are validated to [a-zA-Z0-9_\-.]
-		// Package paths use / which we replace with -
-		sanitized := strings.ReplaceAll(target.Label.Package, "/", "-")
-
-		// Qualify the tag with the build platform (os/arch) so concurrent
-		// multi-arch builds of the same target do not clobber one another.
-		// A single mutable ":latest" tag is shared by every architecture, so
-		// the last push wins: a different arch then seeds its layer cache from a
-		// wrong-arch image (or misses the cache entirely). grog already keys the
-		// target change hash by platform (see internal/hashing/hash_target.go),
-		// so the cache image name must be platform-qualified too. GetPlatform()
-		// returns "os/arch"; the "/" is replaced with "-" to keep the tag
-		// registry-safe.
-		//
-		// NOTE: This remains a best-effort, mutable tag per (target, platform).
-		// Two builds that produce different content for the same target and
-		// platform still race on the tag (last push wins), but that only changes
-		// the layer-cache hit rate, never build correctness. A digest-derived
-		// immutable tag would not fit this design: SeedLayerCache must compute
-		// this name to pull the previous image before the new image (and thus
-		// its digest) exists.
+// cacheImageName returns the registry reference grog uses to cache the image
+// produced by outputIdentifier on target.
+//
+// Naming is driven by whether the target declares an oci_push destination for
+// this output (see model.Target.OciPush). The declared destination's repository
+// — not a name synthesised from the target label — is the cache location, so
+// repository names are explicit in the BUILD file and enumerable by Terraform
+// without reverse-engineering any sanitisation. This mirrors the oci_push
+// explicit-destination model (#159).
+//
+//   - Declared (oci_push present for this output): the cache image lives in the
+//     declared repository, tagged by build platform and the target's content
+//     hash: "<repo>:<platform>-<changeHash>". The tag is immutable and
+//     content-addressed — a changed input (e.g. a lockfile) yields a new
+//     ChangeHash and therefore a new tag, so a stale image can never be
+//     restored as the cache. The author's deploy tag (e.g. ":<git-sha>") is
+//     ignored for caching: only the repository is taken from the declaration.
+//   - Not declared: fall back to the content-addressed scheme (one repo per
+//     unique image digest), preserving grog's default behaviour.
+//
+// digest is only consulted in the content-addressed fallback; the declared
+// path needs no digest because the tag is keyed on the pre-build ChangeHash.
+func (d *DockerRegistryOutputHandler) cacheImageName(target model.Target, outputIdentifier, digest string) string {
+	if repo := declaredCacheRepo(target, outputIdentifier); repo != "" {
+		// Content-addressed tag, qualified by platform. grog already keys the
+		// target change hash by platform (internal/hashing/hash_target.go), so
+		// the cache tag is platform-qualified to match and to keep concurrent
+		// multi-arch builds of the same target from colliding.
 		platformTag := strings.ReplaceAll(config.Global.GetPlatform(), "/", "-")
-		return fmt.Sprintf("%s/%s-%s-%s:%s",
-			d.config.Registry, workspacePrefix, sanitized, target.Label.Name, platformTag)
+		return fmt.Sprintf("%s:%s-%s", repo, platformTag, target.ChangeHash)
 	}
 
-	// Default: content-addressed (one repo per unique image digest)
+	// Default: content-addressed (one repo per unique image digest).
+	workspaceDir := config.Global.WorkspaceRoot
+	workspacePrefix := config.GetWorkspaceCachePrefix(workspaceDir)
 	if strings.Contains(digest, ":") {
 		digest = strings.Split(digest, ":")[1]
 	}
+	return fmt.Sprintf("%s/%s-%s", d.config.Registry, workspacePrefix, digest)
+}
 
-	return fmt.Sprintf("%s/%s-%s", d.config.Registry,
-		workspacePrefix, digest)
+// declaredCacheRepo returns the repository portion of the oci_push destination
+// declared for outputIdentifier on target, or "" if none is declared. The
+// destination may carry a deploy tag (e.g. "registry.org/api:${GIT_SHA}"); only
+// the repository is returned — grog tags the cache image with its own
+// content-addressed scheme. When multiple destinations are declared for one
+// output, the first is used as the cache repository.
+func declaredCacheRepo(target model.Target, outputIdentifier string) string {
+	destinations := target.OciPush[outputIdentifier]
+	if len(destinations) == 0 {
+		return ""
+	}
+	return repoWithoutTag(destinations[0])
+}
+
+// repoWithoutTag strips a trailing ":tag" from a registry reference, leaving the
+// repository (registry host + path). A ":" inside the registry host's port
+// (e.g. "localhost:5000/img") is preserved because the split only treats the
+// segment after the final "/" as a candidate tag.
+func repoWithoutTag(reference string) string {
+	slash := strings.LastIndex(reference, "/")
+	lastSegment := reference[slash+1:]
+	if colon := strings.LastIndex(lastSegment, ":"); colon != -1 {
+		return reference[:slash+1] + lastSegment[:colon]
+	}
+	return reference
 }
 
 // Write inspects and tags the Docker image synchronously, deferring the push to the registry.
@@ -198,7 +227,7 @@ func (d *DockerRegistryOutputHandler) Write(
 		return nil, fmt.Errorf("%s: image output %s was not created: %w", target.Label.String(), localImageName, err)
 	}
 
-	remoteCacheImageName := d.cacheImageName(target, inspect.ID)
+	remoteCacheImageName := d.cacheImageName(target, output.Identifier, inspect.ID)
 
 	logger.Debugf("tagging Docker image %s as %s for deferred push", localImageName, remoteCacheImageName)
 
@@ -252,17 +281,26 @@ func makeRegistryAuth(ref string) (string, error) {
 	return base64.URLEncoding.EncodeToString(raw), nil
 }
 
-// SeedLayerCache pulls the previous image for a target into the local Docker daemon
-// so that its layers are available for cache reuse during the next build.
-// This is only active when prebuild_layer_fetch is enabled (which requires
-// cache_mode = "target" for stable image names).
-// It is called on cache misses, before the target's build command executes.
+// SeedLayerCache pulls the prior cache image for each of the target's declared
+// oci_push outputs into the local Docker daemon, so its layers are available
+// for reuse during the build. It is called on cache misses, before the target's
+// build command executes.
+//
+// Seeding only applies to outputs whose cache repository is declared via
+// oci_push (the same declaration that names the cache image). priorChangeHash
+// identifies the content-addressed image the same target produced at an earlier
+// git ref; the pulled image is used solely to warm the layer cache and is never
+// restored as the build result, so a wrong or missing donor only lowers the
+// layer-hit rate. Seeding is best-effort: every failure is logged and swallowed.
 func (d *DockerRegistryOutputHandler) SeedLayerCache(
 	ctx context.Context,
 	target model.Target,
+	priorChangeHash string,
 	tracker *worker.ProgressTracker,
 ) error {
-	if !d.config.IsPrebuildLayerFetchEnabled() {
+	if priorChangeHash == "" {
+		// No prior content could be determined (first build, shallow clone, or
+		// no seed ref). Nothing to pull.
 		return nil
 	}
 
@@ -273,35 +311,57 @@ func (d *DockerRegistryOutputHandler) SeedLayerCache(
 		return err
 	}
 
-	// Build the stable remote image name for this target.
-	// The digest parameter is unused in target mode, but cacheImageName requires it.
-	remoteImageName := d.cacheImageName(target, "")
+	platformTag := strings.ReplaceAll(config.Global.GetPlatform(), "/", "-")
+	for _, outputRef := range target.AllOutputs() {
+		if outputRef.Type != "oci" {
+			continue
+		}
+		repo := declaredCacheRepo(target, outputRef.Identifier)
+		if repo == "" {
+			// Output uses the content-addressed cache; there is no stable prior
+			// image to seed from.
+			continue
+		}
+		priorImageName := fmt.Sprintf("%s:%s-%s", repo, platformTag, priorChangeHash)
+		d.seedFromImage(ctx, logger, cli, target, priorImageName, tracker)
+	}
+	return nil
+}
 
-	logger.Debugf("seeding Docker layer cache for %s from %s", target.Label, remoteImageName)
+// seedFromImage pulls a single prior cache image into the local daemon for layer
+// reuse. All failures are best-effort: a missing prior image (expected when the
+// target is new or unchanged-but-uncached) and any pull/auth error are logged at
+// debug level and otherwise ignored.
+func (d *DockerRegistryOutputHandler) seedFromImage(
+	ctx context.Context,
+	logger *console.Logger,
+	cli *client.Client,
+	target model.Target,
+	priorImageName string,
+	tracker *worker.ProgressTracker,
+) {
+	logger.Debugf("seeding Docker layer cache for %s from %s", target.Label, priorImageName)
 
-	auth, err := makeRegistryAuth(remoteImageName)
+	auth, err := makeRegistryAuth(priorImageName)
 	if err != nil {
 		logger.Debugf("failed to get registry auth for layer cache seed: %v", err)
-		return nil
+		return
 	}
 
-	pull, err := cli.ImagePull(ctx, remoteImageName, image.PullOptions{
-		RegistryAuth: auth,
-	})
+	pull, err := cli.ImagePull(ctx, priorImageName, image.PullOptions{RegistryAuth: auth})
 	if err != nil {
-		// Not finding a previous image is expected on first build.
-		logger.Debugf("no previous image to seed layer cache for %s: %v", target.Label, err)
-		return nil
+		// Not finding a prior image is expected on first build.
+		logger.Debugf("no prior image to seed layer cache for %s: %v", target.Label, err)
+		return
 	}
 	defer pull.Close()
 
 	if err := consumeDockerProgress(pull, tracker, fmt.Sprintf("%s: seeding layer cache", target.Label)); err != nil {
 		logger.Debugf("error seeding layer cache for %s: %v", target.Label, err)
-		return nil
+		return
 	}
 
-	logger.Debugf("successfully seeded Docker layer cache for %s from %s", target.Label, remoteImageName)
-	return nil
+	logger.Debugf("successfully seeded Docker layer cache for %s from %s", target.Label, priorImageName)
 }
 
 // Load pulls the Docker image from the remote registry and writes it into the local Docker daemon.

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -235,14 +235,15 @@ func makeRegistryAuth(ref string) (string, error) {
 
 // SeedLayerCache pulls the previous image for a target into the local Docker daemon
 // so that its layers are available for cache reuse during the next build.
-// This is only active when cache_mode is "target" (stable image names).
+// This is only active when prebuild_layer_fetch is enabled (which requires
+// cache_mode = "target" for stable image names).
 // It is called on cache misses, before the target's build command executes.
 func (d *DockerRegistryOutputHandler) SeedLayerCache(
 	ctx context.Context,
 	target model.Target,
 	tracker *worker.ProgressTracker,
 ) error {
-	if d.config.CacheMode != config.OCICacheModeTarget {
+	if !d.config.IsPrebuildLayerFetchEnabled() {
 		return nil
 	}
 

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -128,18 +128,29 @@ func (d *DockerRegistryOutputHandler) PushImage(ctx context.Context, image *gen.
 	if imageID == "" {
 		return false, fmt.Errorf("cache write did not populate image_id for push to %s", destination)
 	}
-	src := d.cacheImageName(imageID)
+	// Push copies from the content-addressed cache image; target-mode naming
+	// does not apply here, so a zero target is sufficient.
+	src := d.cacheImageName(model.Target{}, imageID)
 	return oci_push.Copy(ctx, src, destination, oci_push.Options{
 		SourceInsecure:      matchesInsecureRegistry(src, d.config.InsecureRegistries),
 		DestinationInsecure: matchesInsecureRegistry(destination, d.config.InsecureRegistries),
 	})
 }
 
-func (d *DockerRegistryOutputHandler) cacheImageName(digest string) string {
+func (d *DockerRegistryOutputHandler) cacheImageName(target model.Target, digest string) string {
 	workspaceDir := config.Global.WorkspaceRoot
 	workspacePrefix := config.GetWorkspaceCachePrefix(workspaceDir)
 
-	// strip the leading sha256: prefix from the digest
+	if d.config.CacheMode == config.OCICacheModeTarget {
+		// Stable name: one repo per target, enabling Docker layer cache reuse.
+		// Target names are validated to [a-zA-Z0-9_\-.]
+		// Package paths use / which we replace with -
+		sanitized := strings.ReplaceAll(target.Label.Package, "/", "-")
+		return fmt.Sprintf("%s/%s-%s-%s:latest",
+			d.config.Registry, workspacePrefix, sanitized, target.Label.Name)
+	}
+
+	// Default: content-addressed (one repo per unique image digest)
 	if strings.Contains(digest, ":") {
 		digest = strings.Split(digest, ":")[1]
 	}
@@ -168,7 +179,7 @@ func (d *DockerRegistryOutputHandler) Write(
 		return nil, fmt.Errorf("%s: image output %s was not created: %w", target.Label.String(), localImageName, err)
 	}
 
-	remoteCacheImageName := d.cacheImageName(inspect.ID)
+	remoteCacheImageName := d.cacheImageName(target, inspect.ID)
 
 	logger.Debugf("tagging Docker image %s as %s for deferred push", localImageName, remoteCacheImageName)
 
@@ -220,6 +231,57 @@ func makeRegistryAuth(ref string) (string, error) {
 		return "", fmt.Errorf("marshaling auth config: %w", err)
 	}
 	return base64.URLEncoding.EncodeToString(raw), nil
+}
+
+// SeedLayerCache pulls the previous image for a target into the local Docker daemon
+// so that its layers are available for cache reuse during the next build.
+// This is only active when cache_mode is "target" (stable image names).
+// It is called on cache misses, before the target's build command executes.
+func (d *DockerRegistryOutputHandler) SeedLayerCache(
+	ctx context.Context,
+	target model.Target,
+	tracker *worker.ProgressTracker,
+) error {
+	if d.config.CacheMode != config.OCICacheModeTarget {
+		return nil
+	}
+
+	logger := console.GetLogger(ctx)
+
+	cli, err := d.lazyClient()
+	if err != nil {
+		return err
+	}
+
+	// Build the stable remote image name for this target.
+	// The digest parameter is unused in target mode, but cacheImageName requires it.
+	remoteImageName := d.cacheImageName(target, "")
+
+	logger.Debugf("seeding Docker layer cache for %s from %s", target.Label, remoteImageName)
+
+	auth, err := makeRegistryAuth(remoteImageName)
+	if err != nil {
+		logger.Debugf("failed to get registry auth for layer cache seed: %v", err)
+		return nil
+	}
+
+	pull, err := cli.ImagePull(ctx, remoteImageName, image.PullOptions{
+		RegistryAuth: auth,
+	})
+	if err != nil {
+		// Not finding a previous image is expected on first build.
+		logger.Debugf("no previous image to seed layer cache for %s: %v", target.Label, err)
+		return nil
+	}
+	defer pull.Close()
+
+	if err := consumeDockerProgress(pull, tracker, fmt.Sprintf("%s: seeding layer cache", target.Label)); err != nil {
+		logger.Debugf("error seeding layer cache for %s: %v", target.Label, err)
+		return nil
+	}
+
+	logger.Debugf("successfully seeded Docker layer cache for %s from %s", target.Label, remoteImageName)
+	return nil
 }
 
 // Load pulls the Docker image from the remote registry and writes it into the local Docker daemon.

--- a/internal/output/handlers/docker_registry_output_handler_test.go
+++ b/internal/output/handlers/docker_registry_output_handler_test.go
@@ -1,0 +1,190 @@
+package handlers
+
+import (
+	"grog/internal/config"
+	"grog/internal/label"
+	"grog/internal/model"
+	"testing"
+)
+
+func TestCacheImageName_ContentMode(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeContent,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+	}
+
+	got := handler.cacheImageName(target, "sha256:abcdef1234567890")
+	// Content mode: should use the digest (without sha256: prefix) in the name.
+	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
+	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-abcdef1234567890"
+	if got != want {
+		t.Fatalf("content mode:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestCacheImageName_TargetMode(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeTarget,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+	}
+
+	got := handler.cacheImageName(target, "sha256:abcdef1234567890")
+	// Target mode: should use the sanitized target label, not the digest.
+	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
+	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:latest"
+	if got != want {
+		t.Fatalf("target mode:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestCacheImageName_TargetMode_StableAcrossDigests(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeTarget,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+	}
+
+	// Two different digests should produce the same cache image name in target mode.
+	name1 := handler.cacheImageName(target, "sha256:aaaa")
+	name2 := handler.cacheImageName(target, "sha256:bbbb")
+	if name1 != name2 {
+		t.Fatalf("target mode should produce stable names across digests:\n  digest1: %q\n  digest2: %q", name1, name2)
+	}
+}
+
+func TestCacheImageName_ContentMode_DifferentDigests(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeContent,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+	}
+
+	// Two different digests should produce different cache image names in content mode.
+	name1 := handler.cacheImageName(target, "sha256:aaaa")
+	name2 := handler.cacheImageName(target, "sha256:bbbb")
+	if name1 == name2 {
+		t.Fatalf("content mode should produce different names for different digests: both got %q", name1)
+	}
+}
+
+func TestCacheImageName_DefaultCacheModeIsContent(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	// Empty CacheMode should behave like content mode (the default).
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: "",
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
+	}
+
+	name1 := handler.cacheImageName(target, "sha256:aaaa")
+	name2 := handler.cacheImageName(target, "sha256:bbbb")
+	if name1 == name2 {
+		t.Fatalf("empty cache_mode should default to content-addressed: both got %q", name1)
+	}
+}
+
+func TestCacheImageName_TargetMode_RootPackage(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeTarget,
+		},
+	}
+
+	// Target at root package (empty package path).
+	target := model.Target{
+		Label: label.TargetLabel{Package: "", Name: "build_image"},
+	}
+
+	got := handler.cacheImageName(target, "")
+	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
+	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "--build_image:latest"
+	if got != want {
+		t.Fatalf("root package:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestSeedLayerCache_NoopInContentMode(t *testing.T) {
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			CacheMode: config.OCICacheModeContent,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
+	}
+
+	// SeedLayerCache should return nil immediately in content mode
+	// without touching the Docker client (which is nil here -- would panic if called).
+	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
+		t.Fatalf("expected nil error in content mode, got %v", err)
+	}
+}
+
+func TestSeedLayerCache_NoopWithEmptyCacheMode(t *testing.T) {
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			CacheMode: "",
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
+	}
+
+	// Empty cache mode defaults to content mode -- should be a no-op.
+	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
+		t.Fatalf("expected nil error with empty cache mode, got %v", err)
+	}
+}

--- a/internal/output/handlers/docker_registry_output_handler_test.go
+++ b/internal/output/handlers/docker_registry_output_handler_test.go
@@ -188,3 +188,77 @@ func TestSeedLayerCache_NoopWithEmptyCacheMode(t *testing.T) {
 		t.Fatalf("expected nil error with empty cache mode, got %v", err)
 	}
 }
+
+func TestSeedLayerCache_NoopWhenPrebuildLayerFetchDisabled(t *testing.T) {
+	disabled := false
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			CacheMode:          config.OCICacheModeTarget,
+			PrebuildLayerFetch: &disabled,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
+	}
+
+	// Target mode with prebuild_layer_fetch explicitly disabled -- should be a no-op.
+	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
+		t.Fatalf("expected nil error with prebuild_layer_fetch=false, got %v", err)
+	}
+}
+
+func TestIsPrebuildLayerFetchEnabled(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := []struct {
+		name      string
+		cacheMode string
+		prefetch  *bool
+		want      bool
+	}{
+		{
+			name:      "target mode, unset defaults to true",
+			cacheMode: config.OCICacheModeTarget,
+			prefetch:  nil,
+			want:      true,
+		},
+		{
+			name:      "target mode, explicitly true",
+			cacheMode: config.OCICacheModeTarget,
+			prefetch:  boolPtr(true),
+			want:      true,
+		},
+		{
+			name:      "target mode, explicitly false",
+			cacheMode: config.OCICacheModeTarget,
+			prefetch:  boolPtr(false),
+			want:      false,
+		},
+		{
+			name:      "content mode, unset defaults to false",
+			cacheMode: config.OCICacheModeContent,
+			prefetch:  nil,
+			want:      false,
+		},
+		{
+			name:      "empty mode, unset defaults to false",
+			cacheMode: "",
+			prefetch:  nil,
+			want:      false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			dockerConfig := config.OCIConfig{
+				CacheMode:          testCase.cacheMode,
+				PrebuildLayerFetch: testCase.prefetch,
+			}
+			got := dockerConfig.IsPrebuildLayerFetchEnabled()
+			if got != testCase.want {
+				t.Fatalf("IsPrebuildLayerFetchEnabled() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}

--- a/internal/output/handlers/docker_registry_output_handler_test.go
+++ b/internal/output/handlers/docker_registry_output_handler_test.go
@@ -7,313 +7,219 @@ import (
 	"testing"
 )
 
-func TestCacheImageName_ContentMode(t *testing.T) {
+// withRegistryConfig sets up a handler with a registry and pins the workspace
+// root and platform so cache names are deterministic across the test run.
+func withRegistryConfig(t *testing.T) *DockerRegistryOutputHandler {
+	t.Helper()
 	origRoot := config.Global.WorkspaceRoot
 	config.Global.WorkspaceRoot = "/home/user/myproject"
 	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
 
-	handler := &DockerRegistryOutputHandler{
+	origOS, origArch := config.Global.OS, config.Global.Arch
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
+
+	return &DockerRegistryOutputHandler{
 		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeContent,
+			Registry: "123456.dkr.ecr.us-west-2.amazonaws.com",
 		},
 	}
+}
+
+func TestCacheImageName_Declared_IsContentAddressedTag(t *testing.T) {
+	handler := withRegistryConfig(t)
 
 	target := model.Target{
-		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+		Label:      label.TargetLabel{Package: "services/api", Name: "build_image"},
+		OciPush:    map[string][]string{"api": {"registry.org/api:${GIT_SHA}"}},
+		Outputs:    []model.Output{{Type: "oci", Identifier: "api"}},
+		ChangeHash: "deadbeef",
 	}
 
-	got := handler.cacheImageName(target, "sha256:abcdef1234567890")
-	// Content mode: should use the digest (without sha256: prefix) in the name.
+	// The declared destination's repository is used verbatim; the deploy tag is
+	// dropped and replaced with grog's platform-qualified content hash.
+	got := handler.cacheImageName(target, "api", "sha256:ignored")
+	want := "registry.org/api:linux-amd64-deadbeef"
+	if got != want {
+		t.Fatalf("declared cache name:\n  got  %q\n  want %q", got, want)
+	}
+}
+
+func TestCacheImageName_Declared_NewChangeHashYieldsNewTag(t *testing.T) {
+	handler := withRegistryConfig(t)
+
+	target := model.Target{
+		Label:   label.TargetLabel{Package: "services/api", Name: "build_image"},
+		OciPush: map[string][]string{"api": {"registry.org/api:latest"}},
+		Outputs: []model.Output{{Type: "oci", Identifier: "api"}},
+	}
+
+	target.ChangeHash = "aaaa"
+	first := handler.cacheImageName(target, "api", "sha256:same")
+	target.ChangeHash = "bbbb"
+	second := handler.cacheImageName(target, "api", "sha256:same")
+
+	// A changed input (new ChangeHash) must produce a different, immutable tag
+	// so a stale image can never be restored as the cache.
+	if first == second {
+		t.Fatalf("expected distinct tags per ChangeHash, both got %q", first)
+	}
+	if want := "registry.org/api:linux-amd64-aaaa"; first != want {
+		t.Fatalf("first:\n  got  %q\n  want %q", first, want)
+	}
+	if want := "registry.org/api:linux-amd64-bbbb"; second != want {
+		t.Fatalf("second:\n  got  %q\n  want %q", second, want)
+	}
+}
+
+func TestCacheImageName_Declared_DistinctPerPlatform(t *testing.T) {
+	handler := withRegistryConfig(t)
+
+	target := model.Target{
+		Label:      label.TargetLabel{Package: "services/api", Name: "build_image"},
+		OciPush:    map[string][]string{"api": {"registry.org/api:v1"}},
+		Outputs:    []model.Output{{Type: "oci", Identifier: "api"}},
+		ChangeHash: "cafe",
+	}
+
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	amd64Name := handler.cacheImageName(target, "api", "")
+	config.Global.OS, config.Global.Arch = "linux", "arm64"
+	arm64Name := handler.cacheImageName(target, "api", "")
+
+	if amd64Name == arm64Name {
+		t.Fatalf("expected distinct names per platform, both got %q", amd64Name)
+	}
+	if want := "registry.org/api:linux-amd64-cafe"; amd64Name != want {
+		t.Fatalf("amd64:\n  got  %q\n  want %q", amd64Name, want)
+	}
+	if want := "registry.org/api:linux-arm64-cafe"; arm64Name != want {
+		t.Fatalf("arm64:\n  got  %q\n  want %q", arm64Name, want)
+	}
+}
+
+func TestCacheImageName_NoDeclaration_FallsBackToContentAddressed(t *testing.T) {
+	handler := withRegistryConfig(t)
+
+	target := model.Target{
+		Label:   label.TargetLabel{Package: "services/api", Name: "build_image"},
+		Outputs: []model.Output{{Type: "oci", Identifier: "api"}},
+		// No OciPush declared for "api".
+		ChangeHash: "deadbeef",
+	}
+
+	got := handler.cacheImageName(target, "api", "sha256:abcdef1234567890")
 	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
 	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-abcdef1234567890"
 	if got != want {
-		t.Fatalf("content mode:\n  got  %q\n  want %q", got, want)
+		t.Fatalf("content-addressed fallback:\n  got  %q\n  want %q", got, want)
 	}
 }
 
-func TestCacheImageName_TargetMode(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	origOS, origArch := config.Global.OS, config.Global.Arch
-	config.Global.OS, config.Global.Arch = "linux", "amd64"
-	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
-
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeTarget,
-		},
-	}
+func TestCacheImageName_NoDeclaration_DifferentDigestsDiffer(t *testing.T) {
+	handler := withRegistryConfig(t)
 
 	target := model.Target{
-		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+		Label:   label.TargetLabel{Package: "services/api", Name: "build_image"},
+		Outputs: []model.Output{{Type: "oci", Identifier: "api"}},
 	}
 
-	got := handler.cacheImageName(target, "sha256:abcdef1234567890")
-	// Target mode: should use the sanitized target label (not the digest), with
-	// the build platform as the tag so multi-arch builds do not collide.
-	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
-	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-amd64"
-	if got != want {
-		t.Fatalf("target mode:\n  got  %q\n  want %q", got, want)
-	}
-}
-
-func TestCacheImageName_TargetMode_StableAcrossDigests(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	origOS, origArch := config.Global.OS, config.Global.Arch
-	config.Global.OS, config.Global.Arch = "linux", "amd64"
-	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
-
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeTarget,
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
-	}
-
-	// Two different digests should produce the same cache image name in target mode.
-	name1 := handler.cacheImageName(target, "sha256:aaaa")
-	name2 := handler.cacheImageName(target, "sha256:bbbb")
-	if name1 != name2 {
-		t.Fatalf("target mode should produce stable names across digests:\n  digest1: %q\n  digest2: %q", name1, name2)
-	}
-}
-
-func TestCacheImageName_TargetMode_DistinctPerPlatform(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	origOS, origArch := config.Global.OS, config.Global.Arch
-	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
-
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeTarget,
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
-	}
-
-	// The same target built for two architectures must produce distinct image
-	// names. Otherwise concurrent multi-arch builds share one mutable tag and
-	// clobber each other's layer cache.
-	config.Global.OS, config.Global.Arch = "linux", "amd64"
-	amd64Name := handler.cacheImageName(target, "")
-	config.Global.OS, config.Global.Arch = "linux", "arm64"
-	arm64Name := handler.cacheImageName(target, "")
-
-	if amd64Name == arm64Name {
-		t.Fatalf("target mode should produce distinct names per platform: both got %q", amd64Name)
-	}
-
-	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
-	wantAMD64 := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-amd64"
-	if amd64Name != wantAMD64 {
-		t.Fatalf("amd64:\n  got  %q\n  want %q", amd64Name, wantAMD64)
-	}
-	wantARM64 := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-arm64"
-	if arm64Name != wantARM64 {
-		t.Fatalf("arm64:\n  got  %q\n  want %q", arm64Name, wantARM64)
-	}
-}
-
-func TestCacheImageName_ContentMode_DifferentDigests(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeContent,
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
-	}
-
-	// Two different digests should produce different cache image names in content mode.
-	name1 := handler.cacheImageName(target, "sha256:aaaa")
-	name2 := handler.cacheImageName(target, "sha256:bbbb")
+	name1 := handler.cacheImageName(target, "api", "sha256:aaaa")
+	name2 := handler.cacheImageName(target, "api", "sha256:bbbb")
 	if name1 == name2 {
-		t.Fatalf("content mode should produce different names for different digests: both got %q", name1)
+		t.Fatalf("content-addressed fallback should differ per digest, both got %q", name1)
 	}
 }
 
-func TestCacheImageName_DefaultCacheModeIsContent(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	// Empty CacheMode should behave like content mode (the default).
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: "",
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
-	}
-
-	name1 := handler.cacheImageName(target, "sha256:aaaa")
-	name2 := handler.cacheImageName(target, "sha256:bbbb")
-	if name1 == name2 {
-		t.Fatalf("empty cache_mode should default to content-addressed: both got %q", name1)
-	}
-}
-
-func TestCacheImageName_TargetMode_RootPackage(t *testing.T) {
-	origRoot := config.Global.WorkspaceRoot
-	config.Global.WorkspaceRoot = "/home/user/myproject"
-	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
-
-	origOS, origArch := config.Global.OS, config.Global.Arch
-	config.Global.OS, config.Global.Arch = "linux", "amd64"
-	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
-
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
-			CacheMode: config.OCICacheModeTarget,
-		},
-	}
-
-	// Target at root package (empty package path).
-	target := model.Target{
-		Label: label.TargetLabel{Package: "", Name: "build_image"},
-	}
-
-	got := handler.cacheImageName(target, "")
-	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
-	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "--build_image:linux-amd64"
-	if got != want {
-		t.Fatalf("root package:\n  got  %q\n  want %q", got, want)
-	}
-}
-
-func TestSeedLayerCache_NoopInContentMode(t *testing.T) {
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			CacheMode: config.OCICacheModeContent,
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
-	}
-
-	// SeedLayerCache should return nil immediately in content mode
-	// without touching the Docker client (which is nil here -- would panic if called).
-	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
-		t.Fatalf("expected nil error in content mode, got %v", err)
-	}
-}
-
-func TestSeedLayerCache_NoopWithEmptyCacheMode(t *testing.T) {
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			CacheMode: "",
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
-	}
-
-	// Empty cache mode defaults to content mode -- should be a no-op.
-	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
-		t.Fatalf("expected nil error with empty cache mode, got %v", err)
-	}
-}
-
-func TestSeedLayerCache_NoopWhenPrebuildLayerFetchDisabled(t *testing.T) {
-	disabled := false
-	handler := &DockerRegistryOutputHandler{
-		config: config.OCIConfig{
-			CacheMode:          config.OCICacheModeTarget,
-			PrebuildLayerFetch: &disabled,
-		},
-	}
-
-	target := model.Target{
-		Label: label.TargetLabel{Package: "pkg", Name: "tgt"},
-	}
-
-	// Target mode with prebuild_layer_fetch explicitly disabled -- should be a no-op.
-	if err := handler.SeedLayerCache(nil, target, nil); err != nil {
-		t.Fatalf("expected nil error with prebuild_layer_fetch=false, got %v", err)
-	}
-}
-
-func TestIsPrebuildLayerFetchEnabled(t *testing.T) {
-	boolPtr := func(v bool) *bool { return &v }
-
+func TestDeclaredCacheRepo(t *testing.T) {
 	tests := []struct {
-		name      string
-		cacheMode string
-		prefetch  *bool
-		want      bool
+		name       string
+		ociPush    map[string][]string
+		identifier string
+		want       string
 	}{
 		{
-			name:      "target mode, unset defaults to true",
-			cacheMode: config.OCICacheModeTarget,
-			prefetch:  nil,
-			want:      true,
+			name:       "destination with deploy tag drops the tag",
+			ociPush:    map[string][]string{"api": {"registry.org/api:${GIT_SHA}"}},
+			identifier: "api",
+			want:       "registry.org/api",
 		},
 		{
-			name:      "target mode, explicitly true",
-			cacheMode: config.OCICacheModeTarget,
-			prefetch:  boolPtr(true),
-			want:      true,
+			name:       "destination without a tag is unchanged",
+			ociPush:    map[string][]string{"api": {"registry.org/team/api"}},
+			identifier: "api",
+			want:       "registry.org/team/api",
 		},
 		{
-			name:      "target mode, explicitly false",
-			cacheMode: config.OCICacheModeTarget,
-			prefetch:  boolPtr(false),
-			want:      false,
+			name:       "host port preserved, only final tag stripped",
+			ociPush:    map[string][]string{"api": {"localhost:5000/api:v2"}},
+			identifier: "api",
+			want:       "localhost:5000/api",
 		},
 		{
-			name:      "content mode, unset defaults to false",
-			cacheMode: config.OCICacheModeContent,
-			prefetch:  nil,
-			want:      false,
+			name:       "first destination wins for multi-destination",
+			ociPush:    map[string][]string{"api": {"registry.org/api:v1", "mirror.org/api:v1"}},
+			identifier: "api",
+			want:       "registry.org/api",
 		},
 		{
-			name:      "empty mode, unset defaults to false",
-			cacheMode: "",
-			prefetch:  nil,
-			want:      false,
+			name:       "no declaration returns empty",
+			ociPush:    map[string][]string{"other": {"registry.org/other:v1"}},
+			identifier: "api",
+			want:       "",
+		},
+		{
+			name:       "nil map returns empty",
+			ociPush:    nil,
+			identifier: "api",
+			want:       "",
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			dockerConfig := config.OCIConfig{
-				CacheMode:          testCase.cacheMode,
-				PrebuildLayerFetch: testCase.prefetch,
-			}
-			got := dockerConfig.IsPrebuildLayerFetchEnabled()
+			target := model.Target{OciPush: testCase.ociPush}
+			got := declaredCacheRepo(target, testCase.identifier)
 			if got != testCase.want {
-				t.Fatalf("IsPrebuildLayerFetchEnabled() = %v, want %v", got, testCase.want)
+				t.Fatalf("declaredCacheRepo() = %q, want %q", got, testCase.want)
 			}
 		})
+	}
+}
+
+func TestRepoWithoutTag(t *testing.T) {
+	tests := []struct {
+		reference string
+		want      string
+	}{
+		{"registry.org/api:tag", "registry.org/api"},
+		{"registry.org/api", "registry.org/api"},
+		{"localhost:5000/api:v2", "localhost:5000/api"},
+		{"localhost:5000/api", "localhost:5000/api"},
+		{"registry.org/team/sub/api:1.2.3", "registry.org/team/sub/api"},
+		{"123456.dkr.ecr.us-west-2.amazonaws.com/repo:linux-amd64", "123456.dkr.ecr.us-west-2.amazonaws.com/repo"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.reference, func(t *testing.T) {
+			if got := repoWithoutTag(testCase.reference); got != testCase.want {
+				t.Fatalf("repoWithoutTag(%q) = %q, want %q", testCase.reference, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestSeedLayerCache_NoopWhenPriorHashEmpty(t *testing.T) {
+	handler := &DockerRegistryOutputHandler{config: config.OCIConfig{}}
+	target := model.Target{
+		Label:   label.TargetLabel{Package: "pkg", Name: "tgt"},
+		OciPush: map[string][]string{"img": {"registry.org/img:v1"}},
+		Outputs: []model.Output{{Type: "oci", Identifier: "img"}},
+	}
+
+	// With an empty prior change hash there is no donor to pull, so SeedLayerCache
+	// must return immediately without touching the Docker client (nil here --
+	// would panic if dereferenced).
+	if err := handler.SeedLayerCache(nil, target, "", nil); err != nil {
+		t.Fatalf("expected nil error when prior hash is empty, got %v", err)
 	}
 }

--- a/internal/output/handlers/docker_registry_output_handler_test.go
+++ b/internal/output/handlers/docker_registry_output_handler_test.go
@@ -37,6 +37,10 @@ func TestCacheImageName_TargetMode(t *testing.T) {
 	config.Global.WorkspaceRoot = "/home/user/myproject"
 	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
 
+	origOS, origArch := config.Global.OS, config.Global.Arch
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
+
 	handler := &DockerRegistryOutputHandler{
 		config: config.OCIConfig{
 			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
@@ -49,9 +53,10 @@ func TestCacheImageName_TargetMode(t *testing.T) {
 	}
 
 	got := handler.cacheImageName(target, "sha256:abcdef1234567890")
-	// Target mode: should use the sanitized target label, not the digest.
+	// Target mode: should use the sanitized target label (not the digest), with
+	// the build platform as the tag so multi-arch builds do not collide.
 	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
-	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:latest"
+	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-amd64"
 	if got != want {
 		t.Fatalf("target mode:\n  got  %q\n  want %q", got, want)
 	}
@@ -61,6 +66,10 @@ func TestCacheImageName_TargetMode_StableAcrossDigests(t *testing.T) {
 	origRoot := config.Global.WorkspaceRoot
 	config.Global.WorkspaceRoot = "/home/user/myproject"
 	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	origOS, origArch := config.Global.OS, config.Global.Arch
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
 
 	handler := &DockerRegistryOutputHandler{
 		config: config.OCIConfig{
@@ -78,6 +87,48 @@ func TestCacheImageName_TargetMode_StableAcrossDigests(t *testing.T) {
 	name2 := handler.cacheImageName(target, "sha256:bbbb")
 	if name1 != name2 {
 		t.Fatalf("target mode should produce stable names across digests:\n  digest1: %q\n  digest2: %q", name1, name2)
+	}
+}
+
+func TestCacheImageName_TargetMode_DistinctPerPlatform(t *testing.T) {
+	origRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = "/home/user/myproject"
+	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
+
+	origOS, origArch := config.Global.OS, config.Global.Arch
+	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
+
+	handler := &DockerRegistryOutputHandler{
+		config: config.OCIConfig{
+			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
+			CacheMode: config.OCICacheModeTarget,
+		},
+	}
+
+	target := model.Target{
+		Label: label.TargetLabel{Package: "services/api", Name: "build_image"},
+	}
+
+	// The same target built for two architectures must produce distinct image
+	// names. Otherwise concurrent multi-arch builds share one mutable tag and
+	// clobber each other's layer cache.
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	amd64Name := handler.cacheImageName(target, "")
+	config.Global.OS, config.Global.Arch = "linux", "arm64"
+	arm64Name := handler.cacheImageName(target, "")
+
+	if amd64Name == arm64Name {
+		t.Fatalf("target mode should produce distinct names per platform: both got %q", amd64Name)
+	}
+
+	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
+	wantAMD64 := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-amd64"
+	if amd64Name != wantAMD64 {
+		t.Fatalf("amd64:\n  got  %q\n  want %q", amd64Name, wantAMD64)
+	}
+	wantARM64 := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "-services-api-build_image:linux-arm64"
+	if arm64Name != wantARM64 {
+		t.Fatalf("arm64:\n  got  %q\n  want %q", arm64Name, wantARM64)
 	}
 }
 
@@ -134,6 +185,10 @@ func TestCacheImageName_TargetMode_RootPackage(t *testing.T) {
 	config.Global.WorkspaceRoot = "/home/user/myproject"
 	t.Cleanup(func() { config.Global.WorkspaceRoot = origRoot })
 
+	origOS, origArch := config.Global.OS, config.Global.Arch
+	config.Global.OS, config.Global.Arch = "linux", "amd64"
+	t.Cleanup(func() { config.Global.OS, config.Global.Arch = origOS, origArch })
+
 	handler := &DockerRegistryOutputHandler{
 		config: config.OCIConfig{
 			Registry:  "123456.dkr.ecr.us-west-2.amazonaws.com",
@@ -148,7 +203,7 @@ func TestCacheImageName_TargetMode_RootPackage(t *testing.T) {
 
 	got := handler.cacheImageName(target, "")
 	prefix := config.GetWorkspaceCachePrefix("/home/user/myproject")
-	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "--build_image:latest"
+	want := "123456.dkr.ecr.us-west-2.amazonaws.com/" + prefix + "--build_image:linux-amd64"
 	if got != want {
 		t.Fatalf("root package:\n  got  %q\n  want %q", got, want)
 	}

--- a/internal/output/handlers/handler.go
+++ b/internal/output/handlers/handler.go
@@ -49,11 +49,17 @@ type ImagePusher interface {
 }
 
 // LayerCacheSeeder is an optional interface that output handlers may implement
-// to seed build-time caches before a target's command executes. This is used by
-// the Docker registry handler to pull a previous image's layers into the local
-// daemon so that subsequent docker build commands can reuse them.
+// to seed build-time caches before a target's command executes. The Docker
+// registry handler implements it to pull a prior image's layers into the local
+// daemon so that the subsequent `docker build` can reuse them.
+//
+// priorChangeHash identifies the content of the same target at an earlier git
+// ref (see hashing.TargetHasher.PriorChangeHashAtRef). The handler pulls the
+// immutable, content-addressed cache image tagged with that hash. An empty
+// priorChangeHash means no prior content could be determined (e.g. first build,
+// shallow clone) and the handler should treat seeding as a no-op.
 type LayerCacheSeeder interface {
-	SeedLayerCache(ctx context.Context, target model.Target, tracker *worker.ProgressTracker) error
+	SeedLayerCache(ctx context.Context, target model.Target, priorChangeHash string, tracker *worker.ProgressTracker) error
 }
 
 type HandlerType string

--- a/internal/output/handlers/handler.go
+++ b/internal/output/handlers/handler.go
@@ -48,6 +48,14 @@ type ImagePusher interface {
 	PushImage(ctx context.Context, image *gen.OCIImageOutput, destination string, tracker *worker.ProgressTracker) (skipped bool, err error)
 }
 
+// LayerCacheSeeder is an optional interface that output handlers may implement
+// to seed build-time caches before a target's command executes. This is used by
+// the Docker registry handler to pull a previous image's layers into the local
+// daemon so that subsequent docker build commands can reuse them.
+type LayerCacheSeeder interface {
+	SeedLayerCache(ctx context.Context, target model.Target, tracker *worker.ProgressTracker) error
+}
+
 type HandlerType string
 
 const (

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -377,6 +377,43 @@ func (r *Registry) LoadOutputs(
 	return nil
 }
 
+// SeedLayerCaches calls SeedLayerCache on any handler that implements
+// LayerCacheSeeder for the target's outputs. This pulls previous images
+// into the local Docker daemon before a build so their layers can be reused.
+func (r *Registry) SeedLayerCaches(
+	ctx context.Context,
+	target *model.Target,
+	update worker.StatusFunc,
+) {
+	logger := console.GetLogger(ctx)
+
+	// Deduplicate handler types — only seed once per handler even if a target
+	// has multiple docker outputs.
+	seeded := make(map[handlers.HandlerType]bool)
+	for _, outputRef := range target.AllOutputs() {
+		handler := r.mustGetHandler(outputRef.Type)
+		if seeded[handler.Type()] {
+			continue
+		}
+		seeder, ok := handler.(handlers.LayerCacheSeeder)
+		if !ok {
+			continue
+		}
+		seeded[handler.Type()] = true
+
+		update(worker.Status(fmt.Sprintf("%s: seeding layer cache", target.Label)))
+		progress := worker.NewProgressTracker(
+			fmt.Sprintf("%s: seeding layer cache", target.Label),
+			0,
+			update,
+		)
+		if err := seeder.SeedLayerCache(ctx, *target, progress); err != nil {
+			// Layer cache seeding is best-effort; log and continue.
+			logger.Debugf("%s: layer cache seed failed (non-fatal): %v", target.Label, err)
+		}
+	}
+}
+
 // ensureBinOutputExecutable marks a target's bin_output 0755 on disk.
 // The CAS doesn't track file mode, and a user's build command may not chmod
 // the binary itself, so the Registry guarantees this post-condition at every

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -380,9 +380,15 @@ func (r *Registry) LoadOutputs(
 // SeedLayerCaches calls SeedLayerCache on any handler that implements
 // LayerCacheSeeder for the target's outputs. This pulls previous images
 // into the local Docker daemon before a build so their layers can be reused.
+// SeedLayerCaches calls SeedLayerCache on any handler that implements
+// LayerCacheSeeder for the target's outputs. This pulls prior images
+// into the local Docker daemon before a build so their layers can be reused.
+// priorChangeHash identifies the same target's content at an earlier git ref
+// and is forwarded to the seeder to locate the immutable cache image to pull.
 func (r *Registry) SeedLayerCaches(
 	ctx context.Context,
 	target *model.Target,
+	priorChangeHash string,
 	update worker.StatusFunc,
 ) {
 	logger := console.GetLogger(ctx)
@@ -407,7 +413,7 @@ func (r *Registry) SeedLayerCaches(
 			0,
 			update,
 		)
-		if err := seeder.SeedLayerCache(ctx, *target, progress); err != nil {
+		if err := seeder.SeedLayerCache(ctx, *target, priorChangeHash, progress); err != nil {
 			// Layer cache seeding is best-effort; log and continue.
 			logger.Debugf("%s: layer cache seed failed (non-fatal): %v", target.Label, err)
 		}


### PR DESCRIPTION
## Summary

Adds Docker registry **layer-cache reuse** driven by the declared `oci_push`
destination from #159: when a target declares an `oci_push` repository for its
`oci::` output, grog caches the image there under an immutable, content-addressed
tag and seeds the prior build's image before a `docker build` so unchanged layers
(`apt-get`, `pip install`, `npm ci`, …) are reused.

This supersedes #154. That PR derived the cache repository by string-munging the
target label and used a mutable tag; this reimplementation, rebased onto
`v0.43.1`, takes the repository from the explicit `oci_push` declaration and tags
by content hash, so there is no magic naming and no mutable cache tag.

## Motivation

grog's Docker caching is all-or-nothing: any input change triggers a full
`docker build` from scratch, with no layer reuse, because each image is named by
content digest (one repo per digest). To reuse layers across builds you need a
**stable** place to find the previous image — but the repository name should be
explicit, and the restored cache must never be stale.

## Design

**Declared repository (no synthesis).** The cache repository is the repository
portion of the output's `oci_push` destination. The author's deploy tag is
ignored for caching; grog applies its own tag. No `oci_push` for an output ⇒ the
existing content-addressed naming is used unchanged. Repository names are thus
explicit in the BUILD file and enumerable ahead of time (e.g. for ECR).

```yaml
- name: api
  command: docker build -t api .
  outputs:
    - oci::api                       # cache
  oci_push:
    api: registry.org/api:${GIT_SHA} # ship; its repo is also the cache repo
```

**Content-addressed identity.** The cache tag is
`<repo>:<platform>-<target.ChangeHash>` — immutable and keyed on the target's
content hash. A changed input yields a new tag, so a stale image can never be
restored as the cache. Restore keys solely on this tag.

**Seeding without a moving tag.** There is no `:latest`/moving pointer (a mutable
pointer can serve a stale layer donor). On a cache miss, grog recomputes the
target's change hash **as its inputs existed at a git ref** (reading file
contents via `git show <ref>:<path>`, no checkout) and pulls
`<repo>:<platform>-<priorHash>` to warm the layer cache. The donor only warms
`docker build`; it is never restored or recorded as the result, so a wrong/missing
donor costs build time, never correctness. Seeding is best-effort.

The ref comes from a new **`--since`** flag (mirrors `grog changes`): pass
`origin/<base>` on PRs, `HEAD~1` on push-to-default. When omitted, grog
auto-detects the merge-base with `origin/HEAD`, then falls back to `HEAD~1`.

The global `cache_mode` / `prebuild_layer_fetch` config from #154 is **removed**;
behaviour is driven per-output by the presence of an `oci_push` declaration.

## Tradeoff for reviewers

The seed-donor identity is recomputed from git because grog's cache is a pure
content-addressed key/value store with no record of a prior hash. Two deliberate,
**fail-safe** approximations: the prior change hash reuses the *current*
dependency hashes and the *current* target definition (only input file contents
are read at the ref). If a dependency or the definition changed between the ref
and HEAD, the seed is simply skipped (cold build) — it can never restore an
incorrect result. Reconstructing the full prior dependency graph is possible but
larger; given the fail-safe property it is left out of v1. **Happy to gate the
git-recompute behind the naming change** (declared repo + content tag) and defer
donor discovery to a follow-up if you'd prefer the smaller surface.

## Changes

- `config`: remove `cache_mode`/`prebuild_layer_fetch`; add `--since`
  (`CacheSeedRef`).
- `config/git`: `GetGitRoot`, `ResolveCacheSeedRef` (merge-base with
  `origin/HEAD`, fallback `HEAD~1`).
- `hashing`: `HashFilesAtRef` (read inputs at a git ref) + `GetTargetChangeHashAtRef`
  + `TargetHasher.PriorChangeHashAtRef`.
- `output/handlers`: declared-repo `cacheImageName` (content tag);
  `declaredCacheRepo`/`repoWithoutTag`; `SeedLayerCache` pulls the prior image;
  `PushImage` uses the recorded `RemoteTag`.
- `output`/`execution`: thread the prior change hash into seeding; resolve the
  seed ref once per run.
- `cmd`: `--since` persistent flag.
- docs + regenerated CLI reference.

## fs backend (#157)

Out of scope, but the design generalises: the fs backend reads the same
`oci_push` declaration; only its seeding differs (local `docker load` of the
prior tar). No moving tags there either.

## Testing

`go test ./...` passes (the pre-existing `internal/completions` failure is
unrelated and reproduces on `v0.43.1`). New tests cover declared-vs-content
naming, `declaredCacheRepo`/`repoWithoutTag`, `HashFilesAtRef` (proves the at-ref
hash equals the working-tree hash for identical content, reflects prior content
via `HEAD~1`, skips absent files), and `ResolveCacheSeedRef`.
