### PR TITLE
feat: add token-efficient agent output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Read more in [Why grog?](https://grog.build/why-grog/)
 - 🚀 Parallelize your build commands
 - 🔄 Only rebuilds changed targets (incremental)
 - 💾 (Remote) output caching
+- 🤖 Token-efficient `--for-agent` failure output
 - 🛠️ Simple build configuration with either **Makefile**, **JSON**, **yaml**, ...
 - 📦 Single binary
 

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -39,6 +39,8 @@ Reference for the `grog` CLI.
 ### Options
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -49,6 +51,7 @@ Reference for the `grog` CLI.
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
   -h, --help                          help for grog
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
@@ -115,6 +118,8 @@ grog build [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -125,6 +130,7 @@ grog build [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -173,6 +179,8 @@ grog build-and-test [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -183,6 +191,7 @@ grog build-and-test [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -235,6 +244,8 @@ grog changes [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -245,6 +256,7 @@ grog changes [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -291,6 +303,8 @@ grog check [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -301,6 +315,7 @@ grog check [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -353,6 +368,8 @@ grog clean [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -363,6 +380,7 @@ grog clean [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -415,6 +433,8 @@ grog deps [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -425,6 +445,7 @@ grog deps [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -489,6 +510,8 @@ grog explain-changes [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -499,6 +522,7 @@ grog explain-changes [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -552,6 +576,8 @@ grog graph [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -562,6 +588,7 @@ grog graph [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -609,6 +636,8 @@ grog info [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -619,6 +648,7 @@ grog info [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -669,6 +699,8 @@ grog list [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -679,6 +711,7 @@ grog list [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -728,6 +761,8 @@ grog logs [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -738,6 +773,7 @@ grog logs [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -786,6 +822,8 @@ grog owners [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -796,6 +834,7 @@ grog owners [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -848,6 +887,8 @@ grog rdeps [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -858,6 +899,7 @@ grog rdeps [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -908,6 +950,8 @@ grog run [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -918,6 +962,7 @@ grog run [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -968,6 +1013,8 @@ grog taint [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -978,6 +1025,7 @@ grog taint [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1029,6 +1077,8 @@ grog test [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1039,6 +1089,7 @@ grog test [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1075,6 +1126,8 @@ View, analyze, and export build execution traces for performance analysis and da
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1085,6 +1138,7 @@ View, analyze, and export build execution traces for performance analysis and da
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1138,6 +1192,8 @@ grog traces export [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1148,6 +1204,7 @@ grog traces export [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1197,6 +1254,8 @@ grog traces list [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1207,6 +1266,7 @@ grog traces list [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1251,6 +1311,8 @@ grog traces prune [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1261,6 +1323,7 @@ grog traces prune [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1303,6 +1366,8 @@ grog traces pull [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1313,6 +1378,7 @@ grog traces pull [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1358,6 +1424,8 @@ grog traces show <trace-id> [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1368,6 +1436,7 @@ grog traces show <trace-id> [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1417,6 +1486,8 @@ grog traces stats [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1427,6 +1498,7 @@ grog traces stats [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1473,6 +1545,8 @@ grog version [flags]
 ### Options inherited from parent commands
 
 ```text
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -1483,6 +1557,7 @@ grog version [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -27,6 +27,9 @@ all_platforms = false
 # Logging Settings
 stream_logs = true
 log_level = "info"
+# for_agent = true
+# agent_log_lines = 20
+# agent_max_failures = 10
 
 # Environment Variables
 environment_variables = { FOO = "bar" }
@@ -91,6 +94,9 @@ For instance, to set or override the `fail_fast` option set `GROG_FAIL_FAST=fals
 - **num_workers**: Number of concurrent workers for parallel task execution. Defaults to the number of CPUs.
 - **log_level**: Determines verbosity of logging (e.g., "debug", "info"). Defaults to `info`.
 - **stream_logs**: When `true`, Grog will stream build and test logs to stdout. Defaults to `false`.
+- **for_agent**: When `true`, successful executions are silent and failures include only grouped target labels, commands, exit codes, and bounded output tails. Defaults to `false`.
+- **agent_log_lines**: Maximum output lines retained for each failure in agent mode. Defaults to `20`.
+- **agent_max_failures**: Maximum failing targets rendered in agent mode. Defaults to `10`.
 - **disable_default_shell_flags**: When `false` (default), Grog prepends `set -eu` to target commands before execution to fail fast on unset variables and errors. Set to `true` to opt out.
 - **environment_variables**: Key-value pairs that will be set for all target executions and passed to the Pkl loader.
 - **environment_variables_file**: Path to a dotenv-style file whose variables are loaded into the execution environment. The path is relative to the workspace root (where `grog.toml` lives); absolute paths are also accepted. Variables from the file are loaded first, then inline `environment_variables` from `grog.toml` are merged on top — inline values take precedence. The file format supports `KEY=VALUE`, `KEY="VALUE"`, `KEY='VALUE'`, `export KEY=VALUE`, comments (`#`), and variable expansion (`$VAR` or `${VAR}`).

--- a/docs/src/content/docs/topics/coding-agents.mdx
+++ b/docs/src/content/docs/topics/coding-agents.mdx
@@ -1,0 +1,31 @@
+---
+title: Coding Agents
+description: Keep Grog build and test feedback compact for coding agents.
+---
+
+## Token-Efficient Build Output
+
+Pass `--for-agent` to any build, test, or run invocation:
+
+```shell
+grog test //... --for-agent
+```
+
+Successful runs emit no output. Failed runs contain only failing target labels, their commands, exit codes, and bounded output tails. Identical failures are grouped, repeated output lines are removed, and the report is capped so a noisy build cannot consume an agent's context window.
+
+```text
+FAIL //services/api:test (exit 1)
+command: go test ./services/api
+output:
+--- FAIL: TestCreateUser
+expected status 201, got 500
+FAIL
+```
+
+Use `--agent-log-lines` to change the default 20-line tail and `--agent-max-failures` to change the default 10-target report cap.
+
+```shell
+grog test //... --for-agent --agent-log-lines=40 --agent-max-failures=5
+```
+
+The same settings can be stored as `for_agent`, `agent_log_lines`, and `agent_max_failures` in `grog.toml`.

--- a/integration/fixtures/error_platform_flag_and_all_platforms.txt
+++ b/integration/fixtures/error_platform_flag_and_all_platforms.txt
@@ -11,6 +11,8 @@ Flags:
   -h, --help   help for build
 
 Global Flags:
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -21,6 +23,7 @@ Global Flags:
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")

--- a/integration/fixtures/for_agent_failure.txt
+++ b/integration/fixtures/for_agent_failure.txt
@@ -1,0 +1,4 @@
+FAIL //:target_1 (exit 1)
+command: echo 'failed' && exit 1
+output:
+failed

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -24,6 +24,8 @@ Available Commands:
   version         Print the version info.
 
 Flags:
+      --agent-log-lines int           Maximum output lines per failure in --for-agent mode (default 20)
+      --agent-max-failures int        Maximum failing targets rendered in --for-agent mode (default 10)
   -a, --all-platforms                 Select all platforms (bypasses platform selectors)
       --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
       --color string                  Set color output (yes, no, or auto) (default "auto")
@@ -34,6 +36,7 @@ Flags:
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --for-agent                     Emit compact, bounded failure output for coding agents
   -h, --help                          help for grog
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)

--- a/integration/test_scenarios/fail_fast.yaml
+++ b/integration/test_scenarios/fail_fast.yaml
@@ -8,3 +8,9 @@ cases:
       - --fail-fast
       - //...
     expect_fail: true
+  - name: for_agent_failure
+    grog_args:
+      - build
+      - --for-agent
+      - //...
+    expect_fail: true

--- a/internal/cmd/cmds/agent_output.go
+++ b/internal/cmd/cmds/agent_output.go
@@ -1,0 +1,150 @@
+package cmds
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"grog/internal/dag"
+	"grog/internal/execution"
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+type agentFailureGroup struct {
+	labels   []string
+	exitCode *int
+	command  string
+	output   []string
+	message  string
+}
+
+func renderAgentFailures(
+	writer io.Writer,
+	completionMap dag.CompletionMap,
+	graph *dag.DirectedTargetGraph,
+	maximumLogLines int,
+	maximumFailures int,
+) {
+	if maximumLogLines < 0 {
+		maximumLogLines = 0
+	}
+	if maximumFailures < 1 {
+		maximumFailures = 1
+	}
+
+	var failedLabels []string
+	for completionLabel, completion := range completionMap {
+		if !completion.IsSuccess {
+			failedLabels = append(failedLabels, completionLabel.String())
+		}
+	}
+	sort.Strings(failedLabels)
+
+	groupsBySignature := make(map[string]*agentFailureGroup)
+	var orderedGroups []*agentFailureGroup
+	includedFailures := 0
+	for _, failedLabel := range failedLabels {
+		if includedFailures >= maximumFailures {
+			break
+		}
+
+		targetLabel, err := label.ParseTargetLabel("", failedLabel)
+		if err != nil {
+			continue
+		}
+		completion := completionMap[targetLabel]
+		target, ok := graph.GetNodes()[targetLabel].(*model.Target)
+		if !ok {
+			continue
+		}
+
+		group, signature := newAgentFailureGroup(target, completion.Err, maximumLogLines)
+		existingGroup, exists := groupsBySignature[signature]
+		if exists {
+			existingGroup.labels = append(existingGroup.labels, failedLabel)
+		} else {
+			group.labels = []string{failedLabel}
+			groupsBySignature[signature] = group
+			orderedGroups = append(orderedGroups, group)
+		}
+		includedFailures++
+	}
+
+	for groupIndex, group := range orderedGroups {
+		if groupIndex > 0 {
+			fmt.Fprintln(writer)
+		}
+		fmt.Fprintf(writer, "FAIL %s", strings.Join(group.labels, ", "))
+		if group.exitCode != nil {
+			fmt.Fprintf(writer, " (exit %d)", *group.exitCode)
+		}
+		fmt.Fprintln(writer)
+		if group.command != "" {
+			fmt.Fprintf(writer, "command: %s\n", group.command)
+		}
+		if group.message != "" {
+			fmt.Fprintf(writer, "error: %s\n", group.message)
+		}
+		if len(group.output) > 0 {
+			fmt.Fprintln(writer, "output:")
+			for _, line := range group.output {
+				fmt.Fprintln(writer, line)
+			}
+		}
+	}
+
+	if omittedFailures := len(failedLabels) - includedFailures; omittedFailures > 0 {
+		fmt.Fprintf(writer, "\n... %d more failing targets omitted\n", omittedFailures)
+	}
+}
+
+func newAgentFailureGroup(target *model.Target, failure error, maximumLogLines int) (*agentFailureGroup, string) {
+	group := &agentFailureGroup{command: target.Command}
+
+	var commandError *execution.CommandError
+	if errors.As(failure, &commandError) {
+		exitCode := commandError.ExitCode
+		group.exitCode = &exitCode
+		group.output = tailDeduplicatedLines(commandError.Output, maximumLogLines)
+		signature := strings.Join([]string{
+			"command",
+			strconv.Itoa(exitCode),
+			target.Command,
+			strings.Join(group.output, "\n"),
+		}, "\x00")
+		return group, signature
+	}
+
+	if failure != nil {
+		group.message = failure.Error()
+	}
+	return group, "error\x00" + target.Command + "\x00" + group.message
+}
+
+func tailDeduplicatedLines(output string, maximumLines int) []string {
+	if maximumLines == 0 {
+		return nil
+	}
+
+	normalizedOutput := strings.ReplaceAll(output, "\r\n", "\n")
+	lines := strings.Split(strings.TrimSpace(normalizedOutput), "\n")
+	if len(lines) > maximumLines {
+		lines = lines[len(lines)-maximumLines:]
+	}
+
+	seen := make(map[string]bool)
+	deduplicated := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || seen[line] {
+			continue
+		}
+		seen[line] = true
+		deduplicated = append(deduplicated, line)
+	}
+	return deduplicated
+}

--- a/internal/cmd/cmds/agent_output_test.go
+++ b/internal/cmd/cmds/agent_output_test.go
@@ -1,0 +1,61 @@
+package cmds
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"grog/internal/dag"
+	"grog/internal/execution"
+	"grog/internal/label"
+	"grog/internal/model"
+)
+
+func TestTailDeduplicatedLines(t *testing.T) {
+	output := "ignored\nrepeat\nkeep\nrepeat\nlast\n"
+	actual := tailDeduplicatedLines(output, 4)
+	expected := []string{"repeat", "keep", "last"}
+	if strings.Join(actual, "\n") != strings.Join(expected, "\n") {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func TestRenderAgentFailuresGroupsAndCapsFailures(t *testing.T) {
+	firstLabel := label.TargetLabel{Package: "app", Name: "first"}
+	secondLabel := label.TargetLabel{Package: "app", Name: "second"}
+	thirdLabel := label.TargetLabel{Package: "app", Name: "third"}
+	graph := dag.NewDirectedGraphFromTargets(
+		&model.Target{Label: firstLabel, Command: "go test ./app"},
+		&model.Target{Label: secondLabel, Command: "go test ./app"},
+		&model.Target{Label: thirdLabel, Command: "go test ./other"},
+	)
+	completionMap := dag.CompletionMap{
+		firstLabel: {
+			Err: &execution.CommandError{ExitCode: 1, Output: "old\nsame\nlast"},
+		},
+		secondLabel: {
+			Err: &execution.CommandError{ExitCode: 1, Output: "old\nsame\nlast"},
+		},
+		thirdLabel: {
+			Err: errors.New("setup failed"),
+		},
+	}
+
+	var buffer bytes.Buffer
+	renderAgentFailures(&buffer, completionMap, graph, 2, 2)
+	output := buffer.String()
+
+	if !strings.Contains(output, "FAIL //app:first, //app:second (exit 1)") {
+		t.Errorf("expected grouped labels, got:\n%s", output)
+	}
+	if strings.Contains(output, "old") {
+		t.Errorf("expected output tail to exclude old lines, got:\n%s", output)
+	}
+	if !strings.Contains(output, "same\nlast") {
+		t.Errorf("expected final output lines, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 more failing targets omitted") {
+		t.Errorf("expected omitted failure count, got:\n%s", output)
+	}
+}

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -326,6 +326,17 @@ func RunBuildAndAfter(
 	successCount, cacheHits := completionMap.TargetSuccessCount()
 
 	if len(executionErrors) > 0 {
+		if config.Global.ForAgent {
+			renderAgentFailures(
+				os.Stdout,
+				completionMap,
+				graph,
+				config.Global.AgentLogLines,
+				config.Global.AgentMaxFailures,
+			)
+			os.Exit(1)
+		}
+
 		logger.Errorf("%s failed. %s completed (%d cache hits), %d failed:",
 			goal,
 			console.FCountTargets(successCount),

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -142,6 +142,13 @@ func configureRoot() bool {
 	RootCmd.PersistentFlags().Bool("stream-logs", false, "Forward all target build/test logs to stdout/-err")
 	_ = viper.BindPFlag("stream_logs", RootCmd.PersistentFlags().Lookup("stream-logs"))
 
+	RootCmd.PersistentFlags().Bool("for-agent", false, "Emit compact, bounded failure output for coding agents")
+	_ = viper.BindPFlag("for_agent", RootCmd.PersistentFlags().Lookup("for-agent"))
+	RootCmd.PersistentFlags().Int("agent-log-lines", 20, "Maximum output lines per failure in --for-agent mode")
+	_ = viper.BindPFlag("agent_log_lines", RootCmd.PersistentFlags().Lookup("agent-log-lines"))
+	RootCmd.PersistentFlags().Int("agent-max-failures", 10, "Maximum failing targets rendered in --for-agent mode")
+	_ = viper.BindPFlag("agent_max_failures", RootCmd.PersistentFlags().Lookup("agent-max-failures"))
+
 	// output_mode
 	RootCmd.PersistentFlags().Var(flagtypes.NewEnum("terse", "detailed"), "output-mode", "Build output style: terse (one line per target) or detailed (stream each target's lifecycle)")
 	_ = viper.BindPFlag("output_mode", RootCmd.PersistentFlags().Lookup("output-mode"))
@@ -224,6 +231,8 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetDefault("include_hidden", false)
 	viper.SetDefault("environment_variables", make(map[string]string))
 	viper.SetDefault("traces.enabled", false)
+	viper.SetDefault("agent_log_lines", 20)
+	viper.SetDefault("agent_max_failures", 10)
 
 	names := []string{"grog"}
 	if os.Getenv("CI") == "1" {
@@ -278,6 +287,15 @@ func initConfig(cmd *cobra.Command) error {
 	// Merge all config sources into the global
 	if err := viper.Unmarshal(&config.Global); err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	if config.Global.ForAgent {
+		config.Global.LogLevel = "error"
+		config.Global.StreamLogs = false
+		config.Global.DisableProgressTracker = true
+		config.Global.DisableNonDeterministicLogging = true
+		viper.Set("color", "no")
+		viper.Set("disable_tea", true)
 	}
 
 	config.Global.HashAlgorithm = strings.ToLower(config.Global.HashAlgorithm)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,10 +27,13 @@ type WorkspaceConfig struct {
 	CacheNamespace string `mapstructure:"cache_namespace"`
 
 	// Execution
-	FailFast    bool   `mapstructure:"fail_fast"`
-	StreamLogs  bool   `mapstructure:"stream_logs"`
-	NumWorkers  int    `mapstructure:"num_workers"`
-	LoadOutputs string `mapstructure:"load_outputs"`
+	FailFast         bool   `mapstructure:"fail_fast"`
+	StreamLogs       bool   `mapstructure:"stream_logs"`
+	NumWorkers       int    `mapstructure:"num_workers"`
+	LoadOutputs      string `mapstructure:"load_outputs"`
+	ForAgent         bool   `mapstructure:"for_agent"`
+	AgentLogLines    int    `mapstructure:"agent_log_lines"`
+	AgentMaxFailures int    `mapstructure:"agent_max_failures"`
 	// DisableProgressTracker suppresses progress bar updates in task status output
 	// while still allowing status strings to be emitted.
 	DisableProgressTracker bool `mapstructure:"disable_progress_tracker"`


### PR DESCRIPTION
## Summary
- Add `--for-agent` with silent success and compact failure-only output.
- Group identical failures, deduplicate tailed lines, and cap rendered targets and logs.
- Document tunable limits and lock the output contract with a CLI fixture.

## Validation
- `mise x -- go test ./internal/...`
- Targeted `fail_fast_tests` and `empty_repo` integration scenarios.
- Fresh-workspace output smoke test and `cd docs && npm run build`.
