### PR TITLE
feat: add build resources with startup and teardown hooks

### DIFF
--- a/docs/src/content/docs/reference/target-configuration.mdx
+++ b/docs/src/content/docs/reference/target-configuration.mdx
@@ -137,6 +137,8 @@ Other targets that must be built before this one, specified as labels. Labels ca
 - Targets in the same package: `:target_name`
 - Targets in other packages: `//path/to/package:target_name`
 
+Dependencies may also point at [build resources](/topics/build-resources) — long-running helpers like a shared test database that Grog starts before the target runs and tears down after the build.
+
 ### platforms
 
 A list of platform identifiers that restrict where this target can be executed.

--- a/docs/src/content/docs/topics/build-resources.mdx
+++ b/docs/src/content/docs/topics/build-resources.mdx
@@ -36,15 +36,15 @@ Targets depend on resources through the ordinary `dependencies` list. When `inte
 
 ## Fields Reference
 
-| Field          | Type                     | Description                                                                                   |
-| -------------- | ------------------------ | --------------------------------------------------------------------------------------------- |
-| `name`         | `string`                 | Unique identifier for the resource within its package                                         |
-| `up`           | `string`                 | Command that starts the resource. Must return once the resource is running (daemonize it)     |
-| `down`         | `string`                 | Optional command that stops the resource                                                      |
-| `ready`        | `string`                 | Optional probe command, polled until it exits `0` before dependents run                       |
-| `timeout`      | `string`                 | Bounds the start phase (`up` + `ready` polling) and, separately, `down`. Defaults to `5m`     |
-| `exports`      | `Record<string, string>` | Environment variables published to the commands of directly dependent targets                 |
-| `dependencies` | `label[]`                | Targets built before the resource starts (e.g. an image build) — test targets are not allowed |
+| Field          | Type                     | Description                                                                                      |
+| -------------- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `name`         | `string`                 | Unique identifier for the resource within its package                                            |
+| `up`           | `string`                 | Command that starts the resource. Must return once the resource is running (daemonize it)        |
+| `down`         | `string`                 | Optional command that stops the resource                                                         |
+| `ready`        | `string`                 | Optional probe command, polled until it exits `0` before dependents run                          |
+| `timeout`      | `string`                 | Bounds the start phase (`up` + `ready` polling) and, separately, `down`. Defaults to `5m`        |
+| `exports`      | `Record<string, string>` | Environment variables published to the commands of directly dependent targets                    |
+| `dependencies` | `label[]`                | Targets built, and resources started, before this resource starts — test targets are not allowed |
 
 ## Lifecycle
 
@@ -54,6 +54,24 @@ Targets depend on resources through the ordinary `dependencies` list. When `inte
 4. When the build finishes — successfully, with failures, or interrupted — `down` runs for every started resource in reverse start order.
 
 If `up` fails or `ready` times out, every dependent target that needed the resource fails; `down` still runs at the end of the build so partial starts are cleaned up.
+
+## Composing resources
+
+A resource may depend on another resource. Grog starts dependencies first and tears them down last, and the dependency's exports are available to the dependent resource's `up`, `ready`, and `down` commands:
+
+```yaml
+resources:
+  - name: database
+    up: ...
+    exports:
+      DB_DSN: postgres://127.0.0.1:5432/app
+
+  - name: migrations
+    dependencies: [":database"]
+    up: migrate --database "$DB_DSN" up
+```
+
+Exports only flow one level: a target depending on `:migrations` sees the exports of `:migrations`, not those of `:database`. Declare both dependencies if the target needs both.
 
 ## Dynamic exports
 

