### PR TITLE
feat: verify targets affected by changes

### DIFF
--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -34,6 +34,7 @@ Reference for the `grog` CLI.
 - [`grog traces pull`](#grog-traces-pull)
 - [`grog traces show`](#grog-traces-show)
 - [`grog traces stats`](#grog-traces-stats)
+- [`grog verify`](#grog-verify)
 - [`grog version`](#grog-version)
 
 ## grog
@@ -85,6 +86,7 @@ Reference for the `grog` CLI.
 - [`grog taint`](#grog-taint) - Taints targets by pattern to force execution regardless of cache status.
 - [`grog test`](#grog-test) - Loads the user configuration and executes test targets.
 - [`grog traces`](#grog-traces) - View and manage build execution traces.
+- [`grog verify`](#grog-verify) - Builds and tests targets affected by repository changes.
 - [`grog version`](#grog-version) - Print the version info.
 
 ---
@@ -1537,6 +1539,65 @@ grog traces stats [flags]
 ### See also
 
 - [`grog traces`](#grog-traces) - View and manage build execution traces.
+
+---
+
+## grog verify
+
+Builds and tests targets affected by repository changes.
+
+### Synopsis
+
+Finds targets affected by changes since a Git ref or Jujutsu revision, includes their transitive dependents, and builds and tests the resulting graph.
+
+```text
+grog verify [flags]
+```
+
+### Examples
+
+```text
+  grog verify               # Verify uncommitted changes
+  grog v                    # Short alias
+  grog verify --since=main  # Verify all changes since main
+```
+
+### Options
+
+```text
+  -h, --help           help for verify
+      --since string   Git ref or Jujutsu revision to compare against (default "HEAD")
+```
+
+### Options inherited from parent commands
+
+```text
+  -a, --all-platforms                 Select all platforms (bypasses platform selectors)
+      --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
+      --color string                  Set color output (yes, no, or auto) (default "auto")
+      --debug                         Enable debug logging
+      --disable-default-shell-flags   Do not prepend "set -eu" to target commands
+      --disable-progress-tracker      Disable progress tracking updates
+      --disable-tea                   Disable interactive TUI (Bubble Tea)
+      --enable-cache                  Enable cache (default true)
+      --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
+      --fail-fast                     Fail fast on first error
+      --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
+      --log-level string              Set log level (trace, debug, info, warn, error)
+      --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
+      --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
+      --profile string                Select a configuration profile to use
+      --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
+      --stream-logs                   Forward all target build/test logs to stdout/-err
+      --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
+  -v, --verbose count                 Set verbosity level (-v, -vv)
+```
+
+### See also
+
+- [`grog`](#grog)
 
 ---
 

--- a/docs/src/content/docs/topics/querying.mdx
+++ b/docs/src/content/docs/topics/querying.mdx
@@ -24,6 +24,18 @@ Grog offers several commands that can be used individually or chained together w
 - [`grog owners`](#grog-owners): Find targets that include specific files as inputs
 - [`grog changes`](#grog-changes): Identify targets affected by changes since a specific commit
 
+## Verify Repository Changes
+
+Use `grog verify` as the canonical pre-commit command. It finds targets changed since `HEAD`, includes their transitive dependents, and builds and tests the affected graph.
+
+```shell
+grog verify
+grog v
+grog verify --since=origin/main
+```
+
+Uncommitted, staged, and untracked files are included automatically. If no Grog target is affected, the command exits successfully without running unrelated work.
+
 ## Target Selection Basics
 
 Before diving into specific commands, it's important to understand how to select targets in Grog. Most query commands accept target patterns that let you specify individual targets or groups of targets.

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -22,6 +22,7 @@ Available Commands:
   taint           Taints targets by pattern to force execution regardless of cache status.
   test            Loads the user configuration and executes test targets.
   traces          View and manage build execution traces.
+  verify          Builds and tests targets affected by repository changes.
   version         Print the version info.
 
 Flags:

--- a/internal/cmd/cmds/agents.go
+++ b/internal/cmd/cmds/agents.go
@@ -94,7 +94,7 @@ func renderAgentsFragment(graph *dag.DirectedTargetGraph) string {
 	fmt.Fprintln(&buffer, "- Validate configuration with `grog check`.")
 	fmt.Fprintln(&buffer, "- Build the workspace with `grog build //...`.")
 	fmt.Fprintln(&buffer, "- Test the workspace with `grog test //...`.")
-	fmt.Fprintln(&buffer, "- Inspect affected targets with `grog changes --since=HEAD`.")
+	fmt.Fprintln(&buffer, "- Verify all affected targets with `grog verify` (short form: `grog v`).")
 	fmt.Fprintln(&buffer, "- Run a narrower target by passing its label to `grog build` or `grog test`.")
 
 	writeAgentTargetGroup(&buffer, "Build targets", buildTargets)

--- a/internal/cmd/cmds/agents_test.go
+++ b/internal/cmd/cmds/agents_test.go
@@ -32,6 +32,7 @@ func TestRenderAgentsFragmentGroupsSortedTargets(t *testing.T) {
 		"### Binary targets\n\n- `//cmd:tool`",
 		"`grog build //...`",
 		"`grog test //...`",
+		"`grog verify`",
 	} {
 		if !strings.Contains(fragment, expected) {
 			t.Errorf("expected fragment to contain %q:\n%s", expected, fragment)

--- a/internal/cmd/cmds/changes.go
+++ b/internal/cmd/cmds/changes.go
@@ -4,13 +4,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 
-	"grog/internal/analysis"
 	"grog/internal/cmd/flagtypes"
 	"grog/internal/config"
 	"grog/internal/console"
+	"grog/internal/dag"
 	"grog/internal/label"
 	"grog/internal/loading"
 	"grog/internal/model"
@@ -52,74 +51,15 @@ Can optionally include transitive dependents of changed targets to find all affe
 		}
 		logger.Debugf("Changed files: %v", changedFiles)
 
-		packages, err := loading.LoadAllPackages(ctx)
-		if err != nil {
-			logger.Fatalf(
-				"could not load packages: %v",
-				err)
-		}
-
-		nodes, err := model.BuildNodeMapFromPackages(packages)
-		if err != nil {
-			logger.Fatalf("could not create target map: %v", err)
-		}
-
-		graph, err := analysis.BuildGraph(nodes)
-		if err != nil {
-			logger.Fatalf("could not build graph: %v", err)
-		}
-
-		// Find nodes that own the changed files
-		var matchingTargets []*model.Target
-		for _, target := range nodes.GetTargets() {
-			for _, inputFile := range target.Inputs {
-				// Get the absolute path of the input file
-				absInputPath := config.GetPathAbsoluteToWorkspaceRoot(filepath.Join(
-					target.Label.Package,
-					inputFile,
-				))
-
-				if containsFile(changedFiles, absInputPath) {
-					matchingTargets = append(matchingTargets, target)
-					break // Found a match, no need to check other inputs
-				}
-			}
-		}
-
-		// Check package definitions
-		for _, pkg := range packages {
-			for _, target := range pkg.Targets {
-				if containsFile(changedFiles, target.SourceFilePath) {
-					// Add this target if the package source file changed
-					matchingTargets = append(matchingTargets, target)
-				}
-			}
-		}
-
-		// Get dependents if requested
-		var resultTargets []*model.Target
-		if changesOptions.dependents.Value == "transitive" {
-			// Get all transitive dependents of the matching nodes
-			for _, target := range matchingTargets {
-				resultTargets = append(resultTargets, target)
-				for _, descendant := range graph.GetDescendants(target) {
-					if targetDescendant, ok := descendant.(*model.Target); ok {
-						resultTargets = append(resultTargets, targetDescendant)
-					}
-				}
-			}
-		} else {
-			resultTargets = matchingTargets
-		}
-
-		// Deduplicate nodes
-		uniqueLabels := make(map[label.TargetLabel]bool)
-		var deduplicatedTargets []model.BuildNode
-		for _, target := range resultTargets {
-			if !uniqueLabels[target.Label] {
-				uniqueLabels[target.Label] = true
-				deduplicatedTargets = append(deduplicatedTargets, target)
-			}
+		graph := loading.MustLoadGraphForQuery(ctx, logger)
+		affectedTargets := findTargetsAffectedByFiles(
+			graph,
+			changedFiles,
+			changesOptions.dependents.Value == "transitive",
+		)
+		affectedNodes := make([]model.BuildNode, 0, len(affectedTargets))
+		for _, target := range affectedTargets {
+			affectedNodes = append(affectedNodes, target)
 		}
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(changesOptions.targetType.Value)
@@ -128,8 +68,59 @@ Can optionally include transitive dependents of changed targets to find all affe
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 
-		model.PrintSortedLabels(selector.FilterNodes(deduplicatedTargets))
+		model.PrintSortedLabels(selector.FilterNodes(affectedNodes))
 	},
+}
+
+func findTargetsAffectedByFiles(
+	graph *dag.DirectedTargetGraph,
+	changedFiles []string,
+	includeDependents bool,
+) []*model.Target {
+	affectedTargets := make(map[label.TargetLabel]*model.Target)
+
+	for _, node := range graph.GetNodes() {
+		target, ok := node.(*model.Target)
+		if !ok {
+			continue
+		}
+
+		if containsFile(changedFiles, target.SourceFilePath) {
+			affectedTargets[target.Label] = target
+			continue
+		}
+
+		for _, inputFile := range target.Inputs {
+			absoluteInputPath := config.GetPathAbsoluteToWorkspaceRoot(filepath.Join(
+				target.Label.Package,
+				inputFile,
+			))
+			if containsFile(changedFiles, absoluteInputPath) {
+				affectedTargets[target.Label] = target
+				break
+			}
+		}
+	}
+
+	if includeDependents {
+		directlyAffectedTargets := make([]*model.Target, 0, len(affectedTargets))
+		for _, target := range affectedTargets {
+			directlyAffectedTargets = append(directlyAffectedTargets, target)
+		}
+		for _, target := range directlyAffectedTargets {
+			for _, descendant := range graph.GetDescendants(target) {
+				if descendantTarget, ok := descendant.(*model.Target); ok {
+					affectedTargets[descendantTarget.Label] = descendantTarget
+				}
+			}
+		}
+	}
+
+	targets := make([]*model.Target, 0, len(affectedTargets))
+	for _, target := range affectedTargets {
+		targets = append(targets, target)
+	}
+	return targets
 }
 
 // getChangedFiles returns a list of files that have changed since the given revision
@@ -256,7 +247,21 @@ func vcsIsJJ(gitRoot string) bool {
 
 // containsFile checks if the list of files contains the given file
 func containsFile(files []string, file string) bool {
-	return slices.Contains(files, file)
+	canonicalFile := canonicalPath(file)
+	for _, candidate := range files {
+		if canonicalPath(candidate) == canonicalFile {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalPath(path string) string {
+	canonical, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return canonical
+	}
+	return filepath.Clean(path)
 }
 
 func AddChangesCmd(rootCmd *cobra.Command) {

--- a/internal/cmd/cmds/verify.go
+++ b/internal/cmd/cmds/verify.go
@@ -1,0 +1,74 @@
+package cmds
+
+import (
+	"sort"
+
+	"grog/internal/config"
+	"grog/internal/console"
+	"grog/internal/label"
+	"grog/internal/loading"
+	"grog/internal/selection"
+
+	"github.com/spf13/cobra"
+)
+
+var verifyOptions = struct {
+	since string
+}{
+	since: "HEAD",
+}
+
+var verifyCmd = &cobra.Command{
+	Use:     "verify",
+	Aliases: []string{"v"},
+	Short:   "Builds and tests targets affected by repository changes.",
+	Long:    `Finds targets affected by changes since a Git ref or Jujutsu revision, includes their transitive dependents, and builds and tests the resulting graph.`,
+	Example: `  grog verify               # Verify uncommitted changes
+  grog v                    # Short alias
+  grog verify --since=main  # Verify all changes since main`,
+	Args: cobra.NoArgs,
+	Run: func(command *cobra.Command, arguments []string) {
+		commandContext, logger := console.SetupCommand()
+
+		changedFiles, err := getChangedFiles(verifyOptions.since)
+		if err != nil {
+			logger.Fatalf("failed to get changed files: %v", err)
+		}
+		if len(changedFiles) == 0 {
+			logger.Info("No changes to verify.")
+			return
+		}
+
+		graph := loading.MustLoadGraphForBuild(commandContext, logger)
+		affectedTargets := findTargetsAffectedByFiles(graph, changedFiles, true)
+		if len(affectedTargets) == 0 {
+			logger.Info("No Grog targets are affected.")
+			return
+		}
+
+		sort.Slice(affectedTargets, func(firstIndex int, secondIndex int) bool {
+			return affectedTargets[firstIndex].Label.String() < affectedTargets[secondIndex].Label.String()
+		})
+		targetPatterns := make([]label.TargetPattern, 0, len(affectedTargets))
+		for _, target := range affectedTargets {
+			targetPatterns = append(targetPatterns, label.TargetPatternFromLabel(target.Label))
+		}
+
+		RunBuild(
+			commandContext,
+			logger,
+			targetPatterns,
+			graph,
+			selection.AllTargets,
+			config.Global.StreamLogs,
+			config.Global.GetLoadOutputsMode(),
+			"verify",
+		)
+	},
+}
+
+// AddVerifyCmd registers the change-aware verification command.
+func AddVerifyCmd(rootCmd *cobra.Command) {
+	verifyCmd.Flags().StringVar(&verifyOptions.since, "since", "HEAD", "Git ref or Jujutsu revision to compare against")
+	rootCmd.AddCommand(verifyCmd)
+}

--- a/internal/cmd/cmds/verify_test.go
+++ b/internal/cmd/cmds/verify_test.go
@@ -1,0 +1,84 @@
+package cmds
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"grog/internal/config"
+	"grog/internal/dag"
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestFindTargetsAffectedByFiles(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	previousWorkspaceRoot := config.Global.WorkspaceRoot
+	config.Global.WorkspaceRoot = workspaceRoot
+	t.Cleanup(func() {
+		config.Global.WorkspaceRoot = previousWorkspaceRoot
+	})
+
+	libraryTarget := &model.Target{
+		Label:          label.TargetLabel{Package: "library", Name: "build"},
+		Inputs:         []string{"source.go"},
+		SourceFilePath: filepath.Join(workspaceRoot, "library", "BUILD.yaml"),
+	}
+	testTarget := &model.Target{
+		Label:        label.TargetLabel{Package: "app", Name: "test"},
+		Dependencies: []label.TargetLabel{libraryTarget.Label},
+		Tags:         []string{model.TagTestOnly},
+	}
+	unrelatedTarget := &model.Target{
+		Label:  label.TargetLabel{Package: "other", Name: "build"},
+		Inputs: []string{"source.go"},
+	}
+
+	graph := dag.NewDirectedGraphFromTargets(libraryTarget, testTarget, unrelatedTarget)
+	graph.AddEdge(libraryTarget, testTarget)
+
+	testCases := []struct {
+		name              string
+		changedFiles      []string
+		includeDependents bool
+		expectedLabels    []string
+	}{
+		{
+			name:         "matches direct input",
+			changedFiles: []string{filepath.Join(workspaceRoot, "library", "source.go")},
+			expectedLabels: []string{
+				"//library:build",
+			},
+		},
+		{
+			name:              "includes transitive dependents",
+			changedFiles:      []string{filepath.Join(workspaceRoot, "library", "source.go")},
+			includeDependents: true,
+			expectedLabels: []string{
+				"//app:test",
+				"//library:build",
+			},
+		},
+		{
+			name:         "matches package definition",
+			changedFiles: []string{filepath.Join(workspaceRoot, "library", "BUILD.yaml")},
+			expectedLabels: []string{
+				"//library:build",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			targets := findTargetsAffectedByFiles(graph, testCase.changedFiles, testCase.includeDependents)
+			labels := make([]string, 0, len(targets))
+			for _, target := range targets {
+				labels = append(labels, target.Label.String())
+			}
+			slices.Sort(labels)
+			if !slices.Equal(labels, testCase.expectedLabels) {
+				t.Errorf("expected labels %v, got %v", testCase.expectedLabels, labels)
+			}
+		})
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -207,6 +207,7 @@ func configureRoot() bool {
 	cmds.AddExplainChangesCmd(RootCmd)
 	cmds.AddListCmd(RootCmd)
 	cmds.AddAgentsCmd(RootCmd)
+	cmds.AddVerifyCmd(RootCmd)
 	traces.AddCmd(RootCmd)
 	return true
 }


### PR DESCRIPTION
## Summary
- Add `grog verify` and `grog v` to build and test the transitive impact of changes since `HEAD`.
- Reuse change ownership logic across query and execution paths, including checkout-path canonicalization.
- Teach the generated agent fragment and docs the single verification command.

## Validation
- `mise x -- go test ./internal/...`
- Targeted `changes_repos` integration scenario and root CLI fixture update.
- Fresh Git-workspace smoke test plus `cd docs && npm run build`.
