### PR TITLE
fix(output): prevent directory restore deadlock on download errors (#169)

### DIFF
--- a/internal/output/handlers/dir_output_handler.go
+++ b/internal/output/handlers/dir_output_handler.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"sync"
 	"sync/atomic"
 
 	"grog/internal/caching"
@@ -503,20 +502,15 @@ func (d *DirectoryOutputHandler) Load(
 
 	// Concurrent CAS reads are bounded process-wide by the BoundedBackend
 	// wrapper inside cas.Load.
-	var waitGroup sync.WaitGroup
-	errChan := make(chan error, len(tree.Children))
+	group, groupCtx := errgroup.WithContext(ctx)
 	// Recursively load the directory structure
-	if err := d.loadDirectoryRecursive(ctx, dirPath, tree.Root, childrenMap, progress, &waitGroup, errChan); err != nil {
+	if err := d.loadDirectoryRecursive(groupCtx, dirPath, tree.Root, childrenMap, progress, group); err != nil {
 		return fmt.Errorf("failed to load directory structure: %w", err)
 	}
 
-	// Wait for all goroutines to finish
-	waitGroup.Wait()
-	close(errChan)
-	for err := range errChan {
-		if err != nil {
-			return err
-		}
+	// Wait for all file downloads to finish
+	if err := group.Wait(); err != nil {
+		return err
 	}
 
 	if progress != nil {
@@ -533,23 +527,22 @@ func (d *DirectoryOutputHandler) loadDirectoryRecursive(
 	dir *gen.Directory,
 	childrenMap map[string]*gen.Directory,
 	progress *worker.ProgressTracker,
-	waitGroup *sync.WaitGroup,
-	errChan chan error,
+	group *errgroup.Group,
 ) error {
 	// Create all files
 	for _, fileNode := range dir.Files {
 		filePath := filepath.Join(path, fileNode.Name)
+		digest := fileNode.Digest.Hash
+		isExecutable := fileNode.IsExecutable
 
-		waitGroup.Add(1)
 		// Fetch file contents from CAS
-		go func(filePath string, digest string) {
-			defer waitGroup.Done()
+		group.Go(func() error {
 			console.GetLogger(ctx).Debugf("loading file for directory output %s from digest %s", filePath, digest)
-			err := d.downloadFile(ctx, digest, filePath, fileNode.IsExecutable, progress)
-			if err != nil {
-				errChan <- fmt.Errorf("failed to download file %s: %v", filePath, err)
+			if err := d.downloadFile(ctx, digest, filePath, isExecutable, progress); err != nil {
+				return fmt.Errorf("failed to download file %s: %w", filePath, err)
 			}
-		}(filePath, fileNode.Digest.Hash)
+			return nil
+		})
 	}
 
 	// Create all subdirectories
@@ -568,7 +561,7 @@ func (d *DirectoryOutputHandler) loadDirectoryRecursive(
 		}
 
 		// Recursively load the subdirectory
-		if err := d.loadDirectoryRecursive(ctx, subDirPath, childDir, childrenMap, progress, waitGroup, errChan); err != nil {
+		if err := d.loadDirectoryRecursive(ctx, subDirPath, childDir, childrenMap, progress, group); err != nil {
 			return err
 		}
 	}

--- a/internal/output/handlers/dir_output_handler_test.go
+++ b/internal/output/handlers/dir_output_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // mockCacheBackend is a simple mock for CacheBackend to simulate failures.
@@ -182,6 +183,85 @@ func TestDirectoryOutputHandler_Write_FailsOnCacheWrite(t *testing.T) {
 	}
 	if err := result.WritePlan.Cleanup(ctx); err != nil {
 		t.Fatalf("cleanup failed: %v", err)
+	}
+}
+
+// treeOnlyBackend serves a single tree digest from an inner backend but fails
+// every other Get, simulating file downloads erroring out during a restore.
+type treeOnlyBackend struct {
+	backends.CacheBackend
+	treeHash string
+}
+
+func (b *treeOnlyBackend) Get(ctx context.Context, path, key string) (io.ReadCloser, error) {
+	if key == b.treeHash {
+		return b.CacheBackend.Get(ctx, path, key)
+	}
+	return nil, errors.New("simulated download failure")
+}
+
+// TestDirectoryOutputHandler_Load_FileDownloadError_NoDeadlock reproduces issue
+// #169: a flat directory (no subdirectories) whose file downloads fail must
+// return an error rather than deadlocking forever in Load.
+func TestDirectoryOutputHandler_Load_FileDownloadError_NoDeadlock(t *testing.T) {
+	ctx := context.Background()
+
+	rootDir := t.TempDir()
+	config.Global = config.WorkspaceConfig{Root: rootDir, WorkspaceRoot: rootDir}
+
+	cacheBackend, err := backends.NewFileSystemCache(ctx)
+	if err != nil {
+		t.Fatalf("failed to create cache backend: %v", err)
+	}
+	cas := caching.NewCas(cacheBackend)
+	handler := handlers.NewDirectoryOutputHandler(cas)
+
+	target := model.Target{Label: label.TL("pkg", "target"), ChangeHash: "hash"}
+	output := model.NewOutput("dir", "out")
+
+	dirPath := filepath.Join(rootDir, "pkg", "out")
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	for i := 0; i < 64; i++ {
+		name := filepath.Join(dirPath, "file"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+		if err := os.WriteFile(name, []byte("content"+string(rune('0'+i%10))), 0644); err != nil {
+			t.Fatalf("failed to write file: %v", err)
+		}
+	}
+
+	dirOutput, err := handler.Write(ctx, target, output, nil)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := dirOutput.WritePlan.Execute(ctx, nil); err != nil {
+		t.Fatalf("WritePlan.Execute failed: %v", err)
+	}
+
+	// Remove the local directory so Load's dedup check misses and it proceeds
+	// to download files from the cache.
+	if err := os.RemoveAll(dirPath); err != nil {
+		t.Fatalf("failed to remove local directory: %v", err)
+	}
+
+	failingCas := caching.NewCas(&treeOnlyBackend{
+		CacheBackend: cacheBackend,
+		treeHash:     dirOutput.Output.GetDirectory().GetTreeDigest().Hash,
+	})
+	failingHandler := handlers.NewDirectoryOutputHandler(failingCas)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- failingHandler.Load(ctx, target, dirOutput.Output, nil)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected Load to fail when file downloads error, got nil")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Load deadlocked: did not return within 30s")
 	}
 }
 


### PR DESCRIPTION
Fixes #169.

## Fix
- `DirectoryOutputHandler.Load` buffered `errChan` by subdirectory count but wrote once per file, so a failed download blocked its goroutine forever and wedged `waitGroup.Wait` — a silent, permanent hang.
- Replaced the manual `WaitGroup` + channel with an `errgroup.Group` (the pattern already used by `uploadFilesToCas`), which collects errors without a channel and cancels in-flight downloads on first failure.

## Test
- Added `TestDirectoryOutputHandler_Load_FileDownloadError_NoDeadlock`: restores a flat 64-file directory through a backend that serves the tree but fails every file read, guarded by a 30s timeout. It hangs the full 30s against the old code and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)