### PR TITLE
docs: show every build file example in synced YAML/Starlark/Pkl tabs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -54,6 +54,10 @@ export default defineConfig({
       expressiveCode: {
         shiki: {
           langs: [JSON.parse(fs.readFileSync("./pkl_grammar.json", "utf-8"))],
+          langAlias: {
+            starlark: "python",
+            Makefile: "makefile",
+          },
         },
       },
     }),

--- a/docs/src/content/docs/build-configuration.mdx
+++ b/docs/src/content/docs/build-configuration.mdx
@@ -22,8 +22,9 @@ You can configure Grog builds in four different ways:
 
 The simplest way to define your build targets is to create a `BUILD.json` or `BUILD.yaml` file in your package directory. This file defines all build targets for that package in your monorepo.
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
+
 ```yaml
 targets:
   - name: build_app
@@ -37,27 +38,26 @@ targets:
     outputs:
       - dist/bundle.js
 
-- name: generate_proto
-  command: "protoc --js_out=src/generated proto/\*.proto"
-  inputs:
-  - proto/\*.proto
+  - name: generate_proto
+    command: protoc --js_out=src/generated proto/*.proto
+    inputs:
+      - proto/*.proto
     outputs:
-  - dir::src/generated
+      - dir::src/generated
+```
 
-````
 Save this as `BUILD.yaml` in your project directory.
+
   </TabItem>
   <TabItem label="JSON">
+
 ```json
 {
   "targets": [
     {
       "name": "build_app",
       "command": "npm run build",
-      "dependencies": [
-        ":generate_proto",
-        "//path/to/other/package:target_name"
-      ],
+      "dependencies": [":generate_proto", "//path/to/other/package:target_name"],
       "inputs": ["src/**/*.js", "package.json"],
       "outputs": ["dist/bundle.js"]
     },
@@ -69,7 +69,7 @@ Save this as `BUILD.yaml` in your project directory.
     }
   ]
 }
-````
+```
 
 Save this as `BUILD.json` in your project directory.
 
