### PR TITLE
fix(clean): render build-in-progress refusal as one cohesive block

### DIFF
--- a/internal/cmd/cmds/clean.go
+++ b/internal/cmd/cmds/clean.go
@@ -1,10 +1,12 @@
 package cmds
 
 import (
+	"fmt"
 	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/locking"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -33,22 +35,25 @@ Because the cache is shared across checkouts, clean refuses to run while another
 				logger.Fatalf("Clean failed: could not check for running builds: %v", err)
 			}
 			if len(activeLocks) > 0 {
-				logger.Errorf(
-					"Refusing to clean: %d grog build(s) using this cache (%s) are still running:",
+				var message strings.Builder
+				fmt.Fprintf(
+					&message,
+					"Refusing to clean: %d grog build(s) using this cache (%s) are still running:\n",
 					len(activeLocks),
 					config.Global.Root,
 				)
 				for _, lock := range activeLocks {
 					if lock.Command != "" {
-						logger.Errorf("  PID %d: %s", lock.ProcessID, lock.Command)
+						fmt.Fprintf(&message, "  PID %d: %s\n", lock.ProcessID, lock.Command)
 					} else {
-						logger.Errorf("  PID %d", lock.ProcessID)
+						fmt.Fprintf(&message, "  PID %d\n", lock.ProcessID)
 					}
 				}
-				logger.Fatalf(
+				message.WriteString(
 					"Cleaning the shared cache now could corrupt those builds. " +
 						"Wait for them to finish, or pass --force to clean anyway.",
 				)
+				logger.Fatal(message.String())
 			}
 		}
 


### PR DESCRIPTION
Follow-up to #166. The active-lock guard there already lists the running builds' PIDs and commands, but renders them through `logger.Errorf`/`Fatalf` per line, so every line carries an `ERROR:`/`FATAL:` prefix and the closing sentence lands on its own `FATAL:` line.

## Change
- Build the refusal as a single message and emit it with one `logger.Fatal`, matching the [format approved in the #166 thread](https://github.com/chrismatix/grog/pull/166#discussion_r-thread):

```
Refusing to clean: 2 grog build(s) using this cache (/home/you/.grog) are still running:
  PID 12345: grog build //services/api:server
  PID 67890: grog build //web:bundle
Cleaning the shared cache now could corrupt those builds. Wait for them to finish, or pass --force to clean anyway.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)