--- a/docs/src/content/docs/topics/build-resources.mdx
+++ b/docs/src/content/docs/topics/build-resources.mdx
@@ -1,0 +1,85 @@
+---
+title: Build Resources
+description: Share long-running build helpers like test databases between targets with managed startup and teardown hooks.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Many builds and tests need a helper process that is not itself a build artifact — a Postgres test container, a local registry, an emulator. Declaring one as a **resource** lets Grog manage its lifecycle:
+
+- It is started **at most once per invocation**, no matter how many targets depend on it.
+- It starts **lazily**: a fully cached build never starts the resource at all.
+- It is **torn down automatically** when the build finishes, even when the build fails or is interrupted.
+- It is **never cached** and does not affect the change hash of its dependents: restarting a resource does not invalidate any target.
+
+## Declaring a resource
+
+```yaml
+resources:
+  - name: postgres
+    up: |
+      docker run -d --rm --name "grog-pg-$GROG_RESOURCE_ID" -p 0:5432 postgres:16
+      PORT=$(docker port "grog-pg-$GROG_RESOURCE_ID" 5432 | head -1 | cut -d: -f2)
+      echo "PGPORT=$PORT" >> "$GROG_RESOURCE_EXPORTS_FILE"
+    ready: pg_isready -h 127.0.0.1 -p "$PGPORT"
+    down: docker rm -f "grog-pg-$GROG_RESOURCE_ID"
+    exports:
+      PGHOST: 127.0.0.1
+
+targets:
+  - name: integration_test
+    dependencies: [":postgres"]
+    command: go test ./...
+```
+
+Targets depend on resources through the ordinary `dependencies` list. When `integration_test` needs to run, Grog starts the resource, waits until it is ready, and injects the exported variables (`PGHOST`, `PGPORT`) into the target's environment.
+
+## Fields Reference
+
+| Field          | Type                     | Description                                                                                   |
+| -------------- | ------------------------ | --------------------------------------------------------------------------------------------- |
+| `name`         | `string`                 | Unique identifier for the resource within its package                                         |
+| `up`           | `string`                 | Command that starts the resource. Must return once the resource is running (daemonize it)     |
+| `down`         | `string`                 | Optional command that stops the resource                                                      |
+| `ready`        | `string`                 | Optional probe command, polled until it exits `0` before dependents run                       |
+| `timeout`      | `string`                 | Bounds the start phase (`up` + `ready` polling) and, separately, `down`. Defaults to `5m`     |
+| `exports`      | `Record<string, string>` | Environment variables published to the commands of directly dependent targets                 |
+| `dependencies` | `label[]`                | Targets built before the resource starts (e.g. an image build) — test targets are not allowed |
+
+## Lifecycle
+
+1. The first **executing** (i.e. not cached) target that depends on the resource triggers `up`. Concurrent targets wait for the same start.
+2. If `ready` is set, it is polled every 250ms until it succeeds or `timeout` is exceeded.
+3. Dependent target commands run with the resource's exports in their environment.
+4. When the build finishes — successfully, with failures, or interrupted — `down` runs for every started resource in reverse start order.
+
+If `up` fails or `ready` times out, every dependent target that needed the resource fails; `down` still runs at the end of the build so partial starts are cleaned up.
+
+## Dynamic exports
+
+Static `exports` cover fixed values. For values only known after startup — such as a dynamically allocated host port — the `up` command can append `KEY=VALUE` lines to the file at `$GROG_RESOURCE_EXPORTS_FILE`. Dynamic exports override static ones with the same key and are also visible to the `ready` and `down` commands.
+
+## Environment variables
+
+Grog injects the following variables into `up`, `ready`, and `down`:
+
+| Variable Name                             | Description                                                                                                                                                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GROG_RESOURCE`                           | The full label of the resource, e.g. `//services/db:postgres`                                                                                                                                  |
+| `GROG_RESOURCE_ID`                        | A short identifier derived from the resource's label and definition — stable across runs, changes when the definition changes. Use it to name containers so lifecycle commands stay idempotent |
+| `GROG_RESOURCE_EXPORTS_FILE`              | (`up` only) File to append dynamic `KEY=VALUE` exports to                                                                                                                                      |
+| `GROG_PACKAGE`                            | The path to the package directory                                                                                                                                                              |
+| `GROG_WORKSPACE_ROOT`                     | The workspace root directory                                                                                                                                                                   |
+| `GROG_OS` / `GROG_ARCH` / `GROG_PLATFORM` | Grog's target operating system, architecture, and platform                                                                                                                                     |
+
+## Caching semantics
+
+A resource is an ambient runtime dependency, not a build input:
+
+- Resources contribute **nothing** to the change hash of their dependents. Two runs with identical inputs are cache hits even if the resource restarted in between.
+- If a resource's identity **should** invalidate a consumer — say the Postgres major version — declare it in the consumer's [`fingerprint`](/reference/target-configuration/#fingerprint): `fingerprint: { postgres: "16" }`.
+
+<Aside type="note">
+  For serializing access to an external resource Grog cannot manage (a single Docker daemon, a GPU),
+  see [concurrency groups](/reference/target-configuration/#concurrency_group) instead.
+</Aside>

--- a/integration/fixtures/build_starts_resource_once.txt
+++ b/integration/fixtures/build_starts_resource_once.txt
@@ -1,0 +1,7 @@
+INFO: 1 package loaded, 2 targets configured.
+INFO: Selected 2 targets.
+INFO: Resource //:db started.
+INFO: //:consumer_one DONE
+INFO: //:consumer_two DONE
+INFO: Resource //:db stopped.
+INFO: Build completed successfully. 2 targets completed (0 cache hits).

--- a/integration/fixtures/cached_build_skips_resource.txt
+++ b/integration/fixtures/cached_build_skips_resource.txt
@@ -1,0 +1,5 @@
+INFO: 1 package loaded, 2 targets configured.
+INFO: Selected 2 targets.
+INFO: //:consumer_one DONE (cached)
+INFO: //:consumer_two DONE (cached)
+INFO: Build completed successfully. 2 targets completed (2 cache hits).

--- a/integration/test_repos/resources/.gitignore
+++ b/integration/test_repos/resources/.gitignore
@@ -1,0 +1,2 @@
+*.out
+*.marker

--- a/integration/test_repos/resources/BUILD.yaml
+++ b/integration/test_repos/resources/BUILD.yaml
@@ -1,0 +1,26 @@
+resources:
+  - name: db
+    up: |
+      echo "RESOURCE_TOKEN=token-from-up" >> "$GROG_RESOURCE_EXPORTS_FILE"
+      touch db_running.marker
+    ready: test -f db_running.marker
+    down: rm -f db_running.marker
+    exports:
+      STATIC_GREETING: hello-resource
+
+targets:
+  - name: consumer_one
+    dependencies: [":db"]
+    command: echo "$STATIC_GREETING $RESOURCE_TOKEN" > one.out
+    outputs: [one.out]
+    output_checks:
+      - command: cat one.out
+        expected_output: hello-resource token-from-up
+
+  - name: consumer_two
+    dependencies: [":db"]
+    command: echo "$RESOURCE_TOKEN" > two.out
+    outputs: [two.out]
+    output_checks:
+      - command: cat two.out
+        expected_output: token-from-up

--- a/integration/test_scenarios/resources.yaml
+++ b/integration/test_scenarios/resources.yaml
@@ -1,0 +1,13 @@
+name: build resources
+repo: resources
+cases:
+  # Both consumers share the resource: it starts once, exports flow into the
+  # target commands, and it is torn down at the end of the run.
+  - name: build_starts_resource_once
+    grog_args:
+      - build
+
+  # A fully cached build never starts the resource.
+  - name: cached_build_skips_resource
+    grog_args:
+      - build

--- a/internal/analysis/target_constraints.go
+++ b/internal/analysis/target_constraints.go
@@ -55,7 +55,38 @@ func CheckTargetConstraints(logger *console.Logger, nodeMap model.BuildNodeMap) 
 	dependencyConstraintErrors := checkDependencyConstraints(nodeMap)
 	errs = append(errs, dependencyConstraintErrors...)
 
-	return
+	resourceConstraintErrors := checkResourceConstraints(nodeMap)
+	errs = append(errs, resourceConstraintErrors...)
+
+	return errs
+}
+
+// checkResourceConstraints validates resource nodes: a resource may depend on
+// regular targets (e.g. an image build) or other resources, but never on test
+// targets.
+func checkResourceConstraints(nodeMap model.BuildNodeMap) (errs []error) {
+	for _, node := range nodeMap.NodesAlphabetically() {
+		resource, isResource := node.(*model.Resource)
+		if !isResource {
+			continue
+		}
+
+		for _, dependencyLabel := range resource.Dependencies {
+			dependencyTarget := resolveDependencyTarget(nodeMap, dependencyLabel)
+			if dependencyTarget == nil {
+				continue
+			}
+
+			if dependencyTarget.IsTest() {
+				errs = append(errs, fmt.Errorf("%s depends on %s which is a test target",
+					resource.Label,
+					dependencyTarget.Label,
+				))
+			}
+		}
+	}
+
+	return errs
 }
 
 func checkDependencyConstraints(nodeMap model.BuildNodeMap) (errs []error) {

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -381,7 +381,7 @@ func (e *Executor) getTaskFunc(
 			logger.Debugf("%s: loaded target result %s", target.Label, formatTargetResultForDebug(targetResult))
 		}
 
-		outputCheckErr := runOutputChecks(ctx, target, binToolPaths, outputIdentifiers)
+		outputCheckErr := runOutputChecks(ctx, target, binToolPaths, outputIdentifiers, nil)
 		if outputCheckErr != nil {
 			logger.Debugf("running target due to output check error: %v", outputCheckErr)
 		}
@@ -513,8 +513,8 @@ func (e *Executor) executeTarget(
 
 	startTime := time.Now()
 	var err error
+	var resourceEnvironment []string
 	if target.Command != "" {
-		var resourceEnvironment []string
 		resourceEnvironment, err = e.resourceManager.EnsureResourcesStarted(ctx, e.graph, target, update)
 		if err == nil {
 			update(worker.Status(fmt.Sprintf("%s: running \"%s\"", target.Label, target.CommandEllipsis())))
@@ -539,7 +539,7 @@ func (e *Executor) executeTarget(
 	}
 
 	// Run output checks again to see if they match now
-	if outputCheckErr := runOutputChecks(ctx, target, binToolPaths, outputIdentifiers); outputCheckErr != nil {
+	if outputCheckErr := runOutputChecks(ctx, target, binToolPaths, outputIdentifiers, resourceEnvironment); outputCheckErr != nil {
 		return dag.CacheMiss, outputCheckErr
 	}
 

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -50,6 +50,7 @@ type Executor struct {
 	deferAsyncWait   bool
 	asyncDrained     bool
 	rerunGroup       singleflight.Group
+	resourceManager  *ResourceManager
 }
 
 func NewExecutor(
@@ -72,6 +73,7 @@ func NewExecutor(
 		loadOutputsMode:  loadOutputsMode,
 		targetHasher:     hashing.NewTargetHasher(graph),
 		streamLogsToggle: console.NewStreamLogsToggle(streamLogs),
+		resourceManager:  NewResourceManager(),
 	}
 }
 
@@ -135,7 +137,9 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	walkCallback := func(ctx context.Context, node model.BuildNode) (dag.CacheResult, error) {
 		target, ok := node.(*model.Target)
 		if !ok {
-			// this is where we would add the execution of other node types
+			// Aliases complete trivially; resources start lazily when the
+			// first dependent target executes (see ResourceManager), so fully
+			// cached builds never pay for a resource start.
 			return dag.CacheHit, nil
 		}
 
@@ -169,6 +173,10 @@ func (e *Executor) Execute(ctx context.Context) (dag.CompletionMap, error) {
 	// Emit any buffered per-target result lines (deterministic mode only;
 	// otherwise they were streamed as targets completed).
 	resultLogger.Flush(stdLogger)
+
+	// Tear down started resources even when the build was interrupted, hence
+	// the non-cancellable context.
+	e.resourceManager.TeardownAll(context.WithoutCancel(ctx))
 
 	// Drain the I/O pool before returning, but only if the build was not
 	// interrupted and the caller hasn't opted to wait itself. Async cache
@@ -506,9 +514,13 @@ func (e *Executor) executeTarget(
 	startTime := time.Now()
 	var err error
 	if target.Command != "" {
-		update(worker.Status(fmt.Sprintf("%s: running \"%s\"", target.Label, target.CommandEllipsis())))
-		logger.Debugf("running target %s: %s", target.Label, target.CommandEllipsis())
-		err = executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, e.streamLogsToggle.Enabled())
+		var resourceEnvironment []string
+		resourceEnvironment, err = e.resourceManager.EnsureResourcesStarted(ctx, e.graph, target, update)
+		if err == nil {
+			update(worker.Status(fmt.Sprintf("%s: running \"%s\"", target.Label, target.CommandEllipsis())))
+			logger.Debugf("running target %s: %s", target.Label, target.CommandEllipsis())
+			err = executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, resourceEnvironment, e.streamLogsToggle.Enabled())
+		}
 	} else {
 		logger.Debugf("skipped target %s due to no command", target.Label)
 	}

--- a/internal/execution/execute_target.go
+++ b/internal/execution/execute_target.go
@@ -71,6 +71,7 @@ func executeTarget(
 	outputIdentifiers OutputIdentifierMap,
 	transitiveOutputs []string,
 	taggedOutputs TransitiveTaggedOutputs,
+	resourceEnvironment []string,
 	streamLogs bool,
 ) error {
 	if target.Timeout > 0 {
@@ -79,7 +80,7 @@ func executeTarget(
 		defer cancel()
 	}
 
-	cmdOut, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, target.Command, streamLogs)
+	cmdOut, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, resourceEnvironment, target.Command, streamLogs)
 
 	if err != nil {
 		if ctx.Err() != nil {
@@ -111,6 +112,7 @@ func runTargetCommand(
 	outputIdentifiers OutputIdentifierMap,
 	transitiveOutputs []string,
 	taggedOutputs TransitiveTaggedOutputs,
+	resourceEnvironment []string,
 	command string,
 	streamLogs bool,
 ) ([]byte, error) {
@@ -137,7 +139,7 @@ func runTargetCommand(
 	cmd.WaitDelay = 1 * time.Second // cancellation grace time
 
 	// Attach env variables to the existing environment
-	cmd.Env = GetExtendedTargetEnv(ctx, target)
+	cmd.Env = append(GetExtendedTargetEnv(ctx, target), resourceEnvironment...)
 	cmd.Dir = executionPath
 
 	targetLogs := logs.NewTargetLogFile(*target)

--- a/internal/execution/execute_target_test.go
+++ b/internal/execution/execute_target_test.go
@@ -233,7 +233,7 @@ func TestRunTargetCommandForwardsExtraArgs(t *testing.T) {
 	ctx = WithExtraArgs(ctx, []string{"-k", "test_foo", "-x"})
 
 	// The command uses $@ which should expand to the extra args
-	output, err := runTargetCommand(ctx, target, nil, nil, nil, nil, `echo "ARGS:$@"`, false)
+	output, err := runTargetCommand(ctx, target, nil, nil, nil, nil, nil, `echo "ARGS:$@"`, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\noutput: %s", err, string(output))
 	}
@@ -270,7 +270,7 @@ func TestRunTargetCommandHandlesLargeScript(t *testing.T) {
 	// this overflows execve; as a script file it runs fine.
 	command := "# " + strings.Repeat("x", 256*1024) + "\necho OK"
 
-	output, err := runTargetCommand(context.Background(), target, nil, nil, nil, nil, command, false)
+	output, err := runTargetCommand(context.Background(), target, nil, nil, nil, nil, nil, command, false)
 	if err != nil {
 		t.Fatalf("expected large script to execute, got %v\noutput: %s", err, string(output))
 	}
@@ -301,7 +301,7 @@ func TestRunTargetCommandWithoutExtraArgs(t *testing.T) {
 
 	ctx := context.Background()
 
-	output, err := runTargetCommand(ctx, target, nil, nil, nil, nil, `echo "ARGS:$@"`, false)
+	output, err := runTargetCommand(ctx, target, nil, nil, nil, nil, nil, `echo "ARGS:$@"`, false)
 	if err != nil {
 		t.Fatalf("expected no error, got %v\noutput: %s", err, string(output))
 	}

--- a/internal/execution/output_checks.go
+++ b/internal/execution/output_checks.go
@@ -7,9 +7,15 @@ import (
 	"strings"
 )
 
-func runOutputChecks(ctx context.Context, target *model.Target, binToolPaths BinToolMap, outputIdentifiers OutputIdentifierMap) error {
+func runOutputChecks(
+	ctx context.Context,
+	target *model.Target,
+	binToolPaths BinToolMap,
+	outputIdentifiers OutputIdentifierMap,
+	resourceEnvironment []string,
+) error {
 	for _, check := range target.OutputChecks {
-		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, nil, nil, nil, check.Command, false)
+		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, nil, nil, resourceEnvironment, check.Command, false)
 		if err != nil {
 			return fmt.Errorf("output check failed for target %s: %w\ncommand %s",
 				target.Label, err, check.Command)

--- a/internal/execution/output_checks.go
+++ b/internal/execution/output_checks.go
@@ -9,7 +9,7 @@ import (
 
 func runOutputChecks(ctx context.Context, target *model.Target, binToolPaths BinToolMap, outputIdentifiers OutputIdentifierMap) error {
 	for _, check := range target.OutputChecks {
-		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, nil, nil, check.Command, false)
+		output, err := runTargetCommand(ctx, target, binToolPaths, outputIdentifiers, nil, nil, nil, check.Command, false)
 		if err != nil {
 			return fmt.Errorf("output check failed for target %s: %w\ncommand %s",
 				target.Label, err, check.Command)

--- a/internal/execution/output_checks_test.go
+++ b/internal/execution/output_checks_test.go
@@ -1,0 +1,24 @@
+package execution
+
+import (
+	"context"
+	"testing"
+
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestRunOutputChecksReceivesResourceEnvironment(t *testing.T) {
+	setupResourceTestWorkspace(t)
+	target := &model.Target{
+		Label: label.TargetLabel{Package: "pkg", Name: "consumer"},
+		OutputChecks: []model.OutputCheck{
+			{Command: `test "$RESOURCE_TOKEN" = resource-value`},
+		},
+	}
+
+	err := runOutputChecks(context.Background(), target, nil, nil, []string{"RESOURCE_TOKEN=resource-value"})
+	if err != nil {
+		t.Fatalf("output check did not receive resource environment: %v", err)
+	}
+}

--- a/internal/execution/resource_manager.go
+++ b/internal/execution/resource_manager.go
@@ -3,11 +3,13 @@ package execution
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
 	"os"
 	"os/exec"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -31,7 +33,10 @@ import (
 type ResourceManager struct {
 	startGroup singleflight.Group
 
-	mutex sync.Mutex
+	mutex          sync.Mutex
+	startCondition *sync.Cond
+	activeStarts   int
+	tearingDown    bool
 	// started holds resources in start order; a resource is registered before
 	// its up command runs so that partial starts are still torn down.
 	started []*model.Resource
@@ -50,11 +55,13 @@ type ResourceManager struct {
 }
 
 func NewResourceManager() *ResourceManager {
-	return &ResourceManager{
+	manager := &ResourceManager{
 		exports:           make(map[string][]string),
 		dependencyExports: make(map[string][]string),
 		startResults:      make(map[string]error),
 	}
+	manager.startCondition = sync.NewCond(&manager.mutex)
+	return manager
 }
 
 // EnsureResourcesStarted starts every resource the target directly depends on
@@ -68,8 +75,8 @@ func (m *ResourceManager) EnsureResourcesStarted(
 ) ([]string, error) {
 	var combinedExports []string
 	for _, dependency := range graph.GetDependencies(target) {
-		resource, ok := dependency.(*model.Resource)
-		if !ok {
+		resource := resolveResourceDependency(graph, dependency)
+		if resource == nil {
 			continue
 		}
 
@@ -105,15 +112,37 @@ func (m *ResourceManager) ensureStarted(
 			return nil, startErr
 		}
 
-		startErr := m.startWithDependencies(ctx, graph, resource)
+		if beginErr := m.beginStart(); beginErr != nil {
+			m.mutex.Lock()
+			m.startResults[resourceLabel] = beginErr
+			m.mutex.Unlock()
+			return nil, beginErr
+		}
 
-		m.mutex.Lock()
-		m.startResults[resourceLabel] = startErr
-		m.mutex.Unlock()
+		startErr := m.startWithDependencies(ctx, graph, resource)
+		m.finishStart(resourceLabel, startErr)
 
 		return nil, startErr
 	})
 	return err
+}
+
+func (m *ResourceManager) beginStart() error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.tearingDown {
+		return context.Canceled
+	}
+	m.activeStarts++
+	return nil
+}
+
+func (m *ResourceManager) finishStart(resourceLabel string, startErr error) {
+	m.mutex.Lock()
+	m.startResults[resourceLabel] = startErr
+	m.activeStarts--
+	m.startCondition.Broadcast()
+	m.mutex.Unlock()
 }
 
 func (m *ResourceManager) startResult(resourceLabel string) (error, bool) {
@@ -133,8 +162,8 @@ func (m *ResourceManager) startWithDependencies(
 ) error {
 	var dependencyExports []string
 	for _, dependency := range graph.GetDependencies(resource) {
-		dependencyResource, isResource := dependency.(*model.Resource)
-		if !isResource {
+		dependencyResource := resolveResourceDependency(graph, dependency)
+		if dependencyResource == nil {
 			continue
 		}
 
@@ -155,9 +184,35 @@ func (m *ResourceManager) startWithDependencies(
 	return m.start(ctx, resource, dependencyExports)
 }
 
+func resolveResourceDependency(graph *dag.DirectedTargetGraph, dependency model.BuildNode) *model.Resource {
+	visitedLabels := make(map[string]struct{})
+	for dependency != nil {
+		dependencyLabel := dependency.GetLabel().String()
+		if _, visited := visitedLabels[dependencyLabel]; visited {
+			return nil
+		}
+		visitedLabels[dependencyLabel] = struct{}{}
+
+		switch typedDependency := dependency.(type) {
+		case *model.Resource:
+			return typedDependency
+		case *model.Alias:
+			dependency = graph.GetNodes()[typedDependency.Actual]
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
 func (m *ResourceManager) start(ctx context.Context, resource *model.Resource, dependencyExports []string) error {
 	logger := console.GetLogger(ctx)
 	startTime := time.Now()
+	resourceLabel := resource.Label.String()
+
+	m.mutex.Lock()
+	m.exports[resourceLabel] = exportsEnvironment(resource.Exports)
+	m.mutex.Unlock()
 
 	startContext, cancel := context.WithTimeout(ctx, resource.GetTimeout())
 	defer cancel()
@@ -173,22 +228,22 @@ func (m *ResourceManager) start(ctx context.Context, resource *model.Resource, d
 	baseEnvironment := append(m.resourceEnv(resource), dependencyExports...)
 	upEnvironment := append(append([]string{}, baseEnvironment...), "GROG_RESOURCE_EXPORTS_FILE="+exportsFilePath)
 
-	output, err := m.runHookCommand(startContext, resource, resource.Up, upEnvironment)
-	if err != nil {
-		return fmt.Errorf("up command failed: %w\noutput: %s", err, string(output))
-	}
-
-	resolvedExports, err := m.resolveExports(resource, exportsFilePath)
-	if err != nil {
-		return err
-	}
-
-	// Publish exports before probing readiness: a resource whose up succeeded
-	// but whose ready probe timed out still has to be torn down, and its down
-	// command may need the dynamically exported container id or port.
+	output, upErr := m.runHookCommand(startContext, resource, resource.Up, upEnvironment)
+	resolvedExports, exportsErr := m.resolveExports(resource, exportsFilePath)
 	m.mutex.Lock()
-	m.exports[resource.Label.String()] = resolvedExports
+	m.exports[resourceLabel] = resolvedExports
 	m.mutex.Unlock()
+
+	if upErr != nil {
+		upCommandErr := fmt.Errorf("up command failed: %w\noutput: %s", upErr, string(output))
+		if exportsErr != nil {
+			return errors.Join(upCommandErr, exportsErr)
+		}
+		return upCommandErr
+	}
+	if exportsErr != nil {
+		return exportsErr
+	}
 
 	if resource.Ready != "" {
 		readyEnvironment := append(append([]string{}, baseEnvironment...), resolvedExports...)
@@ -229,13 +284,16 @@ func (m *ResourceManager) pollReady(ctx context.Context, resource *model.Resourc
 // Idempotent: a second call is a no-op.
 func (m *ResourceManager) TeardownAll(ctx context.Context) {
 	m.mutex.Lock()
-	started := m.started
+	m.tearingDown = true
+	for m.activeStarts > 0 {
+		m.startCondition.Wait()
+	}
+	started := append([]*model.Resource(nil), m.started...)
 	m.started = nil
 	m.mutex.Unlock()
 
 	logger := console.GetLogger(ctx)
-	for i := len(started) - 1; i >= 0; i-- {
-		resource := started[i]
+	for _, resource := range slices.Backward(started) {
 		if resource.Down == "" {
 			continue
 		}
@@ -307,7 +365,7 @@ func (m *ResourceManager) resolveExports(resource *model.Resource, exportsFilePa
 
 	content, err := os.ReadFile(exportsFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read exports file: %w", err)
+		return exportsEnvironment(merged), fmt.Errorf("failed to read exports file: %w", err)
 	}
 	for line := range strings.SplitSeq(string(content), "\n") {
 		line = strings.TrimSpace(line)
@@ -316,22 +374,25 @@ func (m *ResourceManager) resolveExports(resource *model.Resource, exportsFilePa
 		}
 		key, value, found := strings.Cut(line, "=")
 		if !found || key == "" {
-			return nil, fmt.Errorf("resource %s wrote an invalid exports line (want KEY=VALUE): %q", resource.Label, line)
+			return exportsEnvironment(merged), fmt.Errorf("resource %s wrote an invalid exports line (want KEY=VALUE): %q", resource.Label, line)
 		}
 		merged[key] = value
 	}
+	return exportsEnvironment(merged), nil
+}
 
-	keys := make([]string, 0, len(merged))
-	for key := range merged {
+func exportsEnvironment(exports map[string]string) []string {
+	keys := make([]string, 0, len(exports))
+	for key := range exports {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 
 	environment := make([]string, 0, len(keys))
 	for _, key := range keys {
-		environment = append(environment, key+"="+merged[key])
+		environment = append(environment, key+"="+exports[key])
 	}
-	return environment, nil
+	return environment
 }
 
 // resourceEnv builds the base environment for resource lifecycle commands.

--- a/internal/execution/resource_manager.go
+++ b/internal/execution/resource_manager.go
@@ -1,0 +1,280 @@
+package execution
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	"grog/internal/config"
+	"grog/internal/console"
+	"grog/internal/dag"
+	"grog/internal/hashing"
+	"grog/internal/logs"
+	"grog/internal/model"
+	"grog/internal/worker"
+)
+
+// ResourceManager starts resource nodes lazily and at most once per
+// invocation: the first executing target that depends on a resource triggers
+// its up command, targets that are fully cached never do. Started resources
+// are torn down in reverse start order when the build finishes.
+type ResourceManager struct {
+	startGroup singleflight.Group
+
+	mutex sync.Mutex
+	// started holds resources in start order; a resource is registered before
+	// its up command runs so that partial starts are still torn down.
+	started []*model.Resource
+	// exports holds the resolved KEY=VALUE environment pairs per resource,
+	// including dynamic exports written by the up command.
+	exports map[string][]string
+}
+
+func NewResourceManager() *ResourceManager {
+	return &ResourceManager{
+		exports: make(map[string][]string),
+	}
+}
+
+// EnsureResourcesStarted starts every resource the target directly depends on
+// (unless already running) and returns the combined exported environment.
+func (m *ResourceManager) EnsureResourcesStarted(
+	ctx context.Context,
+	graph *dag.DirectedTargetGraph,
+	target *model.Target,
+	update worker.StatusFunc,
+) ([]string, error) {
+	var combinedExports []string
+	for _, dependency := range graph.GetDependencies(target) {
+		resource, ok := dependency.(*model.Resource)
+		if !ok {
+			continue
+		}
+
+		update(worker.Status(fmt.Sprintf("%s: waiting for resource %s", target.Label, resource.Label)))
+		if err := m.ensureStarted(ctx, resource); err != nil {
+			return nil, fmt.Errorf("resource %s required by %s: %w", resource.Label, target.Label, err)
+		}
+
+		m.mutex.Lock()
+		combinedExports = append(combinedExports, m.exports[resource.Label.String()]...)
+		m.mutex.Unlock()
+	}
+	return combinedExports, nil
+}
+
+// ensureStarted runs the resource's up command and ready probe exactly once
+// across all concurrent callers; later callers share the first result.
+func (m *ResourceManager) ensureStarted(ctx context.Context, resource *model.Resource) error {
+	_, err, _ := m.startGroup.Do(resource.Label.String(), func() (any, error) {
+		m.mutex.Lock()
+		m.started = append(m.started, resource)
+		m.mutex.Unlock()
+
+		return nil, m.start(ctx, resource)
+	})
+	return err
+}
+
+func (m *ResourceManager) start(ctx context.Context, resource *model.Resource) error {
+	logger := console.GetLogger(ctx)
+	startTime := time.Now()
+
+	startContext, cancel := context.WithTimeout(ctx, resource.GetTimeout())
+	defer cancel()
+
+	exportsFile, err := os.CreateTemp("", "grog-resource-exports-*")
+	if err != nil {
+		return fmt.Errorf("failed to create exports file: %w", err)
+	}
+	exportsFilePath := exportsFile.Name()
+	_ = exportsFile.Close()
+	defer os.Remove(exportsFilePath)
+
+	baseEnvironment := m.resourceEnv(resource)
+	upEnvironment := append(append([]string{}, baseEnvironment...), "GROG_RESOURCE_EXPORTS_FILE="+exportsFilePath)
+
+	output, err := m.runHookCommand(startContext, resource, resource.Up, upEnvironment)
+	if err != nil {
+		return fmt.Errorf("up command failed: %w\noutput: %s", err, string(output))
+	}
+
+	resolvedExports, err := m.resolveExports(resource, exportsFilePath)
+	if err != nil {
+		return err
+	}
+
+	if resource.Ready != "" {
+		readyEnvironment := append(append([]string{}, baseEnvironment...), resolvedExports...)
+		if err := m.pollReady(startContext, resource, readyEnvironment); err != nil {
+			return err
+		}
+	}
+
+	m.mutex.Lock()
+	m.exports[resource.Label.String()] = resolvedExports
+	m.mutex.Unlock()
+
+	if config.Global.DisableNonDeterministicLogging {
+		logger.Infof("Resource %s started.", resource.Label)
+	} else {
+		logger.Infof("Resource %s started in %.1fs.", resource.Label, time.Since(startTime).Seconds())
+	}
+	return nil
+}
+
+// pollReady runs the ready probe until it succeeds or the start deadline is hit.
+func (m *ResourceManager) pollReady(ctx context.Context, resource *model.Resource, environment []string) error {
+	var lastOutput []byte
+	var lastErr error
+	for {
+		lastOutput, lastErr = m.runHookCommand(ctx, resource, resource.Ready, environment)
+		if lastErr == nil {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("did not become ready within %s: %w\nlast probe output: %s",
+				resource.GetTimeout(), lastErr, string(lastOutput))
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+// TeardownAll runs the down command of every started resource in reverse
+// start order. Failures are logged as warnings and do not fail the build.
+// Idempotent: a second call is a no-op.
+func (m *ResourceManager) TeardownAll(ctx context.Context) {
+	m.mutex.Lock()
+	started := m.started
+	m.started = nil
+	m.mutex.Unlock()
+
+	logger := console.GetLogger(ctx)
+	for i := len(started) - 1; i >= 0; i-- {
+		resource := started[i]
+		if resource.Down == "" {
+			continue
+		}
+
+		downContext, cancel := context.WithTimeout(ctx, resource.GetTimeout())
+		m.mutex.Lock()
+		environment := append(m.resourceEnv(resource), m.exports[resource.Label.String()]...)
+		m.mutex.Unlock()
+
+		output, err := m.runHookCommand(downContext, resource, resource.Down, environment)
+		cancel()
+		if err != nil {
+			logger.Warnf("Resource %s down command failed: %v\noutput: %s", resource.Label, err, string(output))
+			continue
+		}
+		logger.Infof("Resource %s stopped.", resource.Label)
+	}
+}
+
+// runHookCommand executes a resource lifecycle command in the resource's
+// package directory and returns the combined output.
+func (m *ResourceManager) runHookCommand(
+	ctx context.Context,
+	resource *model.Resource,
+	command string,
+	environment []string,
+) ([]byte, error) {
+	script := command
+	if !config.Global.DisableDefaultShellFlags {
+		script = "set -eu\n" + command
+	}
+
+	scriptPath, cleanup, err := writeCommandScript(script)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	cmd := exec.CommandContext(ctx, "sh", scriptPath)
+	cmd.WaitDelay = 1 * time.Second
+	cmd.Dir = config.GetPathAbsoluteToWorkspaceRoot(resource.Label.Package)
+	cmd.Env = environment
+
+	resourceLogs := logs.NewTargetLogFile(model.Target{Label: resource.Label})
+	var buffer bytes.Buffer
+	if logWriter, logErr := resourceLogs.Open(); logErr == nil {
+		defer logWriter.Close()
+		multiOut := io.MultiWriter(&buffer, logWriter)
+		cmd.Stdout = multiOut
+		cmd.Stderr = multiOut
+	} else {
+		cmd.Stdout = &buffer
+		cmd.Stderr = &buffer
+	}
+
+	if err := cmd.Run(); err != nil {
+		return buffer.Bytes(), err
+	}
+	return buffer.Bytes(), nil
+}
+
+// resolveExports merges the statically declared exports with KEY=VALUE lines
+// the up command appended to the exports file (dynamic values win) and
+// returns them as a sorted environment slice.
+func (m *ResourceManager) resolveExports(resource *model.Resource, exportsFilePath string) ([]string, error) {
+	merged := make(map[string]string, len(resource.Exports))
+	maps.Copy(merged, resource.Exports)
+
+	content, err := os.ReadFile(exportsFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read exports file: %w", err)
+	}
+	for line := range strings.SplitSeq(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, found := strings.Cut(line, "=")
+		if !found || key == "" {
+			return nil, fmt.Errorf("resource %s wrote an invalid exports line (want KEY=VALUE): %q", resource.Label, line)
+		}
+		merged[key] = value
+	}
+
+	keys := make([]string, 0, len(merged))
+	for key := range merged {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	environment := make([]string, 0, len(keys))
+	for _, key := range keys {
+		environment = append(environment, key+"="+merged[key])
+	}
+	return environment, nil
+}
+
+// resourceEnv builds the base environment for resource lifecycle commands.
+func (m *ResourceManager) resourceEnv(resource *model.Resource) []string {
+	environment := append([]string{}, os.Environ()...)
+	for key, value := range config.Global.EnvironmentVariables {
+		environment = append(environment, key+"="+value)
+	}
+
+	return append(environment,
+		"GROG_RESOURCE="+resource.Label.String(),
+		"GROG_RESOURCE_ID="+hashing.GetResourceIdentity(*resource),
+		"GROG_OS="+config.Global.OS,
+		"GROG_ARCH="+config.Global.Arch,
+		"GROG_PLATFORM="+config.Global.GetPlatform(),
+		"GROG_PACKAGE="+resource.Label.Package,
+		"GROG_WORKSPACE_ROOT="+config.Global.WorkspaceRoot,
+	)
+}

--- a/internal/execution/resource_manager.go
+++ b/internal/execution/resource_manager.go
@@ -38,16 +38,28 @@ type ResourceManager struct {
 	// exports holds the resolved KEY=VALUE environment pairs per resource,
 	// including dynamic exports written by the up command.
 	exports map[string][]string
+	// dependencyExports holds the exports a resource inherits from the
+	// resources it depends on. Kept separate from exports so that dependent
+	// targets only ever see the exports of the resources they declare.
+	dependencyExports map[string][]string
+	// startResults memoizes the terminal outcome of each start attempt.
+	// singleflight only dedupes calls that overlap in time, so consumers
+	// reaching a resource after its start finished must be served from here to
+	// keep the at-most-once guarantee.
+	startResults map[string]error
 }
 
 func NewResourceManager() *ResourceManager {
 	return &ResourceManager{
-		exports: make(map[string][]string),
+		exports:           make(map[string][]string),
+		dependencyExports: make(map[string][]string),
+		startResults:      make(map[string]error),
 	}
 }
 
 // EnsureResourcesStarted starts every resource the target directly depends on
-// (unless already running) and returns the combined exported environment.
+// (and, transitively, the resources those depend on) unless already running,
+// and returns the exported environment of the target's direct resources.
 func (m *ResourceManager) EnsureResourcesStarted(
 	ctx context.Context,
 	graph *dag.DirectedTargetGraph,
@@ -62,7 +74,7 @@ func (m *ResourceManager) EnsureResourcesStarted(
 		}
 
 		update(worker.Status(fmt.Sprintf("%s: waiting for resource %s", target.Label, resource.Label)))
-		if err := m.ensureStarted(ctx, resource); err != nil {
+		if err := m.ensureStarted(ctx, graph, resource); err != nil {
 			return nil, fmt.Errorf("resource %s required by %s: %w", resource.Label, target.Label, err)
 		}
 
@@ -73,20 +85,77 @@ func (m *ResourceManager) EnsureResourcesStarted(
 	return combinedExports, nil
 }
 
-// ensureStarted runs the resource's up command and ready probe exactly once
-// across all concurrent callers; later callers share the first result.
-func (m *ResourceManager) ensureStarted(ctx context.Context, resource *model.Resource) error {
-	_, err, _ := m.startGroup.Do(resource.Label.String(), func() (any, error) {
+// ensureStarted starts the resource exactly once for the whole invocation:
+// singleflight collapses concurrent callers and startResults serves callers
+// that arrive after the start already finished.
+func (m *ResourceManager) ensureStarted(
+	ctx context.Context,
+	graph *dag.DirectedTargetGraph,
+	resource *model.Resource,
+) error {
+	resourceLabel := resource.Label.String()
+	if startErr, isStarted := m.startResult(resourceLabel); isStarted {
+		return startErr
+	}
+
+	_, err, _ := m.startGroup.Do(resourceLabel, func() (any, error) {
+		// A start may have completed between the check above and this call
+		// acquiring the singleflight slot.
+		if startErr, isStarted := m.startResult(resourceLabel); isStarted {
+			return nil, startErr
+		}
+
+		startErr := m.startWithDependencies(ctx, graph, resource)
+
 		m.mutex.Lock()
-		m.started = append(m.started, resource)
+		m.startResults[resourceLabel] = startErr
 		m.mutex.Unlock()
 
-		return nil, m.start(ctx, resource)
+		return nil, startErr
 	})
 	return err
 }
 
-func (m *ResourceManager) start(ctx context.Context, resource *model.Resource) error {
+func (m *ResourceManager) startResult(resourceLabel string) (error, bool) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	startErr, isStarted := m.startResults[resourceLabel]
+	return startErr, isStarted
+}
+
+// startWithDependencies starts the resources this resource depends on before
+// registering and starting it, so that a resource always comes up after the
+// resources it needs and is torn down before them.
+func (m *ResourceManager) startWithDependencies(
+	ctx context.Context,
+	graph *dag.DirectedTargetGraph,
+	resource *model.Resource,
+) error {
+	var dependencyExports []string
+	for _, dependency := range graph.GetDependencies(resource) {
+		dependencyResource, isResource := dependency.(*model.Resource)
+		if !isResource {
+			continue
+		}
+
+		if err := m.ensureStarted(ctx, graph, dependencyResource); err != nil {
+			return fmt.Errorf("resource dependency %s: %w", dependencyResource.Label, err)
+		}
+
+		m.mutex.Lock()
+		dependencyExports = append(dependencyExports, m.exports[dependencyResource.Label.String()]...)
+		m.mutex.Unlock()
+	}
+
+	m.mutex.Lock()
+	m.started = append(m.started, resource)
+	m.dependencyExports[resource.Label.String()] = dependencyExports
+	m.mutex.Unlock()
+
+	return m.start(ctx, resource, dependencyExports)
+}
+
+func (m *ResourceManager) start(ctx context.Context, resource *model.Resource, dependencyExports []string) error {
 	logger := console.GetLogger(ctx)
 	startTime := time.Now()
 
@@ -101,7 +170,7 @@ func (m *ResourceManager) start(ctx context.Context, resource *model.Resource) e
 	_ = exportsFile.Close()
 	defer os.Remove(exportsFilePath)
 
-	baseEnvironment := m.resourceEnv(resource)
+	baseEnvironment := append(m.resourceEnv(resource), dependencyExports...)
 	upEnvironment := append(append([]string{}, baseEnvironment...), "GROG_RESOURCE_EXPORTS_FILE="+exportsFilePath)
 
 	output, err := m.runHookCommand(startContext, resource, resource.Up, upEnvironment)
@@ -114,16 +183,19 @@ func (m *ResourceManager) start(ctx context.Context, resource *model.Resource) e
 		return err
 	}
 
+	// Publish exports before probing readiness: a resource whose up succeeded
+	// but whose ready probe timed out still has to be torn down, and its down
+	// command may need the dynamically exported container id or port.
+	m.mutex.Lock()
+	m.exports[resource.Label.String()] = resolvedExports
+	m.mutex.Unlock()
+
 	if resource.Ready != "" {
 		readyEnvironment := append(append([]string{}, baseEnvironment...), resolvedExports...)
 		if err := m.pollReady(startContext, resource, readyEnvironment); err != nil {
 			return err
 		}
 	}
-
-	m.mutex.Lock()
-	m.exports[resource.Label.String()] = resolvedExports
-	m.mutex.Unlock()
 
 	if config.Global.DisableNonDeterministicLogging {
 		logger.Infof("Resource %s started.", resource.Label)
@@ -170,7 +242,8 @@ func (m *ResourceManager) TeardownAll(ctx context.Context) {
 
 		downContext, cancel := context.WithTimeout(ctx, resource.GetTimeout())
 		m.mutex.Lock()
-		environment := append(m.resourceEnv(resource), m.exports[resource.Label.String()]...)
+		environment := append(m.resourceEnv(resource), m.dependencyExports[resource.Label.String()]...)
+		environment = append(environment, m.exports[resource.Label.String()]...)
 		m.mutex.Unlock()
 
 		output, err := m.runHookCommand(downContext, resource, resource.Down, environment)

--- a/internal/execution/resource_manager_test.go
+++ b/internal/execution/resource_manager_test.go
@@ -236,6 +236,124 @@ func TestTeardownAllRunsForPartiallyFailedStart(t *testing.T) {
 	}
 }
 
+func TestTeardownAfterFailedUpHasExports(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	downFile := filepath.Join(tmpDir, "down.log")
+
+	resource := &model.Resource{
+		Label:   label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:      `echo "CONTAINER_ID=abc123" >> "$GROG_RESOURCE_EXPORTS_FILE"; false`,
+		Down:    `echo "$STATIC_NAME:$CONTAINER_ID" > ` + downFile,
+		Exports: map[string]string{"STATIC_NAME": "database"},
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	if _, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus); err == nil {
+		t.Fatal("expected up failure")
+	}
+	manager.TeardownAll(context.Background())
+
+	content, err := os.ReadFile(downFile)
+	if err != nil {
+		t.Fatalf("failed to read down log: %v", err)
+	}
+	if strings.TrimSpace(string(content)) != "database:abc123" {
+		t.Fatalf("expected down to receive exports, got %q", content)
+	}
+}
+
+func TestTeardownAllWaitsForActiveStart(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	launchedFile := filepath.Join(tmpDir, "launched.marker")
+	runningFile := filepath.Join(tmpDir, "running.marker")
+
+	resource := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:    "touch " + launchedFile + "; sleep 0.2; touch " + runningFile,
+		Down:  "rm -f " + runningFile,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	startResult := make(chan error, 1)
+	go func() {
+		_, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus)
+		startResult <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(launchedFile); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("resource start did not launch")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	manager.TeardownAll(context.Background())
+	if err := <-startResult; err != nil {
+		t.Fatalf("resource start failed: %v", err)
+	}
+	if _, err := os.Stat(runningFile); !os.IsNotExist(err) {
+		t.Fatalf("resource remained after teardown: %v", err)
+	}
+}
+
+func TestEnsureResourcesStartedResolvesResourceAlias(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	startedFile := filepath.Join(tmpDir, "started.marker")
+
+	resource := &model.Resource{
+		Label:   label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:      "touch " + startedFile,
+		Exports: map[string]string{"DATABASE_URL": "postgres://local"},
+	}
+	resourceAlias := &model.Alias{
+		Label:  label.TargetLabel{Package: "pkg", Name: "database"},
+		Actual: resource.Label,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resourceAlias.Label},
+	}
+	graph := newResourceTestGraph(t, resource, resourceAlias, target)
+	if err := graph.AddEdge(resource, resourceAlias); err != nil {
+		t.Fatalf("failed to add resource edge: %v", err)
+	}
+	if err := graph.AddEdge(resourceAlias, target); err != nil {
+		t.Fatalf("failed to add alias edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	environment, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus)
+	if err != nil {
+		t.Fatalf("failed to start aliased resource: %v", err)
+	}
+	if _, err := os.Stat(startedFile); err != nil {
+		t.Fatalf("aliased resource did not start: %v", err)
+	}
+	if !strings.Contains(strings.Join(environment, "\n"), "DATABASE_URL=postgres://local") {
+		t.Fatalf("aliased resource exports missing: %v", environment)
+	}
+}
+
 // TestEnsureResourcesStartedIsAtMostOnceAcrossSequentialConsumers guards
 // against relying on singleflight as a cache: it only collapses calls that
 // overlap in time, so a consumer arriving after the first start finished must

--- a/internal/execution/resource_manager_test.go
+++ b/internal/execution/resource_manager_test.go
@@ -235,3 +235,150 @@ func TestTeardownAllRunsForPartiallyFailedStart(t *testing.T) {
 		t.Fatalf("expected down to run for partially started resource: %v", err)
 	}
 }
+
+// TestEnsureResourcesStartedIsAtMostOnceAcrossSequentialConsumers guards
+// against relying on singleflight as a cache: it only collapses calls that
+// overlap in time, so a consumer arriving after the first start finished must
+// still not re-run up.
+func TestEnsureResourcesStartedIsAtMostOnceAcrossSequentialConsumers(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	countFile := filepath.Join(tmpDir, "starts.log")
+
+	resource := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:    "echo up >> " + countFile,
+	}
+	firstConsumer := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "first"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	secondConsumer := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "second"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, firstConsumer, secondConsumer)
+	for _, consumer := range []*model.Target{firstConsumer, secondConsumer} {
+		if err := graph.AddEdge(resource, consumer); err != nil {
+			t.Fatalf("failed to add edge: %v", err)
+		}
+	}
+
+	manager := NewResourceManager()
+	for _, consumer := range []*model.Target{firstConsumer, secondConsumer} {
+		if _, err := manager.EnsureResourcesStarted(context.Background(), graph, consumer, noopStatus); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+
+	content, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("failed to read start counter: %v", err)
+	}
+	if got := strings.Count(string(content), "up"); got != 1 {
+		t.Fatalf("expected exactly one up invocation across sequential consumers, got %d", got)
+	}
+}
+
+// TestEnsureResourcesStartedStartsResourceDependencies verifies that a
+// resource depending on another resource brings its dependency up first, can
+// read its exports, and is torn down before it.
+func TestEnsureResourcesStartedStartsResourceDependencies(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	orderFile := filepath.Join(tmpDir, "order.log")
+
+	database := &model.Resource{
+		Label:   label.TargetLabel{Package: "pkg", Name: "database"},
+		Up:      "echo database_up >> " + orderFile,
+		Down:    "echo database_down >> " + orderFile,
+		Exports: map[string]string{"DB_DSN": "postgres://local"},
+	}
+	migrations := &model.Resource{
+		Label:        label.TargetLabel{Package: "pkg", Name: "migrations"},
+		Up:           `echo "migrations_up:$DB_DSN" >> ` + orderFile,
+		Down:         `echo "migrations_down:$DB_DSN" >> ` + orderFile,
+		Dependencies: []label.TargetLabel{database.Label},
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{migrations.Label},
+	}
+	graph := newResourceTestGraph(t, database, migrations, target)
+	if err := graph.AddEdge(database, migrations); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+	if err := graph.AddEdge(migrations, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	targetExports, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	manager.TeardownAll(context.Background())
+
+	content, err := os.ReadFile(orderFile)
+	if err != nil {
+		t.Fatalf("failed to read order log: %v", err)
+	}
+	lines := strings.Fields(string(content))
+	want := []string{
+		"database_up",
+		"migrations_up:postgres://local",
+		"migrations_down:postgres://local",
+		"database_down",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("expected %v, got %v", want, lines)
+	}
+	for i, wantLine := range want {
+		if lines[i] != wantLine {
+			t.Fatalf("expected %v, got %v", want, lines)
+		}
+	}
+
+	// The target only declared :migrations, so it must not inherit the
+	// database's exports.
+	if strings.Contains(strings.Join(targetExports, "\n"), "DB_DSN") {
+		t.Errorf("expected target not to inherit transitive resource exports, got %v", targetExports)
+	}
+}
+
+// TestTeardownAfterReadyTimeoutHasExports verifies that a resource whose up
+// succeeded but whose ready probe timed out still tears down with its dynamic
+// exports available, so cleanup can address the started instance.
+func TestTeardownAfterReadyTimeoutHasExports(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	downFile := filepath.Join(tmpDir, "down.log")
+
+	resource := &model.Resource{
+		Label:   label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:      `echo "CONTAINER_ID=abc123" >> "$GROG_RESOURCE_EXPORTS_FILE"`,
+		Ready:   "false",
+		Down:    `echo "removed:$CONTAINER_ID" >> ` + downFile,
+		Timeout: 300 * time.Millisecond,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	if _, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus); err == nil {
+		t.Fatal("expected ready timeout error")
+	}
+
+	manager.TeardownAll(context.Background())
+
+	content, err := os.ReadFile(downFile)
+	if err != nil {
+		t.Fatalf("failed to read down log: %v", err)
+	}
+	if strings.TrimSpace(string(content)) != "removed:abc123" {
+		t.Fatalf("expected down to see the dynamic export, got %q", string(content))
+	}
+}

--- a/internal/execution/resource_manager_test.go
+++ b/internal/execution/resource_manager_test.go
@@ -1,0 +1,237 @@
+package execution
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"grog/internal/config"
+	"grog/internal/dag"
+	"grog/internal/label"
+	"grog/internal/model"
+	"grog/internal/worker"
+)
+
+func setupResourceTestWorkspace(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	prev := config.Global
+	config.Global = config.WorkspaceConfig{
+		Root:                     tmpDir,
+		WorkspaceRoot:            tmpDir,
+		DisableDefaultShellFlags: true,
+	}
+	t.Cleanup(func() { config.Global = prev })
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, "pkg"), 0755); err != nil {
+		t.Fatalf("failed to create package dir: %v", err)
+	}
+	return tmpDir
+}
+
+func noopStatus(worker.StatusUpdate) {}
+
+func newResourceTestGraph(t *testing.T, nodes ...model.BuildNode) *dag.DirectedTargetGraph {
+	t.Helper()
+	graph := dag.NewDirectedGraphFromTargets(nodes...)
+	return graph
+}
+
+func TestEnsureResourcesStartedStartsOnceAndInjectsExports(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	countFile := filepath.Join(tmpDir, "starts.log")
+
+	resource := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:    `echo up >> ` + countFile + `; echo "DYNAMIC_TOKEN=from-up" >> "$GROG_RESOURCE_EXPORTS_FILE"`,
+		Exports: map[string]string{
+			"STATIC_TOKEN": "from-static",
+			// The up command overrides this one dynamically
+			"DYNAMIC_TOKEN": "overridden",
+		},
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+
+	var waitGroup sync.WaitGroup
+	environments := make([][]string, 10)
+	errors := make([]error, 10)
+	for i := range 10 {
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+			environments[index], errors[index] = manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus)
+		}(i)
+	}
+	waitGroup.Wait()
+
+	for _, err := range errors {
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	}
+
+	content, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatalf("failed to read start counter: %v", err)
+	}
+	if got := strings.Count(string(content), "up"); got != 1 {
+		t.Fatalf("expected exactly one up invocation, got %d", got)
+	}
+
+	joined := strings.Join(environments[0], "\n")
+	if !strings.Contains(joined, "STATIC_TOKEN=from-static") {
+		t.Errorf("expected static export, got %v", environments[0])
+	}
+	if !strings.Contains(joined, "DYNAMIC_TOKEN=from-up") {
+		t.Errorf("expected dynamic export to win, got %v", environments[0])
+	}
+}
+
+func TestEnsureResourcesStartedWaitsForReady(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	readyFile := filepath.Join(tmpDir, "ready.marker")
+
+	resource := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "db"},
+		// Up daemonizes a short task that only later creates the ready marker
+		Up:    `(sleep 0.4 && touch ` + readyFile + `) &`,
+		Ready: `test -f ` + readyFile,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	if _, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus); err != nil {
+		t.Fatalf("expected resource to become ready, got %v", err)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("expected ready marker to exist: %v", err)
+	}
+}
+
+func TestEnsureResourcesStartedFailsWhenReadyTimesOut(t *testing.T) {
+	setupResourceTestWorkspace(t)
+
+	resource := &model.Resource{
+		Label:   label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:      "true",
+		Ready:   "false",
+		Timeout: 500 * time.Millisecond,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	_, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus)
+	if err == nil {
+		t.Fatal("expected ready timeout error")
+	}
+	if !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("expected ready timeout error, got %v", err)
+	}
+}
+
+func TestTeardownAllRunsDownInReverseStartOrder(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	orderFile := filepath.Join(tmpDir, "order.log")
+
+	first := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "first"},
+		Up:    "true",
+		Down:  "echo first >> " + orderFile,
+	}
+	second := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "second"},
+		Up:    "true",
+		Down:  "echo second >> " + orderFile,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{first.Label, second.Label},
+	}
+	graph := newResourceTestGraph(t, first, second, target)
+	if err := graph.AddEdge(first, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+	if err := graph.AddEdge(second, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	if _, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	manager.TeardownAll(context.Background())
+
+	content, err := os.ReadFile(orderFile)
+	if err != nil {
+		t.Fatalf("failed to read teardown order: %v", err)
+	}
+	lines := strings.Fields(string(content))
+	if len(lines) != 2 || lines[0] != "second" || lines[1] != "first" {
+		t.Fatalf("expected reverse start order [second first], got %v", lines)
+	}
+
+	// TeardownAll is idempotent
+	manager.TeardownAll(context.Background())
+	content, _ = os.ReadFile(orderFile)
+	if got := len(strings.Fields(string(content))); got != 2 {
+		t.Fatalf("expected no additional teardowns, got %d lines", got)
+	}
+}
+
+func TestTeardownAllRunsForPartiallyFailedStart(t *testing.T) {
+	tmpDir := setupResourceTestWorkspace(t)
+	downFile := filepath.Join(tmpDir, "down.marker")
+
+	resource := &model.Resource{
+		Label: label.TargetLabel{Package: "pkg", Name: "db"},
+		Up:    "false",
+		Down:  "touch " + downFile,
+	}
+	target := &model.Target{
+		Label:        label.TargetLabel{Package: "pkg", Name: "consumer"},
+		Dependencies: []label.TargetLabel{resource.Label},
+	}
+	graph := newResourceTestGraph(t, resource, target)
+	if err := graph.AddEdge(resource, target); err != nil {
+		t.Fatalf("failed to add edge: %v", err)
+	}
+
+	manager := NewResourceManager()
+	if _, err := manager.EnsureResourcesStarted(context.Background(), graph, target, noopStatus); err == nil {
+		t.Fatal("expected up failure")
+	}
+
+	manager.TeardownAll(context.Background())
+	if _, err := os.Stat(downFile); err != nil {
+		t.Fatalf("expected down to run for partially started resource: %v", err)
+	}
+}

--- a/internal/hashing/hash_resource.go
+++ b/internal/hashing/hash_resource.go
@@ -1,22 +1,46 @@
 package hashing
 
-import "grog/internal/model"
+import (
+	"sort"
+	"strconv"
 
-// GetResourceIdentity returns a short stable identifier for a resource derived
-// from its label and definition. Editing the definition changes the identity,
-// so lifecycle commands built on it (e.g. container names) never adopt an
-// instance started from a stale definition.
+	"grog/internal/model"
+)
+
+// GetResourceIdentity returns a short stable identifier derived from the
+// resource's complete behavior-affecting definition.
 func GetResourceIdentity(resource model.Resource) string {
 	hasher := GetHasher()
-	_, _ = hasher.WriteString(resource.Label.String())
-	_, _ = hasher.WriteString(resource.Up)
-	_, _ = hasher.WriteString(resource.Down)
-	_, _ = hasher.WriteString(resource.Ready)
-	_, _ = hasher.WriteString(sortedKeyValue(resource.Exports))
+	writeResourceIdentityValue(hasher, resource.Label.String())
+	writeResourceIdentityValue(hasher, resource.Up)
+	writeResourceIdentityValue(hasher, resource.Down)
+	writeResourceIdentityValue(hasher, resource.Ready)
+	writeResourceIdentityValue(hasher, resource.GetTimeout().String())
+	writeResourceIdentityValue(hasher, strconv.Itoa(len(resource.Dependencies)))
+	for _, dependency := range resource.Dependencies {
+		writeResourceIdentityValue(hasher, dependency.String())
+	}
+
+	exportKeys := make([]string, 0, len(resource.Exports))
+	for key := range resource.Exports {
+		exportKeys = append(exportKeys, key)
+	}
+	sort.Strings(exportKeys)
+	writeResourceIdentityValue(hasher, strconv.Itoa(len(exportKeys)))
+	for _, key := range exportKeys {
+		writeResourceIdentityValue(hasher, key)
+		writeResourceIdentityValue(hasher, resource.Exports[key])
+	}
 
 	sum := hasher.SumString()
 	if len(sum) > 12 {
 		return sum[:12]
 	}
 	return sum
+}
+
+func writeResourceIdentityValue(hasher Hasher, value string) {
+	_, _ = hasher.WriteString(strconv.Itoa(len(value)))
+	_, _ = hasher.WriteString(":")
+	_, _ = hasher.WriteString(value)
 }

--- a/internal/hashing/hash_resource.go
+++ b/internal/hashing/hash_resource.go
@@ -1,0 +1,22 @@
+package hashing
+
+import "grog/internal/model"
+
+// GetResourceIdentity returns a short stable identifier for a resource derived
+// from its label and definition. Editing the definition changes the identity,
+// so lifecycle commands built on it (e.g. container names) never adopt an
+// instance started from a stale definition.
+func GetResourceIdentity(resource model.Resource) string {
+	hasher := GetHasher()
+	_, _ = hasher.WriteString(resource.Label.String())
+	_, _ = hasher.WriteString(resource.Up)
+	_, _ = hasher.WriteString(resource.Down)
+	_, _ = hasher.WriteString(resource.Ready)
+	_, _ = hasher.WriteString(sortedKeyValue(resource.Exports))
+
+	sum := hasher.SumString()
+	if len(sum) > 12 {
+		return sum[:12]
+	}
+	return sum
+}

--- a/internal/hashing/hash_resource_test.go
+++ b/internal/hashing/hash_resource_test.go
@@ -1,0 +1,59 @@
+package hashing
+
+import (
+	"testing"
+	"time"
+
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestGetResourceIdentityIncludesCompleteDefinition(t *testing.T) {
+	base := model.Resource{
+		Label:   label.TL("pkg", "database"),
+		Up:      "start",
+		Down:    "stop",
+		Ready:   "ready",
+		Exports: map[string]string{"DATABASE_URL": "postgres://local"},
+	}
+	baseIdentity := GetResourceIdentity(base)
+
+	testCases := []struct {
+		name     string
+		resource model.Resource
+	}{
+		{
+			name: "timeout",
+			resource: func() model.Resource {
+				modified := base
+				modified.Timeout = time.Minute
+				return modified
+			}(),
+		},
+		{
+			name: "dependencies",
+			resource: func() model.Resource {
+				modified := base
+				modified.Dependencies = []label.TargetLabel{label.TL("pkg", "network")}
+				return modified
+			}(),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if identity := GetResourceIdentity(testCase.resource); identity == baseIdentity {
+				t.Fatalf("resource identity did not change for %s", testCase.name)
+			}
+		})
+	}
+}
+
+func TestGetResourceIdentitySeparatesFieldBoundaries(t *testing.T) {
+	first := model.Resource{Label: label.TL("pkg", "database"), Up: "ab", Down: "c"}
+	second := model.Resource{Label: first.Label, Up: "a", Down: "bc"}
+
+	if GetResourceIdentity(first) == GetResourceIdentity(second) {
+		t.Fatal("resource identities collided across field boundaries")
+	}
+}

--- a/internal/hashing/target_hasher.go
+++ b/internal/hashing/target_hasher.go
@@ -42,8 +42,8 @@ func (t *TargetHasher) SetTargetChangeHash(target *model.Target) error {
 
 	// Collect the OutputHash values of all dependencies
 	dependencies := t.graph.GetDependencies(target)
-	dependencyHashes := make([]string, len(target.Dependencies))
-	for index, dependency := range dependencies {
+	dependencyHashes := make([]string, 0, len(dependencies))
+	for _, dependency := range dependencies {
 		targetDependency, ok := dependency.(*model.Target)
 		if !ok {
 			// Only consider dependencies that are targets
@@ -55,7 +55,7 @@ func (t *TargetHasher) SetTargetChangeHash(target *model.Target) error {
 			return fmt.Errorf("dependency %s of %s has no output hash", targetDependency.Label, target.Label)
 		}
 
-		dependencyHashes[index] = targetDependency.OutputHash
+		dependencyHashes = append(dependencyHashes, targetDependency.OutputHash)
 	}
 
 	changeHash, err := GetTargetChangeHash(*target, dependencyHashes, t.extraArgs)

--- a/internal/hashing/target_hasher_test.go
+++ b/internal/hashing/target_hasher_test.go
@@ -1,0 +1,50 @@
+package hashing
+
+import (
+	"testing"
+
+	"grog/internal/dag"
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestTargetHasherIgnoresResourceDependencies(t *testing.T) {
+	dependency := &model.Target{
+		Label:      label.TL("pkg", "dependency"),
+		OutputHash: "dependency-output",
+	}
+	resource := &model.Resource{Label: label.TL("pkg", "database"), Up: "true"}
+	withoutResource := &model.Target{
+		Label:        label.TL("pkg", "consumer"),
+		Command:      "true",
+		Dependencies: []label.TargetLabel{dependency.Label},
+	}
+	withResource := &model.Target{
+		Label:        withoutResource.Label,
+		Command:      withoutResource.Command,
+		Dependencies: []label.TargetLabel{dependency.Label, resource.Label},
+	}
+
+	withoutResourceGraph := dag.NewDirectedGraphFromTargets(dependency, withoutResource)
+	if err := withoutResourceGraph.AddEdge(dependency, withoutResource); err != nil {
+		t.Fatalf("failed to add dependency edge: %v", err)
+	}
+	if err := NewTargetHasher(withoutResourceGraph).SetTargetChangeHash(withoutResource); err != nil {
+		t.Fatalf("failed to hash target without resource: %v", err)
+	}
+
+	withResourceGraph := dag.NewDirectedGraphFromTargets(dependency, resource, withResource)
+	if err := withResourceGraph.AddEdge(dependency, withResource); err != nil {
+		t.Fatalf("failed to add dependency edge: %v", err)
+	}
+	if err := withResourceGraph.AddEdge(resource, withResource); err != nil {
+		t.Fatalf("failed to add resource edge: %v", err)
+	}
+	if err := NewTargetHasher(withResourceGraph).SetTargetChangeHash(withResource); err != nil {
+		t.Fatalf("failed to hash target with resource: %v", err)
+	}
+
+	if withoutResource.ChangeHash != withResource.ChangeHash {
+		t.Fatalf("resource changed target hash: %s != %s", withoutResource.ChangeHash, withResource.ChangeHash)
+	}
+}

--- a/internal/loading/dto.go
+++ b/internal/loading/dto.go
@@ -80,6 +80,18 @@ type AliasDTO struct {
 	Actual string `json:"actual" yaml:"actual" pkl:"actual" starlark:"actual"`
 }
 
+// ResourceDTO is used for deserializing a resource in a loader.
+// The resource used internally is model.Resource.
+type ResourceDTO struct {
+	Name         string            `json:"name" yaml:"name" pkl:"name" starlark:"name"`
+	Up           string            `json:"up" yaml:"up" pkl:"up" starlark:"up"`
+	Down         string            `json:"down,omitempty" yaml:"down,omitempty" pkl:"down" starlark:"down"`
+	Ready        string            `json:"ready,omitempty" yaml:"ready,omitempty" pkl:"ready" starlark:"ready"`
+	Timeout      string            `json:"timeout,omitempty" yaml:"timeout,omitempty" pkl:"timeout" starlark:"timeout"`
+	Exports      map[string]string `json:"exports,omitempty" yaml:"exports,omitempty" pkl:"exports" starlark:"exports"`
+	Dependencies []string          `json:"dependencies,omitempty" yaml:"dependencies,omitempty" pkl:"dependencies" starlark:"dependencies"`
+}
+
 type EnvironmentDTO struct {
 	Name         string   `json:"name" yaml:"name" pkl:"name" starlark:"name"`
 	Type         string   `json:"type" yaml:"type" pkl:"type" starlark:"type"`
@@ -96,6 +108,7 @@ type PackageDTO struct {
 
 	Targets      []*TargetDTO      `json:"targets" yaml:"targets" pkl:"targets" starlark:"targets"`
 	Aliases      []*AliasDTO       `json:"aliases" yaml:"aliases" pkl:"aliases" starlark:"aliases"`
+	Resources    []*ResourceDTO    `json:"resources" yaml:"resources" pkl:"resources" starlark:"resources"`
 	Environments []*EnvironmentDTO `json:"environments" yaml:"environments" pkl:"environments" starlark:"environments"`
 
 	// DefaultPlatforms specifies the platform selectors at the package level.

--- a/internal/loading/enrich_package.go
+++ b/internal/loading/enrich_package.go
@@ -120,6 +120,50 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 		}
 	}
 
+	resources := make(map[label.TargetLabel]*model.Resource)
+	for _, resource := range pkg.Resources {
+		var resourceDeps []label.TargetLabel
+		for _, dep := range resource.Dependencies {
+			depLabel, err := label.ParseTargetLabel(packagePath, dep)
+			if err != nil {
+				return nil, err
+			}
+			resourceDeps = append(resourceDeps, depLabel)
+		}
+
+		if packagePath == "." {
+			packagePath = ""
+		}
+		resourceLabel := label.TargetLabel{Package: packagePath, Name: resource.Name}
+		if _, ok := targets[resourceLabel]; ok || resources[resourceLabel] != nil {
+			return nil, fmt.Errorf("duplicate target label: %s (package file %s)", resource.Name, pkg.SourceFilePath)
+		}
+
+		if resource.Up == "" {
+			return nil, fmt.Errorf("resource %s must define an up command (package file %s)", resourceLabel, pkg.SourceFilePath)
+		}
+
+		var resourceTimeout time.Duration
+		if resource.Timeout != "" {
+			var err error
+			resourceTimeout, err = time.ParseDuration(resource.Timeout)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse timeout for resource %s: %w", resourceLabel, err)
+			}
+		}
+
+		resources[resourceLabel] = &model.Resource{
+			SourceFilePath: pkg.SourceFilePath,
+			Label:          resourceLabel,
+			Up:             resource.Up,
+			Down:           resource.Down,
+			Ready:          resource.Ready,
+			Timeout:        resourceTimeout,
+			Exports:        resource.Exports,
+			Dependencies:   resourceDeps,
+		}
+	}
+
 	for _, alias := range pkg.Aliases {
 		actualLabel, err := label.ParseTargetLabel(packagePath, alias.Actual)
 		if err != nil {
@@ -130,7 +174,7 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 			packagePath = ""
 		}
 		aliasLabel := label.TargetLabel{Package: packagePath, Name: alias.Name}
-		if _, ok := targets[aliasLabel]; ok || aliases[aliasLabel] != nil {
+		if _, ok := targets[aliasLabel]; ok || aliases[aliasLabel] != nil || resources[aliasLabel] != nil {
 			return nil, fmt.Errorf("duplicate target label: %s (package file %s)", alias.Name, pkg.SourceFilePath)
 		}
 
@@ -142,9 +186,10 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 	}
 
 	return &model.Package{
-		Path:    packagePath,
-		Targets: targets,
-		Aliases: aliases,
+		Path:      packagePath,
+		Targets:   targets,
+		Aliases:   aliases,
+		Resources: resources,
 	}, nil
 }
 

--- a/internal/loading/enrich_package_test.go
+++ b/internal/loading/enrich_package_test.go
@@ -101,3 +101,75 @@ func TestGetEnrichedPackage_FingerprintCopied(t *testing.T) {
 		}
 	}
 }
+
+func TestGetEnrichedPackage_Resources(t *testing.T) {
+	logger := console.NewFromSugared(zaptest.NewLogger(t).Sugar(), zapcore.DebugLevel)
+	packagePath := "test/package"
+
+	pkgDTO := PackageDTO{
+		SourceFilePath: "test/package/BUILD.yaml",
+		Targets: []*TargetDTO{
+			{Name: "image", Command: "echo image"},
+		},
+		Resources: []*ResourceDTO{
+			{
+				Name:         "postgres",
+				Up:           "docker run -d postgres",
+				Down:         "docker rm -f postgres",
+				Ready:        "pg_isready",
+				Timeout:      "2m",
+				Exports:      map[string]string{"DATABASE_URL": "postgres://localhost/test"},
+				Dependencies: []string{":image"},
+			},
+		},
+	}
+
+	enrichedPkg, err := getEnrichedPackage(logger, packagePath, pkgDTO)
+	if err != nil {
+		t.Fatalf("Failed to enrich package: %v", err)
+	}
+
+	resource, ok := enrichedPkg.Resources[label.TL(packagePath, "postgres")]
+	if !ok {
+		t.Fatalf("Resource //test/package:postgres not found in enriched package")
+	}
+	if resource.Up != "docker run -d postgres" || resource.Down != "docker rm -f postgres" || resource.Ready != "pg_isready" {
+		t.Errorf("Resource lifecycle commands not preserved: %+v", resource)
+	}
+	if resource.Timeout.String() != "2m0s" {
+		t.Errorf("Resource timeout not parsed: got %s", resource.Timeout)
+	}
+	if resource.Exports["DATABASE_URL"] != "postgres://localhost/test" {
+		t.Errorf("Resource exports not preserved: %v", resource.Exports)
+	}
+	if len(resource.Dependencies) != 1 || resource.Dependencies[0].String() != "//test/package:image" {
+		t.Errorf("Resource dependencies not parsed: %v", resource.Dependencies)
+	}
+}
+
+func TestGetEnrichedPackage_ResourceRequiresUp(t *testing.T) {
+	logger := console.NewFromSugared(zaptest.NewLogger(t).Sugar(), zapcore.DebugLevel)
+
+	pkgDTO := PackageDTO{
+		SourceFilePath: "test/package/BUILD.yaml",
+		Resources:      []*ResourceDTO{{Name: "postgres"}},
+	}
+
+	if _, err := getEnrichedPackage(logger, "test/package", pkgDTO); err == nil {
+		t.Fatal("expected error for resource without up command")
+	}
+}
+
+func TestGetEnrichedPackage_ResourceDuplicateLabel(t *testing.T) {
+	logger := console.NewFromSugared(zaptest.NewLogger(t).Sugar(), zapcore.DebugLevel)
+
+	pkgDTO := PackageDTO{
+		SourceFilePath: "test/package/BUILD.yaml",
+		Targets:        []*TargetDTO{{Name: "postgres", Command: "echo hi"}},
+		Resources:      []*ResourceDTO{{Name: "postgres", Up: "true"}},
+	}
+
+	if _, err := getEnrichedPackage(logger, "test/package", pkgDTO); err == nil {
+		t.Fatal("expected duplicate label error")
+	}
+}

--- a/internal/loading/load.go
+++ b/internal/loading/load.go
@@ -131,10 +131,19 @@ func mergePackages(from *model.Package, into *model.Package) error {
 	if into.Aliases == nil {
 		into.Aliases = make(map[label.TargetLabel]*model.Alias)
 	}
+	if into.Resources == nil {
+		into.Resources = make(map[label.TargetLabel]*model.Resource)
+	}
 
 	for fromTargetLabel, fromTarget := range from.Targets {
 		if intoTarget, exists := into.Targets[fromTargetLabel]; exists {
 			return fmt.Errorf("duplicate target label: %s (defined in %s and %s)", fromTargetLabel, intoTarget.SourceFilePath, fromTarget.SourceFilePath)
+		}
+		if intoAlias, exists := into.Aliases[fromTargetLabel]; exists {
+			return fmt.Errorf("duplicate target label: %s (defined in %s and as alias in %s)", fromTargetLabel, fromTarget.SourceFilePath, intoAlias.SourceFilePath)
+		}
+		if intoResource, exists := into.Resources[fromTargetLabel]; exists {
+			return fmt.Errorf("duplicate target label: %s (defined in %s and as resource in %s)", fromTargetLabel, fromTarget.SourceFilePath, intoResource.SourceFilePath)
 		}
 		into.Targets[fromTargetLabel] = fromTarget
 	}
@@ -146,7 +155,23 @@ func mergePackages(from *model.Package, into *model.Package) error {
 		if intoTarget, exists := into.Targets[fromAliasLabel]; exists {
 			return fmt.Errorf("duplicate alias label: %s (defined in %s and as target in %s)", fromAliasLabel, fromAlias.SourceFilePath, intoTarget.SourceFilePath)
 		}
+		if intoResource, exists := into.Resources[fromAliasLabel]; exists {
+			return fmt.Errorf("duplicate alias label: %s (defined in %s and as resource in %s)", fromAliasLabel, fromAlias.SourceFilePath, intoResource.SourceFilePath)
+		}
 		into.Aliases[fromAliasLabel] = fromAlias
+	}
+
+	for fromResourceLabel, fromResource := range from.Resources {
+		if intoResource, exists := into.Resources[fromResourceLabel]; exists {
+			return fmt.Errorf("duplicate resource label: %s (defined in %s and %s)", fromResourceLabel, intoResource.SourceFilePath, fromResource.SourceFilePath)
+		}
+		if intoTarget, exists := into.Targets[fromResourceLabel]; exists {
+			return fmt.Errorf("duplicate resource label: %s (defined in %s and as target in %s)", fromResourceLabel, fromResource.SourceFilePath, intoTarget.SourceFilePath)
+		}
+		if intoAlias, exists := into.Aliases[fromResourceLabel]; exists {
+			return fmt.Errorf("duplicate resource label: %s (defined in %s and as alias in %s)", fromResourceLabel, fromResource.SourceFilePath, intoAlias.SourceFilePath)
+		}
+		into.Resources[fromResourceLabel] = fromResource
 	}
 
 	return nil

--- a/internal/loading/load_test.go
+++ b/internal/loading/load_test.go
@@ -2,13 +2,16 @@ package loading
 
 import (
 	"fmt"
-	"grog/internal/console"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
+
+	"grog/internal/console"
+	"grog/internal/label"
+	"grog/internal/model"
 
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -222,6 +225,63 @@ func TestResolveInputs(t *testing.T) {
 
 			if !reflect.DeepEqual(actual, tc.expected) {
 				t.Errorf("Unexpected resolved inputs.\nExpected: %v\nActual:   %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestMergePackagesIncludesResources(t *testing.T) {
+	resourceLabel := label.TL("pkg", "database")
+	fromPackage := &model.Package{
+		Resources: map[label.TargetLabel]*model.Resource{
+			resourceLabel: {Label: resourceLabel, Up: "true"},
+		},
+	}
+	intoPackage := &model.Package{
+		Targets: map[label.TargetLabel]*model.Target{
+			label.TL("pkg", "consumer"): {Label: label.TL("pkg", "consumer")},
+		},
+	}
+
+	if err := mergePackages(fromPackage, intoPackage); err != nil {
+		t.Fatalf("failed to merge packages: %v", err)
+	}
+	if intoPackage.Resources[resourceLabel] == nil {
+		t.Fatal("resource was not merged")
+	}
+}
+
+func TestMergePackagesRejectsResourceTargetCollisionsInBothOrders(t *testing.T) {
+	resourceLabel := label.TL("pkg", "database")
+	testCases := []struct {
+		name        string
+		fromPackage *model.Package
+		intoPackage *model.Package
+	}{
+		{
+			name: "resource into target",
+			fromPackage: &model.Package{Resources: map[label.TargetLabel]*model.Resource{
+				resourceLabel: {Label: resourceLabel, SourceFilePath: "resource.yaml"},
+			}},
+			intoPackage: &model.Package{Targets: map[label.TargetLabel]*model.Target{
+				resourceLabel: {Label: resourceLabel, SourceFilePath: "target.yaml"},
+			}},
+		},
+		{
+			name: "target into resource",
+			fromPackage: &model.Package{Targets: map[label.TargetLabel]*model.Target{
+				resourceLabel: {Label: resourceLabel, SourceFilePath: "target.yaml"},
+			}},
+			intoPackage: &model.Package{Resources: map[label.TargetLabel]*model.Resource{
+				resourceLabel: {Label: resourceLabel, SourceFilePath: "resource.yaml"},
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := mergePackages(testCase.fromPackage, testCase.intoPackage); err == nil {
+				t.Fatal("expected duplicate label error")
 			}
 		})
 	}

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -23,10 +23,11 @@ func (sl StarlarkLoader) Matches(fileName string) bool {
 	return fileName == "BUILD.star" || fileName == "BUILD.bzl"
 }
 
-// starlarkPackageCollector holds the collected targets, aliases, and environments.
+// starlarkPackageCollector holds the collected targets, aliases, resources, and environments.
 type starlarkPackageCollector struct {
 	targets          []*TargetDTO
 	aliases          []*AliasDTO
+	resources        []*ResourceDTO
 	environments     []*EnvironmentDTO
 	defaultPlatforms []string
 }
@@ -44,6 +45,7 @@ func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO,
 	collector := &starlarkPackageCollector{
 		targets:      make([]*TargetDTO, 0),
 		aliases:      make([]*AliasDTO, 0),
+		resources:    make([]*ResourceDTO, 0),
 		environments: make([]*EnvironmentDTO, 0),
 	}
 
@@ -57,6 +59,7 @@ func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO,
 	predeclared := starlark.StringDict{
 		"target":      starlark.NewBuiltin("target", collector.targetBuiltin),
 		"alias":       starlark.NewBuiltin("alias", collector.aliasBuiltin),
+		"resource":    starlark.NewBuiltin("resource", collector.resourceBuiltin),
 		"environment": starlark.NewBuiltin("environment", collector.environmentBuiltin),
 		"json":        json.Module,
 		"math":        math.Module,
@@ -83,6 +86,7 @@ func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO,
 	packageDTO := PackageDTO{
 		Targets:          collector.targets,
 		Aliases:          collector.aliases,
+		Resources:        collector.resources,
 		Environments:     collector.environments,
 		DefaultPlatforms: collector.defaultPlatforms,
 	}
@@ -338,6 +342,56 @@ func (c *starlarkPackageCollector) aliasBuiltin(thread *starlark.Thread, fn *sta
 	}
 
 	c.aliases = append(c.aliases, alias)
+	return starlark.None, nil
+}
+
+// resourceBuiltin implements the resource() function in Starlark.
+func (c *starlarkPackageCollector) resourceBuiltin(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	var up string
+	var down string
+	var ready string
+	var timeout string
+	var exports *starlark.Dict
+	var dependencies *starlark.List
+
+	if err := starlark.UnpackArgs("resource", args, kwargs,
+		"name", &name,
+		"up", &up,
+		"down?", &down,
+		"ready?", &ready,
+		"timeout?", &timeout,
+		"exports?", &exports,
+		"dependencies?", &dependencies,
+	); err != nil {
+		return nil, err
+	}
+
+	resource := &ResourceDTO{
+		Name:    name,
+		Up:      up,
+		Down:    down,
+		Ready:   ready,
+		Timeout: timeout,
+	}
+
+	if exports != nil {
+		exportMap, err := starlarkDictToStringMap(exports)
+		if err != nil {
+			return nil, fmt.Errorf("exports: %w", err)
+		}
+		resource.Exports = exportMap
+	}
+
+	if dependencies != nil {
+		deps, err := starlarkListToStringSlice(dependencies)
+		if err != nil {
+			return nil, fmt.Errorf("dependencies: %w", err)
+		}
+		resource.Dependencies = deps
+	}
+
+	c.resources = append(c.resources, resource)
 	return starlark.None, nil
 }
 

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -139,6 +139,7 @@ func (sl StarlarkLoader) loadModule(thread *starlark.Thread, module string, curr
 	predeclared := starlark.StringDict{
 		"target":      starlark.NewBuiltin("target", collector.targetBuiltin),
 		"alias":       starlark.NewBuiltin("alias", collector.aliasBuiltin),
+		"resource":    starlark.NewBuiltin("resource", collector.resourceBuiltin),
 		"environment": starlark.NewBuiltin("environment", collector.environmentBuiltin),
 		"json":        json.Module,
 		"math":        math.Module,

--- a/internal/model/build_node.go
+++ b/internal/model/build_node.go
@@ -6,8 +6,9 @@ import "grog/internal/label"
 type NodeType string
 
 const (
-	TargetNode NodeType = "target"
-	AliasNode  NodeType = "alias"
+	TargetNode   NodeType = "target"
+	AliasNode    NodeType = "alias"
+	ResourceNode NodeType = "resource"
 )
 
 // BuildNode represents a node in the build graph. It is implemented by

--- a/internal/model/build_node_map.go
+++ b/internal/model/build_node_map.go
@@ -25,6 +25,12 @@ func BuildNodeMapFromPackages(packages []*Package) (BuildNodeMap, error) {
 			}
 			nodes[a.Label] = a
 		}
+		for _, r := range pkg.GetResources() {
+			if _, ok := nodes[r.Label]; ok {
+				return nil, fmt.Errorf("duplicate target label: %s", r.Label)
+			}
+			nodes[r.Label] = r
+		}
 	}
 	return nodes, nil
 }

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -11,8 +11,9 @@ type Package struct {
 	// Record the path to this package relative to the workspace root
 	Path string
 
-	Targets map[label.TargetLabel]*Target `json:"targets"`
-	Aliases map[label.TargetLabel]*Alias  `json:"aliases"`
+	Targets   map[label.TargetLabel]*Target   `json:"targets"`
+	Aliases   map[label.TargetLabel]*Alias    `json:"aliases"`
+	Resources map[label.TargetLabel]*Resource `json:"resources"`
 }
 
 func (p *Package) GetTargets() []*Target {
@@ -21,4 +22,8 @@ func (p *Package) GetTargets() []*Target {
 
 func (p *Package) GetAliases() []*Alias {
 	return slices.Collect(maps.Values(p.Aliases))
+}
+
+func (p *Package) GetResources() []*Resource {
+	return slices.Collect(maps.Values(p.Resources))
 }

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"time"
+
+	"grog/internal/label"
+)
+
+var _ BuildNode = &Resource{}
+
+// Resource is a build node that manages the lifecycle of a shared external
+// helper (e.g. a database container) instead of producing outputs. It is
+// started at most once per invocation when the first dependent target
+// executes and torn down when the build finishes. Resources are never cached
+// and do not contribute to the change hash of their dependents.
+type Resource struct {
+	// The file in which this resource was defined
+	SourceFilePath string `json:"-"`
+
+	Label label.TargetLabel `json:"label"`
+
+	// Up is the command that starts the resource. It must return once the
+	// resource is started (daemonized), not block for its lifetime.
+	Up string `json:"up"`
+	// Down is the optional command that tears the resource down.
+	Down string `json:"down,omitempty"`
+	// Ready is an optional probe command that is polled until it exits 0
+	// before dependents may run.
+	Ready string `json:"ready,omitempty"`
+	// Timeout bounds the start phase (up + ready polling) and, separately,
+	// the down command. Zero means DefaultResourceTimeout.
+	Timeout time.Duration `json:"timeout,omitempty"`
+
+	// Exports are environment variables published to the commands of targets
+	// that directly depend on this resource. The up command can add or
+	// override entries by appending KEY=VALUE lines to the file at
+	// $GROG_RESOURCE_EXPORTS_FILE.
+	Exports map[string]string `json:"exports,omitempty"`
+
+	Dependencies []label.TargetLabel `json:"dependencies,omitempty"`
+
+	IsSelected bool `json:"is_selected,omitempty"`
+}
+
+// DefaultResourceTimeout is used when a resource does not declare a timeout.
+const DefaultResourceTimeout = 5 * time.Minute
+
+func (r *Resource) GetType() NodeType { return ResourceNode }
+
+func (r *Resource) GetLabel() label.TargetLabel { return r.Label }
+
+func (r *Resource) GetDependencies() []label.TargetLabel { return r.Dependencies }
+
+func (r *Resource) Select() { r.IsSelected = true }
+
+func (r *Resource) GetIsSelected() bool { return r.IsSelected }
+
+func (r *Resource) GetTimeout() time.Duration {
+	if r.Timeout > 0 {
+		return r.Timeout
+	}
+	return DefaultResourceTimeout
+}

--- a/pkl/package.pkl
+++ b/pkl/package.pkl
@@ -34,10 +34,25 @@ class Target {
   concurrency_group: String?
 }
 
+class Resource {
+  name: String
+  // up starts the resource and must return once it is running (daemonized).
+  up: String
+  down: String?
+  // ready is polled until it exits 0 before dependents may run.
+  ready: String?
+  timeout: String?
+  // exports are environment variables published to directly dependent targets.
+  exports: Mapping<String, String>?
+  dependencies: Listing<String>(isDistinct)
+}
+
 default_platforms: Listing<String>(isDistinct)?
 
 targets: Listing<Target>(isDistinctBy((it) -> it.name))
 
 aliases: Listing<alias>(isDistinctBy((it) -> it.name))?
+
+resources: Listing<Resource>(isDistinctBy((it) -> it.name))?
 
 environments: Listing<alias>(isDistinctBy((it) -> it.name))?


### PR DESCRIPTION
Shared build helpers — a Postgres test container, an emulator, a local registry — are not build artifacts: they have a lifecycle rather than an output, and N consumers need exactly one instance. Today they can only be modelled as targets, so every build/test starts its own copy and nothing tears them down. This adds `resources` as a new build node type, wired through ordinary `dependencies`.

## Behavior

- Starts **lazily and at most once per invocation** (singleflight-deduped by the first cache-missing dependent), gates dependents on an optional `ready` probe, and tears down in reverse start order on success, failure, and interrupt.
- Publishes `exports` into dependent target environments; the `up` hook can append `KEY=VALUE` to `$GROG_RESOURCE_EXPORTS_FILE` for values only known at startup (e.g. an allocated port). Hooks also get `GROG_RESOURCE_ID`, a label+definition hash that keeps container names stable across runs but rotates when the definition changes.
- **Never cached, and contributes nothing to a dependent's change hash** — resources are ambient runtime dependencies, so restarting one never invalidates a target. Consumers that must invalidate on a resource's identity declare it in `fingerprint`.

## Notes

- v1 covers per-invocation scope. Deferred: `scope: shared` across invocations with adoption + `grog resource ls|down`, `grog run` support, and Makefile-annotation syntax.
- Unit tests cover start-once-under-concurrency, ready polling/timeout, reverse-order and idempotent teardown, failed-start cleanup, and loader parsing; the integration scenario's two fixtures pin the headline behaviors (resource starts and stops around two consumers; warm rebuild is all cache hits with no resource activity).
- Full integration suite, linter, `pkl project package`, and the docs build pass locally. The `changes_repos` scenario fails on my machine only because `jj` isn't installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)