@@ -78,11 +78,39 @@ Save this as `BUILD.json` in your project directory.
 
 You can also define simple **aliases** that point to other targets:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 aliases:
   - name: default
     actual: :build_app
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+alias(
+    name = "default",
+    actual = ":build_app",
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+aliases {
+  new {
+    name = "default"
+    actual = ":build_app"
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 Running `grog build :default` would build `:build_app`.
 
@@ -131,7 +159,7 @@ This Makefile exposes the targets `build_app` and `generate_proto` to Grog, allo
 
 Here's the same build configuration as above, but using Starlark:
 
-```python
+```starlark
 # BUILD.star
 target(
     name = "build_app",
@@ -161,7 +189,7 @@ Save this as `BUILD.star` or `BUILD.bzl` in your project directory.
 
 One of Starlark's key features is the ability to create reusable macros using functions. For example, if you want a standard setup for TypeScript projects that includes build, test, and format targets:
 
-```python
+```starlark
 # rules.star
 def ts_package(name, srcs = [], deps = []):
     """Creates a TypeScript package with build, test, and format targets."""
@@ -192,7 +220,7 @@ def ts_package(name, srcs = [], deps = []):
 
 You can then use this macro in your BUILD files:
 
-```python
+```starlark
 # packages/example/BUILD.star
 load("//rules.star", "ts_package")
 
@@ -229,7 +257,7 @@ As your codebase grows, maintaining consistent build configurations across packa
 Here's the same build configuration as above, but using Pkl:
 
 ```Pkl
-amends "package://grog.build/releases/v0.16.1/grog@0.16.1#/package.pkl"
+amends "package://grog.build/releases/v0.44.0/grog@0.44.0#/package.pkl"
 
 targets {
   new {
@@ -267,7 +295,7 @@ One of Pkl's strengths is the ability to create reusable build macros.
 For example, if you want a standard setup for Next.js projects that includes installing dependencies and building the app, you can create a reusable macro:
 
 ```Pkl
-import "package://grog.build/releases/v0.16.1/grog@0.16.1#/package.pkl"
+import "package://grog.build/releases/v0.44.0/grog@0.44.0#/package.pkl"
 
 // Create a function that returns
 // a list of targets for a Next.js app

--- a/docs/src/content/docs/get-started.mdx
+++ b/docs/src/content/docs/get-started.mdx
@@ -60,7 +60,7 @@ Refer to the [configuration reference](/reference/configuration) to see all avai
 Each target is a **command** that runs when its file **inputs** or **dependencies** change.
 Grog provides a wide array of build file formats:
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -204,7 +204,7 @@ Save this as `BUILD.star` in your project directory.
 <TabItem label="Pkl">
 
 ```Pkl
-amends "package://grog.build/releases/v0.9.3/grog@0.9.3#/package.pkl"
+amends "package://grog.build/releases/v0.44.0/grog@0.44.0#/package.pkl"
 
 targets {
   new {
@@ -336,12 +336,40 @@ You can find the complete target configuration reference [here](/reference/targe
 Inputs are files that your build target depends on. When any of these files change, Grog will re-run the target's command.
 You can specify inputs using file paths or glob patterns:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 inputs:
   - "src/**/*.js"
   - package.json
   - "assets/*.{png,jpg}"
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+inputs = [
+    "src/**/*.js",
+    "package.json",
+    "assets/*.{png,jpg}",
+],
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+inputs {
+  "src/**/*.js"
+  "package.json"
+  "assets/*.{png,jpg}"
+}
+```
+
+  </TabItem>
+</Tabs>
 
 - `src/**/*.js` - All JavaScript files in src directory and subdirectories
 - `package.json` - A specific file
@@ -360,11 +388,37 @@ This allows it to detect changes and only rebuild when necessary.
 Dependencies are other targets that must be built before the current target.
 This creates a directed acyclic graph (DAG) of build steps:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 dependencies:
   - :generate_proto
   - //lib:build_lib
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+dependencies = [
+    ":generate_proto",
+    "//lib:build_lib",
+],
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+dependencies {
+  ":generate_proto"
+  "//lib:build_lib"
+}
+```
+
+  </TabItem>
+</Tabs>
 
 - `generate_proto` - A dependency on another target in the same package
 - `//lib:build_lib` - A dependency on a target in another package
@@ -380,12 +434,40 @@ When you specify dependencies:
 Outputs are artifacts that your build target produces and who you might want to share between machines using a remote cache.
 Grog, therefore, caches these outputs and restores them when possible to avoid unnecessary rebuilds.
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 outputs:
   - dist/bundle.js
   - dir::dist/assets/
   - oci::some-image
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+outputs = [
+    "dist/bundle.js",
+    "dir::dist/assets/",
+    "oci::some-image",
+],
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+outputs {
+  "dist/bundle.js"
+  "dir::dist/assets/"
+  "oci::some-image"
+}
+```
+
+  </TabItem>
+</Tabs>
 
 - `dist/bundle.js` - A file output
 - `dir::dist/assets/` - A directory output

--- a/docs/src/content/docs/reference/target-aliases.mdx
+++ b/docs/src/content/docs/reference/target-aliases.mdx
@@ -3,6 +3,8 @@ title: Target Aliases
 description: Use aliases to create alternative labels pointing to existing targets.
 ---
 
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
 A **target alias** is a lightweight entry in a `BUILD` file that simply points to another target.
 It has its own label but no command or outputs. When you build an alias, Grog will
 transparently build the aliased target.
@@ -16,10 +18,38 @@ transparently build the aliased target.
 
 ## Example
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 aliases:
   - name: default
     actual: :build_app
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+alias(
+    name = "default",
+    actual = ":build_app",
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+aliases {
+  new {
+    name = "default"
+    actual = ":build_app"
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 Running `grog build :default` would build the `:build_app` target.

--- a/docs/src/content/docs/reference/target-configuration.mdx
+++ b/docs/src/content/docs/reference/target-configuration.mdx
@@ -3,7 +3,7 @@ title: Target Configuration
 description: Targets define what builds to run and how. This reference covers all the configuration options for a target.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Overview
 
@@ -109,6 +109,9 @@ Examples:
 
 A map from the local name of an `oci::` output to one or more remote registry destinations to ship it to under `grog build --push`. See [Docker (OCI) Outputs › Pushing images](/topics/docker-outputs#pushing-images) for the full story; the short version:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 outputs:
   - oci::api
@@ -119,16 +122,73 @@ oci_push:
     - registry.org/worker:latest
 ```
 
-The destination tag is **not** part of the cache key, so bumping `${VERSION}` reuses the cached image and only re-runs the push.
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+outputs = ["oci::api"],
+oci_push = {
+    # single destination
+    "api": "registry.org/api:" + GROG_GIT_HASH,
+    # multi-destination
+    "worker": [
+        "registry.org/worker:" + GROG_GIT_HASH,
+        "registry.org/worker:latest",
+    ],
+},
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+outputs { "oci::api" }
+oci_push {
+  // single destination
+  ["api"] { "registry.org/api:\(read("env:GROG_GIT_HASH").text)" }
+  // multi-destination
+  ["worker"] {
+    "registry.org/worker:\(read("env:GROG_GIT_HASH").text)"
+    "registry.org/worker:latest"
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+The destination tag is **not** part of the cache key, so bumping the destination tag reuses the cached image and only re-runs the push.
 
 ### binary_requires_push
 
 When set to `true`, running the target's binary with `grog run` fails unless the `--push` flag is provided. This is useful for release-style binaries whose side effects (publishing artifacts, deploying) should only happen on an explicit `grog run --push`.
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 bin_output: ./release.sh
 binary_requires_push: true
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+bin_output = "./release.sh",
+binary_requires_push = True,
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+bin_output = "./release.sh"
+binary_requires_push = true
+```
+
+  </TabItem>
+</Tabs>
 
 ### dependencies
 
@@ -165,6 +225,9 @@ There are a few reserved tags that alter the way grog treats a target:
 
 `fingerprint` lets you inject additional pieces of identity that should bust the cache even when none of the declared inputs change. Each key/value pair is fed into the target definition hash, so modifying any entry forces a rebuild on the next run.
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   - name: publish
@@ -173,6 +236,39 @@ targets:
       release_channel: "stable"
       node_version: "22.1.0"
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "publish",
+    command = "npm publish --tag $RELEASE_CHANNEL",
+    fingerprint = {
+        "release_channel": "stable",
+        "node_version": "22.1.0",
+    },
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "publish"
+    command = "npm publish --tag $RELEASE_CHANNEL"
+    fingerprint {
+      ["release_channel"] = "stable"
+      ["node_version"] = "22.1.0"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 In the example above, bumping `node_version` will change the computed change hash despite the command and inputs staying the same. This is useful for build metadata like compiler versions or environment-provided secrets.
 
@@ -200,10 +296,39 @@ Optional name of a concurrency group. At most `capacity` members of a group run 
 
 Group capacities are configured workspace-wide in `grog.toml` under `[concurrency_groups]` (see [Configuration → Concurrency Groups](/reference/configuration/#concurrency-groups)). Use groups for shared external resources — a single docker daemon, a test database, a GPU, a bound port — where the contention is not expressible as a target dependency.
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
+```yaml
+targets:
+  - name: image
+    command: docker build -t myapp .
+    concurrency_group: docker
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "image",
+    command = "docker build -t myapp .",
+    concurrency_group = "docker",
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
 ```pkl
-new Target {
-  name = "image"
-  concurrency_group = "docker"
-  command = "docker build -t myapp ."
+targets {
+  new {
+    name = "image"
+    command = "docker build -t myapp ."
+    concurrency_group = "docker"
+  }
 }
 ```
+
+  </TabItem>
+</Tabs>

--- a/docs/src/content/docs/reference/target-configuration.mdx
+++ b/docs/src/content/docs/reference/target-configuration.mdx
@@ -115,6 +115,7 @@ A map from the local name of an `oci::` output to one or more remote registry de
 ```yaml
 outputs:
   - oci::api
+  - oci::worker
 oci_push:
   api: registry.org/api:${VERSION} # single destination
   worker: # multi-destination
@@ -126,7 +127,7 @@ oci_push:
   <TabItem label="Starlark">
 
 ```starlark
-outputs = ["oci::api"],
+outputs = ["oci::api", "oci::worker"],
 oci_push = {
     # single destination
     "api": "registry.org/api:" + GROG_GIT_HASH,
@@ -142,7 +143,7 @@ oci_push = {
   <TabItem label="Pkl">
 
 ```pkl
-outputs { "oci::api" }
+outputs { "oci::api" ; "oci::worker" }
 oci_push {
   // single destination
   ["api"] { "registry.org/api:\(read("env:GROG_GIT_HASH").text)" }

--- a/docs/src/content/docs/topics/binary-outputs.mdx
+++ b/docs/src/content/docs/topics/binary-outputs.mdx
@@ -3,7 +3,7 @@ title: Binary and Tool Outputs
 description: Learn how to manage build tools and executables in your Grog build process for better reproducibility.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Managing Build Tools
 
@@ -30,6 +30,9 @@ Each target can specify a single `bin_output` field that points to a file output
 
 ### Example: Creating and Using a Binary Tool
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   # Target that builds a tool
@@ -54,6 +57,73 @@ targets:
     outputs:
       - dir::generated
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+# Target that builds a tool
+target(
+    name = "protoc_compiler",
+    command = """
+    curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip -o protoc.zip
+    unzip protoc.zip -d protoc
+    chmod +x protoc/bin/protoc
+    """,
+    outputs = ["dir::protoc/include/google/protobuf/"],
+    bin_output = "protoc/bin/protoc",
+)
+
+# Target that uses the tool
+target(
+    name = "generate_protos",
+    dependencies = [":protoc_compiler"],
+    inputs = ["proto/*.proto"],
+    # Use the binary tool with $(bin :target_name)
+    command = "$(bin :protoc_compiler) --cpp_out=generated proto/*.proto",
+    outputs = ["dir::generated"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  // Target that builds a tool
+  new {
+    name = "protoc_compiler"
+    command = """
+      curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip -o protoc.zip
+      unzip protoc.zip -d protoc
+      chmod +x protoc/bin/protoc
+      """
+    outputs {
+      "dir::protoc/include/google/protobuf/"
+    }
+    bin_output = "protoc/bin/protoc"
+  }
+
+  // Target that uses the tool
+  new {
+    name = "generate_protos"
+    dependencies {
+      ":protoc_compiler"
+    }
+    inputs {
+      "proto/*.proto"
+    }
+    // Use the binary tool with $(bin :target_name)
+    command = "$(bin :protoc_compiler) --cpp_out=generated proto/*.proto"
+    outputs {
+      "dir::generated"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 ### Running Binary Tools Directly
 
@@ -92,10 +162,13 @@ Say, for instance, that you have a shell or python script that you want to use a
 To do so all you need to do is omit the command field and add the `no-cache` attribute to ensure that grog does not store the script file in its cache.
 Here is what that could look like:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   # Assuming that this script exists in
-  # the same directory as the build filr
+  # the same directory as the build file
   - name: protoc_compiler_script
     inputs:
       - compile.sh
@@ -115,6 +188,67 @@ targets:
       - dir::generated
 ```
 
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+# Assuming that this script exists in
+# the same directory as the build file
+target(
+    name = "protoc_compiler_script",
+    inputs = ["compile.sh"],
+    bin_output = "compile.sh",
+    tags = ["no-cache"],
+)
+
+target(
+    name = "generate_protos",
+    dependencies = [":protoc_compiler_script"],
+    inputs = ["proto/*.proto"],
+    # Use the binary tool with $(bin :target_name)
+    command = "$(bin :protoc_compiler_script) --cpp_out=generated proto/*.proto",
+    outputs = ["dir::generated"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  // Assuming that this script exists in
+  // the same directory as the build file
+  new {
+    name = "protoc_compiler_script"
+    inputs {
+      "compile.sh"
+    }
+    bin_output = "compile.sh"
+    tags {
+      "no-cache"
+    }
+  }
+
+  new {
+    name = "generate_protos"
+    dependencies {
+      ":protoc_compiler_script"
+    }
+    inputs {
+      "proto/*.proto"
+    }
+    // Use the binary tool with $(bin :target_name)
+    command = "$(bin :protoc_compiler_script) --cpp_out=generated proto/*.proto"
+    outputs {
+      "dir::generated"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
 This makes it easy to share scripts across your workspace without having to invoke them by their relative file path.
 
 ## Output Checks
@@ -130,6 +264,9 @@ This is the life-cycle of a target's execution with output checks:
 It is therefore recommended to keep output checks as light and fast as possible.
 
 ### How to Define Output Checks
+
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
 
 ```yaml
 targets:
@@ -167,6 +304,103 @@ targets:
     outputs:
       - dist/bundle.js
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "ensure_nvm",
+    command = "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash",
+    # The target will fail if this command
+    # returns a non-zero exit code
+    output_checks = [
+        {"command": "nvm --version"},
+    ],
+)
+
+target(
+    name = "ensure_node_22",
+    command = "nvm install 22",
+    # If specified, grog will run this command everytime the tool
+    # is used to check that it has the correct version
+    output_checks = [
+        {"command": "node --version", "expected_output": "v20.11.1"},
+        {"command": "npm --version", "expected_output": "10.2.4"},
+    ],
+    dependencies = [":ensure_nvm"],
+)
+
+target(
+    name = "build_js",
+    dependencies = [":ensure_node_22"],
+    # Node is now guaranteed to be available
+    command = "node build.js",
+    inputs = [
+        "src/**/*.js",
+        "package.json",
+    ],
+    outputs = ["dist/bundle.js"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "ensure_nvm"
+    command = "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash"
+    // The target will fail if this command
+    // returns a non-zero exit code
+    output_checks {
+      new {
+        command = "nvm --version"
+      }
+    }
+  }
+
+  new {
+    name = "ensure_node_22"
+    command = "nvm install 22"
+    // If specified, grog will run this command everytime the tool
+    // is used to check that it has the correct version
+    output_checks {
+      new {
+        command = "node --version"
+        expected_output = "v20.11.1"
+      }
+      new {
+        command = "npm --version"
+        expected_output = "10.2.4"
+      }
+    }
+    dependencies {
+      ":ensure_nvm"
+    }
+  }
+
+  new {
+    name = "build_js"
+    dependencies {
+      ":ensure_node_22"
+    }
+    // Node is now guaranteed to be available
+    command = "node build.js"
+    inputs {
+      "src/**/*.js"
+      "package.json"
+    }
+    outputs {
+      "dist/bundle.js"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 In this example, the `ensure_node` target verifies that `node` is available in the PATH.
 If it's not, the command installs it.

--- a/docs/src/content/docs/topics/docker-outputs.mdx
+++ b/docs/src/content/docs/topics/docker-outputs.mdx
@@ -96,6 +96,9 @@ When using the registry backend, Grog expects your current session to be authent
 
 Once your Docker storage is set up, you can define container image outputs for your targets. The prefix is `oci::` regardless of which tool builds the image:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   - name: build_api_image
@@ -112,9 +115,57 @@ targets:
       - oci::api-service:latest
 ```
 
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "build_api_image",
+    inputs = [
+        "Dockerfile",
+        "src/**/*.go",
+        "go.mod",
+        "go.sum",
+    ],
+    # Build the Docker image
+    command = "docker build -t api-service:latest .",
+    # Cache the local image
+    outputs = ["oci::api-service:latest"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "build_api_image"
+    inputs {
+      "Dockerfile"
+      "src/**/*.go"
+      "go.mod"
+      "go.sum"
+    }
+    // Build the Docker image
+    command = "docker build -t api-service:latest ."
+    // Cache the local image
+    outputs {
+      "oci::api-service:latest"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
+
 ## Using Docker Images in Dependent Targets
 
 You can use Docker images built by one target in dependent targets:
+
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
 
 ```yaml
 targets:
@@ -127,7 +178,6 @@ targets:
       - oci::api-service:latest
 
   - name: integration_test
-
     dependencies:
       - :build_api_image
     command: |
@@ -136,6 +186,67 @@ targets:
       # Run tests against the image
       go test -tags=integration ./tests/...
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "build_api_image",
+    inputs = [
+        "Dockerfile",
+        "src/**/*.go",
+    ],
+    command = "docker build -t api-service:latest .",
+    outputs = ["oci::api-service:latest"],
+)
+
+target(
+    name = "integration_test",
+    dependencies = [":build_api_image"],
+    command = """
+    # The api-service image is now available locally
+    docker run --rm api-service:latest --version
+    # Run tests against the image
+    go test -tags=integration ./tests/...
+    """,
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "build_api_image"
+    inputs {
+      "Dockerfile"
+      "src/**/*.go"
+    }
+    command = "docker build -t api-service:latest ."
+    outputs {
+      "oci::api-service:latest"
+    }
+  }
+
+  new {
+    name = "integration_test"
+    dependencies {
+      ":build_api_image"
+    }
+    command = """
+      # The api-service image is now available locally
+      docker run --rm api-service:latest --version
+      # Run tests against the image
+      go test -tags=integration ./tests/...
+      """
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 ## Pushing images
 
@@ -149,7 +260,24 @@ predeclared `GROG_GIT_HASH` variable directly into the destination string
 (YAML has no built-in interpolation, so you'd have to template the file
 yourself).
 
-<Tabs>
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
+```yaml
+targets:
+  - name: build_api_image
+    command: docker build -t api-service .
+    inputs:
+      - Dockerfile
+      - src/**/*.go
+    outputs:
+      - oci::api-service
+    oci_push:
+      # No interpolation in YAML — use a static destination tag
+      api-service: us-east1-docker.pkg.dev/proj/api:latest
+```
+
+  </TabItem>
   <TabItem label="Starlark">
 
 ```starlark
@@ -168,8 +296,8 @@ target(
   </TabItem>
   <TabItem label="Pkl">
 
-```Pkl
-amends "package://grog.build/releases/<version>/grog@<version>#/package.pkl"
+```pkl
+amends "package://grog.build/releases/v0.44.0/grog@0.44.0#/package.pkl"
 
 targets {
   new {

--- a/docs/src/content/docs/topics/grog-scripts.mdx
+++ b/docs/src/content/docs/topics/grog-scripts.mdx
@@ -3,7 +3,7 @@ title: Grog Scripts
 description: Learn how to turn annotated shell and Python scripts into first-class Grog targets that are easy to share and run.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## What are Grog Scripts?
 
@@ -66,8 +66,33 @@ Use `--` to forward additional parameters to the script.
 
 Before this feature you would have to define a wrapper target that defines the existing script file as an executable target with a `bin_output` like so:
 
-```Pkl
-amends "package://grog.build/releases/v0.16.1/grog@0.16.1#/package.pkl"
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
+```yaml
+targets:
+  - name: your_script
+    bin_output: script_file.sh
+    tags:
+      - no-cache
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "your_script",
+    bin_output = "script_file.sh",
+    tags = ["no-cache"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+amends "package://grog.build/releases/v0.44.0/grog@0.44.0#/package.pkl"
 
 targets {
   new {
@@ -79,5 +104,8 @@ targets {
   }
 }
 ```
+
+  </TabItem>
+</Tabs>
 
 While this is less convenient and arguably a bit awkward, since there is no actual build step, it can still be useful in case you want to keep your build configuration separate from your scripts.

--- a/docs/src/content/docs/topics/multi-platform-builds.mdx
+++ b/docs/src/content/docs/topics/multi-platform-builds.mdx
@@ -3,7 +3,7 @@ title: Multiplatform Builds
 description: Learn how to build for multiple platforms using Grog's platform selectors and cross-compilation strategies.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Building for Multiple Platforms
 
@@ -24,6 +24,9 @@ When a target doesn't match the current host's platform, Grog will **skip** it a
 ### Defining Platform Selectors
 
 You can specify platform requirements using the `platforms` field:
+
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
 
 ```yaml
 default_platforms:
@@ -50,6 +53,77 @@ targets:
     outputs:
       - dist/myapp-darwin-arm64
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+# Starlark has no package-level default_platforms; set platforms per target
+target(
+    name = "build_linux_amd64",
+    command = "go build -o dist/myapp-linux-amd64 ./cmd/myapp",
+    platforms = ["linux/amd64"],
+    inputs = [
+        "cmd/**/*.go",
+        "go.mod",
+    ],
+    outputs = ["dist/myapp-linux-amd64"],
+)
+
+target(
+    name = "build_darwin_arm64",
+    command = "go build -o dist/myapp-darwin-arm64 ./cmd/myapp",
+    platforms = ["darwin/arm64"],
+    inputs = [
+        "cmd/**/*.go",
+        "go.mod",
+    ],
+    outputs = ["dist/myapp-darwin-arm64"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+default_platforms {
+  "linux/amd64"
+}
+
+targets {
+  // default_platforms is applied here
+  new {
+    name = "build_linux_amd64"
+    command = "go build -o dist/myapp-linux-amd64 ./cmd/myapp"
+    inputs {
+      "cmd/**/*.go"
+      "go.mod"
+    }
+    outputs {
+      "dist/myapp-linux-amd64"
+    }
+  }
+
+  new {
+    name = "build_darwin_arm64"
+    command = "go build -o dist/myapp-darwin-arm64 ./cmd/myapp"
+    // This overrides default_platforms
+    platforms {
+      "darwin/arm64"
+    }
+    inputs {
+      "cmd/**/*.go"
+      "go.mod"
+    }
+    outputs {
+      "dist/myapp-darwin-arm64"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 In this example:
 
@@ -85,6 +159,9 @@ internal-only build box, or a CI runner with privileged credentials).
 
 Add a custom tag to a target's `platforms` list. A target with a tag-only `platforms` list is also valid.
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   - name: gpu_train
@@ -105,6 +182,67 @@ targets:
     inputs:
       - publish.sh
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "gpu_train",
+    command = "python train.py",
+    platforms = [
+        "linux/amd64",  # auto-detected platform identifier
+        "gpu-runner",  # custom platform tag
+    ],
+    inputs = ["train.py"],
+    outputs = ["model.pt"],
+)
+
+target(
+    name = "secrets_publish",
+    command = "./publish.sh",
+    # Only ever runs on hosts that opt into the "release" tag.
+    platforms = ["release"],
+    inputs = ["publish.sh"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "gpu_train"
+    command = "python train.py"
+    platforms {
+      "linux/amd64" // auto-detected platform identifier
+      "gpu-runner" // custom platform tag
+    }
+    inputs {
+      "train.py"
+    }
+    outputs {
+      "model.pt"
+    }
+  }
+
+  new {
+    name = "secrets_publish"
+    command = "./publish.sh"
+    // Only ever runs on hosts that opt into the "release" tag.
+    platforms {
+      "release"
+    }
+    inputs {
+      "publish.sh"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 `gpu_train` will run on any `linux/amd64` host **or** on any host with the `gpu-runner` platform tag enabled.
 `secrets_publish` runs only on hosts that explicitly enable the `release` tag.
@@ -138,6 +276,9 @@ Inside target commands, the active tags are also exposed as `GROG_PLATFORM_TAGS`
 
 When a target depends on a platform-specific target, Grog enforces platform compatibility:
 
+<Tabs syncKey="build-file-format">
+  <TabItem label="YAML">
+
 ```yaml
 targets:
   - name: linux_binary
@@ -156,6 +297,61 @@ targets:
     outputs:
       - dist/myapp-linux.tar.gz
 ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "linux_binary",
+    command = "go build -o dist/myapp-linux ./cmd/myapp",
+    platforms = ["linux/amd64"],
+    outputs = ["dist/myapp-linux"],
+)
+
+target(
+    name = "package_linux",
+    dependencies = [":linux_binary"],
+    command = "tar -czf dist/myapp-linux.tar.gz dist/myapp-linux",
+    platforms = ["linux/amd64"],
+    outputs = ["dist/myapp-linux.tar.gz"],
+)
+```
+
+  </TabItem>
+  <TabItem label="Pkl">
+
+```pkl
+targets {
+  new {
+    name = "linux_binary"
+    command = "go build -o dist/myapp-linux ./cmd/myapp"
+    platforms {
+      "linux/amd64"
+    }
+    outputs {
+      "dist/myapp-linux"
+    }
+  }
+
+  new {
+    name = "package_linux"
+    dependencies {
+      ":linux_binary"
+    }
+    command = "tar -czf dist/myapp-linux.tar.gz dist/myapp-linux"
+    platforms {
+      "linux/amd64"
+    }
+    outputs {
+      "dist/myapp-linux.tar.gz"
+    }
+  }
+}
+```
+
+  </TabItem>
+</Tabs>
 
 If you try to build `package_linux` on a non-Linux platform, Grog will fail with an error because the dependency `linux_binary` cannot be built on the current platform.
 

--- a/docs/src/content/docs/topics/sandboxing.mdx
+++ b/docs/src/content/docs/topics/sandboxing.mdx
@@ -18,7 +18,7 @@ This will allow you
 An environment configuration exists on the build graph, but is distinct from targets.
 You can define a docker environment like so:
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
     ```yaml
     targets:
@@ -34,6 +34,52 @@ You can define a docker environment like so:
         defaults:
           mount_dependencies: transitive # or: none, direct
           mount_dependency_inputs: true # whether to also mount the input files of dependencies
+    ```
+
+  </TabItem>
+  <TabItem label="Starlark">
+    ```starlark
+    target(
+        name = "foo",
+        # ...
+    )
+
+    environment(
+        name = "arm64",
+        type = "docker",
+        dependencies = ["arm64-image"],
+        oci_image = "arm64-builder",
+        defaults = {
+            "mount_dependencies": "transitive",  # or: "none", "direct"
+            "mount_dependency_inputs": True,  # whether to also mount the input files of dependencies
+        },
+    )
+    ```
+
+  </TabItem>
+  <TabItem label="Pkl">
+    ```pkl
+    targets {
+      new {
+        name = "foo"
+        // ...
+      }
+    }
+
+    environments {
+      new {
+        name = "arm64"
+        type = "docker"
+        dependencies {
+          "arm64-image"
+        }
+        oci_image = "arm64-builder"
+        defaults {
+          mount_dependencies = "transitive" // or: "none", "direct"
+          mount_dependency_inputs = true // whether to also mount the input files of dependencies
+        }
+      }
+    }
     ```
 
   </TabItem>

--- a/docs/src/content/docs/topics/script-functions.mdx
+++ b/docs/src/content/docs/topics/script-functions.mdx
@@ -13,7 +13,7 @@ These helpers let you reference dependency outputs without hard-coding file path
 `$(bin //pkg:target)` returns the absolute path to the dependency's `bin_output`.
 You can also use the shorthand `$(bin :target)` for dependencies that live in the same package, or `$(bin //pkg)` when the target label can be shortened.
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -25,6 +25,19 @@ You can also use the shorthand `$(bin :target)` for dependencies that live in th
     $(bin //tools:protoc) --python_out=generated proto/*.proto
   outputs:
     - dir::generated
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "generate_stubs",
+    dependencies = ["//tools:protoc"],
+    # The protoc binary path resolves automatically regardless of cwd
+    command = "$(bin //tools:protoc) --python_out=generated proto/*.proto",
+    outputs = ["dir::generated"],
+)
 ```
 
   </TabItem>
@@ -57,7 +70,7 @@ targets {
 Indexes are zero-based and follow the order defined in the dependency's `outputs` list (with its `bin_output` appended last when present).
 File and directory outputs resolve to absolute paths on disk, while other output types return their identifier strings—for example, Docker outputs return the image tag you defined.
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -69,6 +82,19 @@ File and directory outputs resolve to absolute paths on disk, while other output
     cp -R $(output //frontend:build 0) dist/
   outputs:
     - dir::dist
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "package_site",
+    dependencies = ["//frontend:build"],
+    # Copy the compiled assets from the build target's first output directory
+    command = "cp -R $(output //frontend:build 0) dist/",
+    outputs = ["dir::dist"],
+)
 ```
 
   </TabItem>
@@ -100,7 +126,7 @@ If you reference an index that does not exist—or a dependency that produces no
 
 To reference Docker images (or any other non-filesystem outputs), use the identifier directly:
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -109,6 +135,17 @@ To reference Docker images (or any other non-filesystem outputs), use the identi
     - //containers:backend_image
   command: |
     docker run --rm $(output //containers:backend_image 0) --health-check
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "smoke_test_image",
+    dependencies = ["//containers:backend_image"],
+    command = "docker run --rm $(output //containers:backend_image 0) --health-check",
+)
 ```
 
   </TabItem>
@@ -138,7 +175,7 @@ This is useful when a target needs to aggregate outputs from its full ancestor g
 
 When there are no transitive dependencies (or none of them produce outputs), the function silently returns nothing.
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -152,6 +189,23 @@ When there are no transitive dependencies (or none of them produce outputs), the
     done
   outputs:
     - dir::bundle
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+target(
+    name = "bundle_all",
+    dependencies = ["//libs:core"],
+    command = """
+    # Collect every output produced by any transitive dependency
+    for artifact in $(transitive_outputs); do
+      cp "$artifact" bundle/
+    done
+    """,
+    outputs = ["dir::bundle"],
+)
 ```
 
   </TabItem>
@@ -188,7 +242,7 @@ This lets you select a subset of ancestor outputs based on a convention you defi
 If no transitive dependency carries the requested tag, the function exits with an error to make the misconfiguration obvious.
 When there are no transitive tagged outputs at all (the target has no transitive deps with tags), the function silently returns nothing.
 
-<Tabs>
+<Tabs syncKey="build-file-format">
   <TabItem label="YAML">
 
 ```yaml
@@ -212,6 +266,33 @@ When there are no transitive tagged outputs at all (the target has no transitive
       FIND_LINKS="$FIND_LINKS --find-links $dir"
     done
     pip install $FIND_LINKS my-package
+```
+
+  </TabItem>
+  <TabItem label="Starlark">
+
+```starlark
+# A library target that tags its outputs for downstream discovery
+target(
+    name = "my_lib",
+    tags = ["find-links"],
+    command = "python -m build --wheel --outdir dist/",
+    outputs = ["dir::dist"],
+)
+
+# A downstream target that collects all find-links directories
+# from the full transitive dependency graph
+target(
+    name = "install",
+    dependencies = ["//libs:my_lib"],
+    command = """
+    FIND_LINKS=""
+    for dir in $(transitive_outputs_by_tag find-links); do
+      FIND_LINKS="$FIND_LINKS --find-links $dir"
+    done
+    pip install $FIND_LINKS my-package
+    """,
+)
 ```
 
   </TabItem>


### PR DESCRIPTION
## What

- Every build file example across the docs now renders as Starlight tabs with at least YAML, Starlark, and Pkl variants (JSON/Makefile kept where they existed), all sharing `syncKey="build-file-format"` so picking a format once applies site-wide.
- Translations follow the real schemas (`pkl/package.pkl`, `starlark_loader.go`); Starlark has no `default_platforms`, so its multi-platform tab sets `platforms` per target, and YAML `oci_push` tabs use static tags since YAML destinations aren't interpolated.
- The per-format tutorial sections in build-configuration.mdx intentionally stay single-format — each exists to teach one format, and the Starlark/Pkl macro examples have no YAML equivalent.

## Fixes along the way

- `starlark` fences were silently rendering as plain text (no Shiki grammar); added `langAlias: { starlark: "python", Makefile: "makefile" }`, clearing all highlighter warnings.
- Repaired a mangled YAML block in build-configuration.mdx and standardized Pkl `amends` URLs on v0.44.0 (was a mix of v0.9.3, v0.16.1, and `<version>` placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)