### PR TITLE
feat: generate coding agent instructions

### DIFF
--- a/docs/src/content/docs/get-started.mdx
+++ b/docs/src/content/docs/get-started.mdx
@@ -473,6 +473,17 @@ outputs {
 - `dir::dist/assets/` - A directory output
 - `oci::some-image-tag` - An OCI container image output
 
+## Add Grog to Coding Agent Instructions
+
+Run `grog agents init` to add a managed Grog fragment to the repository's `AGENTS.md`. The fragment lists the available targets and the canonical build, test, change, and configuration commands, so coding agents discover the repository workflow automatically.
+
+```shell
+grog agents init
+grog agents init --file CLAUDE.md
+```
+
+Existing instructions outside the managed fragment remain unchanged. Rerun the command after changing targets to refresh the generated list, or use `--stdout` to print the fragment without modifying a file.
+
 ## Next Steps
 
 Now that you've set up Grog and created your first build targets, you might want to explore:

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -9,6 +9,8 @@ Reference for the `grog` CLI.
 ## Commands
 
 - [`grog`](#grog)
+- [`grog agents`](#grog-agents)
+- [`grog agents init`](#grog-agents-init)
 - [`grog build`](#grog-build)
 - [`grog build-and-test`](#grog-build-and-test)
 - [`grog changes`](#grog-changes)
@@ -65,6 +67,7 @@ Reference for the `grog` CLI.
 
 ### See also
 
+- [`grog agents`](#grog-agents) - Generates repository guidance for coding agents.
 - [`grog build`](#grog-build) - Loads the user configuration and executes build targets.
 - [`grog build-and-test`](#grog-build-and-test) - Loads the user configuration and executes build and test targets.
 - [`grog changes`](#grog-changes) - Lists targets whose inputs have been modified since a given commit.
@@ -83,6 +86,97 @@ Reference for the `grog` CLI.
 - [`grog test`](#grog-test) - Loads the user configuration and executes test targets.
 - [`grog traces`](#grog-traces) - View and manage build execution traces.
 - [`grog version`](#grog-version) - Print the version info.
+
+---
+
+## grog agents
+
+Generates repository guidance for coding agents.
+
+### Options
+
+```text
+  -h, --help   help for agents
+```
+
+### Options inherited from parent commands
+
+```text
+  -a, --all-platforms                 Select all platforms (bypasses platform selectors)
+      --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
+      --color string                  Set color output (yes, no, or auto) (default "auto")
+      --debug                         Enable debug logging
+      --disable-default-shell-flags   Do not prepend "set -eu" to target commands
+      --disable-progress-tracker      Disable progress tracking updates
+      --disable-tea                   Disable interactive TUI (Bubble Tea)
+      --enable-cache                  Enable cache (default true)
+      --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
+      --fail-fast                     Fail fast on first error
+      --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
+      --log-level string              Set log level (trace, debug, info, warn, error)
+      --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
+      --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
+      --profile string                Select a configuration profile to use
+      --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
+      --stream-logs                   Forward all target build/test logs to stdout/-err
+      --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
+  -v, --verbose count                 Set verbosity level (-v, -vv)
+```
+
+### See also
+
+- [`grog`](#grog)
+- [`grog agents init`](#grog-agents-init) - Adds Grog commands and targets to an agent instruction file.
+
+---
+
+## grog agents init
+
+Adds Grog commands and targets to an agent instruction file.
+
+```text
+grog agents init [flags]
+```
+
+### Options
+
+```text
+      --file string   Instruction file path, relative to the workspace root (default "AGENTS.md")
+  -h, --help          help for init
+      --stdout        Print the managed fragment instead of writing a file
+```
+
+### Options inherited from parent commands
+
+```text
+  -a, --all-platforms                 Select all platforms (bypasses platform selectors)
+      --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
+      --color string                  Set color output (yes, no, or auto) (default "auto")
+      --debug                         Enable debug logging
+      --disable-default-shell-flags   Do not prepend "set -eu" to target commands
+      --disable-progress-tracker      Disable progress tracking updates
+      --disable-tea                   Disable interactive TUI (Bubble Tea)
+      --enable-cache                  Enable cache (default true)
+      --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
+      --fail-fast                     Fail fast on first error
+      --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
+      --log-level string              Set log level (trace, debug, info, warn, error)
+      --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
+      --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
+      --profile string                Select a configuration profile to use
+      --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
+      --stream-logs                   Forward all target build/test logs to stdout/-err
+      --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
+  -v, --verbose count                 Set verbosity level (-v, -vv)
+```
+
+### See also
+
+- [`grog agents`](#grog-agents) - Generates repository guidance for coding agents.
 
 ---
 

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -2,6 +2,7 @@ Usage:
   grog [command]
 
 Available Commands:
+  agents          Generates repository guidance for coding agents.
   build           Loads the user configuration and executes build targets.
   build-and-test  Loads the user configuration and executes build and test targets.
   changes         Lists targets whose inputs have been modified since a given commit.

--- a/internal/cmd/cmds/agents.go
+++ b/internal/cmd/cmds/agents.go
@@ -1,0 +1,164 @@
+package cmds
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"grog/internal/config"
+	"grog/internal/console"
+	"grog/internal/dag"
+	"grog/internal/loading"
+	"grog/internal/model"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	agentsFragmentStart = "<!-- grog:agents:start -->"
+	agentsFragmentEnd   = "<!-- grog:agents:end -->"
+)
+
+var agentsInitOptions = struct {
+	filePath string
+	stdout   bool
+}{
+	filePath: "AGENTS.md",
+}
+
+var agentsCmd = &cobra.Command{
+	Use:   "agents",
+	Short: "Generates repository guidance for coding agents.",
+}
+
+var agentsInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Adds Grog commands and targets to an agent instruction file.",
+	Args:  cobra.NoArgs,
+	Run: func(command *cobra.Command, arguments []string) {
+		commandContext, logger := console.SetupCommand()
+		graph := loading.MustLoadGraphForQuery(commandContext, logger)
+		fragment := renderAgentsFragment(graph)
+
+		if agentsInitOptions.stdout {
+			fmt.Print(fragment)
+			return
+		}
+
+		outputPath := agentsInitOptions.filePath
+		if !filepath.IsAbs(outputPath) {
+			outputPath = filepath.Join(config.Global.WorkspaceRoot, outputPath)
+		}
+		if err := writeAgentsFragment(outputPath, fragment); err != nil {
+			logger.Fatalf("could not write agent instructions: %v", err)
+		}
+		logger.Infof("Updated %s", outputPath)
+	},
+}
+
+func renderAgentsFragment(graph *dag.DirectedTargetGraph) string {
+	var buildTargets []string
+	var testTargets []string
+	var binaryTargets []string
+
+	for _, node := range graph.GetNodes() {
+		target, ok := node.(*model.Target)
+		if !ok {
+			continue
+		}
+
+		label := target.Label.String()
+		switch {
+		case target.IsTestOnly():
+			testTargets = append(testTargets, label)
+		case target.BinOutput.IsSet():
+			binaryTargets = append(binaryTargets, label)
+		default:
+			buildTargets = append(buildTargets, label)
+		}
+	}
+
+	sort.Strings(buildTargets)
+	sort.Strings(testTargets)
+	sort.Strings(binaryTargets)
+
+	var buffer bytes.Buffer
+	fmt.Fprintln(&buffer, agentsFragmentStart)
+	fmt.Fprintln(&buffer, "## Grog")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "Use Grog as the repository's canonical build and test interface:")
+	fmt.Fprintln(&buffer)
+	fmt.Fprintln(&buffer, "- Validate configuration with `grog check`.")
+	fmt.Fprintln(&buffer, "- Build the workspace with `grog build //...`.")
+	fmt.Fprintln(&buffer, "- Test the workspace with `grog test //...`.")
+	fmt.Fprintln(&buffer, "- Inspect affected targets with `grog changes --since=HEAD`.")
+	fmt.Fprintln(&buffer, "- Run a narrower target by passing its label to `grog build` or `grog test`.")
+
+	writeAgentTargetGroup(&buffer, "Build targets", buildTargets)
+	writeAgentTargetGroup(&buffer, "Test targets", testTargets)
+	writeAgentTargetGroup(&buffer, "Binary targets", binaryTargets)
+
+	fmt.Fprintln(&buffer, agentsFragmentEnd)
+	return buffer.String()
+}
+
+func writeAgentTargetGroup(buffer *bytes.Buffer, heading string, labels []string) {
+	if len(labels) == 0 {
+		return
+	}
+
+	fmt.Fprintf(buffer, "\n### %s\n\n", heading)
+	for _, label := range labels {
+		fmt.Fprintf(buffer, "- `%s`\n", label)
+	}
+}
+
+func writeAgentsFragment(path string, fragment string) error {
+	existingContent, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	updatedContent, err := replaceAgentsFragment(string(existingContent), fragment)
+	if err != nil {
+		return err
+	}
+
+	mode := os.FileMode(0o644)
+	if fileInfo, statError := os.Stat(path); statError == nil {
+		mode = fileInfo.Mode().Perm()
+	}
+	return os.WriteFile(path, []byte(updatedContent), mode)
+}
+
+func replaceAgentsFragment(existingContent string, fragment string) (string, error) {
+	startIndex := strings.Index(existingContent, agentsFragmentStart)
+	endIndex := strings.Index(existingContent, agentsFragmentEnd)
+	if (startIndex >= 0) != (endIndex >= 0) {
+		return "", fmt.Errorf("found an incomplete Grog agent fragment")
+	}
+	if endIndex >= 0 && endIndex < startIndex {
+		return "", fmt.Errorf("found an invalid Grog agent fragment")
+	}
+
+	if startIndex >= 0 {
+		endIndex += len(agentsFragmentEnd)
+		return existingContent[:startIndex] + strings.TrimSuffix(fragment, "\n") + existingContent[endIndex:], nil
+	}
+
+	if existingContent == "" {
+		return fragment, nil
+	}
+	return strings.TrimRight(existingContent, "\n") + "\n\n" + fragment, nil
+}
+
+// AddAgentsCmd registers commands that generate coding-agent instructions.
+func AddAgentsCmd(rootCmd *cobra.Command) {
+	agentsInitCmd.Flags().StringVar(&agentsInitOptions.filePath, "file", "AGENTS.md", "Instruction file path, relative to the workspace root")
+	agentsInitCmd.Flags().BoolVar(&agentsInitOptions.stdout, "stdout", false, "Print the managed fragment instead of writing a file")
+	agentsCmd.AddCommand(agentsInitCmd)
+	rootCmd.AddCommand(agentsCmd)
+}

--- a/internal/cmd/cmds/agents_test.go
+++ b/internal/cmd/cmds/agents_test.go
@@ -1,0 +1,98 @@
+package cmds
+
+import (
+	"strings"
+	"testing"
+
+	"grog/internal/dag"
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestRenderAgentsFragmentGroupsSortedTargets(t *testing.T) {
+	graph := dag.NewDirectedGraphFromMap(model.BuildNodeMap{
+		label.TargetLabel{Package: "app", Name: "test"}: &model.Target{
+			Label: label.TargetLabel{Package: "app", Name: "test"},
+			Tags:  []string{model.TagTestOnly},
+		},
+		label.TargetLabel{Package: "app", Name: "build"}: &model.Target{
+			Label: label.TargetLabel{Package: "app", Name: "build"},
+		},
+		label.TargetLabel{Package: "cmd", Name: "tool"}: &model.Target{
+			Label:     label.TargetLabel{Package: "cmd", Name: "tool"},
+			BinOutput: model.NewOutput("bin", "tool"),
+		},
+	})
+
+	fragment := renderAgentsFragment(graph)
+
+	for _, expected := range []string{
+		"### Build targets\n\n- `//app:build`",
+		"### Test targets\n\n- `//app:test`",
+		"### Binary targets\n\n- `//cmd:tool`",
+		"`grog build //...`",
+		"`grog test //...`",
+	} {
+		if !strings.Contains(fragment, expected) {
+			t.Errorf("expected fragment to contain %q:\n%s", expected, fragment)
+		}
+	}
+}
+
+func TestReplaceAgentsFragment(t *testing.T) {
+	testCases := []struct {
+		name            string
+		existingContent string
+		fragment        string
+		expectedContent string
+		expectError     bool
+	}{
+		{
+			name:            "creates new file content",
+			fragment:        agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+			expectedContent: agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+		},
+		{
+			name:            "appends to existing instructions",
+			existingContent: "# Existing\n",
+			fragment:        agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+			expectedContent: "# Existing\n\n" + agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+		},
+		{
+			name:            "replaces managed content",
+			existingContent: "# Existing\n\n" + agentsFragmentStart + "\nold\n" + agentsFragmentEnd + "\n",
+			fragment:        agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+			expectedContent: "# Existing\n\n" + agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+		},
+		{
+			name:            "rejects incomplete marker",
+			existingContent: agentsFragmentStart + "\nold\n",
+			fragment:        agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+			expectError:     true,
+		},
+		{
+			name:            "rejects reversed markers",
+			existingContent: agentsFragmentEnd + "\nold\n" + agentsFragmentStart,
+			fragment:        agentsFragmentStart + "\nnew\n" + agentsFragmentEnd + "\n",
+			expectError:     true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualContent, err := replaceAgentsFragment(testCase.existingContent, testCase.fragment)
+			if testCase.expectError {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("replaceAgentsFragment returned an error: %v", err)
+			}
+			if actualContent != testCase.expectedContent {
+				t.Errorf("expected %q, got %q", testCase.expectedContent, actualContent)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -206,6 +206,7 @@ func configureRoot() bool {
 	cmds.AddChangesCmd(RootCmd)
 	cmds.AddExplainChangesCmd(RootCmd)
 	cmds.AddListCmd(RootCmd)
+	cmds.AddAgentsCmd(RootCmd)
 	traces.AddCmd(RootCmd)
 	return true
 }


### PR DESCRIPTION
## Summary
- Add `grog agents init` with `AGENTS.md`, `CLAUDE.md`, and stdout workflows.
- Generate deterministic target groups inside safely replaceable managed markers.
- Document the workflow and refresh CLI output fixtures.

## Validation
- `go test ./internal/cmd/cmds ./internal/cmd`
- Fresh-workspace binary smoke test and targeted integration fixture update.
- `cd docs && npm run build`
