### PR TITLE
feat(tracing): export grog.requested_patterns on the root span

### DIFF
--- a/internal/tracing/export.go
+++ b/internal/tracing/export.go
@@ -201,6 +201,7 @@ func buildOTLPResourceSpans(trace *BuildTrace) otlpResourceSpans {
 			{Key: "grog.cache_hit_count", Value: intVal(int64(trace.Build.CacheHitCount))},
 			{Key: "grog.failure_count", Value: intVal(int64(trace.Build.FailureCount))},
 			{Key: "grog.is_ci", Value: boolVal(trace.Build.IsCI)},
+			{Key: "grog.requested_patterns", Value: stringVal(trace.Build.RequestedPatterns)},
 		},
 		Status: &otlpStatus{Code: 1},
 	}


### PR DESCRIPTION
The requested target patterns are already captured on `BuildRow.RequestedPatterns` but aren't emitted to OTLP. Consumers therefore only get the subcommand (via the `grog <command>` span name) and can't see what was actually built.

This adds them as a `grog.requested_patterns` root-span attribute, so `grog <command> <patterns>` is fully reconstructable from a trace.

One line in `buildOTLPResourceSpans`; `go build`/`go vet` pass. (Local `go test` can't link the duckdb cgo test binary — `-lresolv` under the nix clang wrapper — but the production package compiles.)