### PR TITLE
docs: highlight worktree cache sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Read more in [Why grog?](https://grog.build/why-grog/)
 - 🚀 Parallelize your build commands
 - 🔄 Only rebuilds changed targets (incremental)
 - 💾 (Remote) output caching
+- 🌳 Share local cache hits across Git worktrees automatically
 - 🛠️ Simple build configuration with either **Makefile**, **JSON**, **yaml**, ...
 - 📦 Single binary
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -14,7 +14,7 @@ hero:
       link: /why-grog/
 features:
   - title: Cache what matters
-    details: Reuse build outputs across runs with local or remote caching.
+    details: Reuse build outputs across runs, worktrees, and agents with local or remote caching.
   - title: Parallel by default
     details: Run independent targets at the same time to keep CI moving.
   - title: Bring your own commands
@@ -59,7 +59,8 @@ Grog coordinates the commands you already use and runs only what changed in para
 
 <CardGrid>
   <Card title="File-aware caching" icon="document">
-    Use content hashing to avoid repeating work across machines and branches.
+    Content-addressed keys let parallel agents in separate Git worktrees share local cache hits
+    automatically.
   </Card>
   <Card title="Language agnostic" icon="translate">
     Build Go, Node, Rust, Python, or anything else that runs in a shell.

--- a/docs/src/content/docs/topics/remote-caching.mdx
+++ b/docs/src/content/docs/topics/remote-caching.mdx
@@ -17,6 +17,8 @@ When using a remote cache grog will effectively use the remote file system as a 
 This means that local outputs are first cached locally and then on the cloud.
 Likewise, when checking the cache grog will fall back to the remote cache if there is no local copy
 
+Local cache keys are content-addressed and independent of the checkout path. Parallel coding agents working in separate Git worktrees therefore share cache hits automatically through the same `GROG_ROOT`, without requiring a remote cache.
+
 **Note:** Grog does not take garbage collect your cache files in any way so even though storage is relatively cheap it can be good practice to set up a mechanism for monitoring its size.
 
 ## Google Cloud Storage (GCS)


### PR DESCRIPTION
## Summary
- Highlight that content-addressed local cache keys work across checkout paths.
- Position automatic cache sharing as a benefit for parallel agents in Git worktrees.

## Validation
- `cd docs && npm install && npm run build`
