### PR TITLE
feat: add stable JSON output and error codes

### DIFF
--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -50,6 +50,7 @@ Reference for the `grog` CLI.
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
   -h, --help                          help for grog
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -125,6 +126,7 @@ grog build [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -183,6 +185,7 @@ grog build-and-test [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -245,6 +248,7 @@ grog changes [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -301,6 +305,7 @@ grog check [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -363,6 +368,7 @@ grog clean [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -425,6 +431,7 @@ grog deps [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -499,6 +506,7 @@ grog explain-changes [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -562,6 +570,7 @@ grog graph [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -619,6 +628,7 @@ grog info [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -679,6 +689,7 @@ grog list [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -738,6 +749,7 @@ grog logs [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -796,6 +808,7 @@ grog owners [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -858,6 +871,7 @@ grog rdeps [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -918,6 +932,7 @@ grog run [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -978,6 +993,7 @@ grog taint [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1039,6 +1055,7 @@ grog test [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1085,6 +1102,7 @@ View, analyze, and export build execution traces for performance analysis and da
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1148,6 +1166,7 @@ grog traces export [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1207,6 +1226,7 @@ grog traces list [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1261,6 +1281,7 @@ grog traces prune [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1313,6 +1334,7 @@ grog traces pull [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1368,6 +1390,7 @@ grog traces show <trace-id> [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1427,6 +1450,7 @@ grog traces stats [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
@@ -1483,6 +1507,7 @@ grog version [flags]
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")

--- a/docs/src/content/docs/reference/json-output.mdx
+++ b/docs/src/content/docs/reference/json-output.mdx
@@ -1,0 +1,43 @@
+---
+title: JSON Output
+description: Stable JSON envelopes and error codes for Grog automation.
+---
+
+Pass `--json` to any Grog command to emit newline-delimited JSON. Every line uses schema version `1` and is one of three envelope types:
+
+```json
+{"schema_version":"1","type":"result","data":{"targets":["//app:test"]}}
+{"schema_version":"1","type":"log","level":"info","message":"Selected 1 target."}
+{"schema_version":"1","type":"error","error":{"code":"target_failure","message":"1 target failed"}}
+```
+
+## Envelope Schema
+
+| Field            | Type   | Required | Description                          |
+| ---------------- | ------ | -------- | ------------------------------------ |
+| `schema_version` | string | yes      | Schema version. Currently `"1"`.     |
+| `type`           | string | yes      | `result`, `log`, or `error`.         |
+| `data`           | object | results  | Command-specific result payload.     |
+| `level`          | string | logs     | `debug`, `info`, `warn`, or `error`. |
+| `message`        | string | logs     | Human-readable log message.          |
+| `error.code`     | string | errors   | Stable symbolic error code.          |
+| `error.message`  | string | errors   | Human-readable error detail.         |
+
+Query commands return typed arrays such as `data.targets`. Build, test, and run commands emit log events throughout execution and finish with an error event when they fail. Commands with an explicit export format, such as `grog traces export --output`, preserve the requested file format.
+
+## Error Codes
+
+| Code                 | Exit status | Meaning                                      |
+| -------------------- | ----------- | -------------------------------------------- |
+| `invalid_invocation` | 2           | Invalid flags, arguments, or command usage.  |
+| `runtime_failure`    | 1           | Configuration, loading, cache, or I/O error. |
+| `target_failure`     | 1           | One or more selected targets failed.         |
+
+Exit status `0` means the command completed successfully.
+
+## Examples
+
+```shell
+grog list //... --json | jq -r '.data.targets[]?'
+grog test //app:test --json | jq -c 'select(.type == "error")'
+```

--- a/integration/cli_test.go
+++ b/integration/cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -63,11 +64,12 @@ type TestTable struct {
 // If SetupCommand is defined and GrogArgs is empty the step will only run the setup command (without fixtures).
 type TestStep struct {
 	// Names must be unique as they determine the fixture file name
-	Name         string   `yaml:"name"`
-	SetupCommand string   `yaml:"setup_command"`
-	GrogArgs     []string `yaml:"grog_args"`
-	EnvVars      []string `yaml:"env_vars"`
-	ExpectFail   bool     `yaml:"expect_fail"`
+	Name             string   `yaml:"name"`
+	SetupCommand     string   `yaml:"setup_command"`
+	GrogArgs         []string `yaml:"grog_args"`
+	EnvVars          []string `yaml:"env_vars"`
+	ExpectFail       bool     `yaml:"expect_fail"`
+	ExpectedExitCode *int     `yaml:"expected_exit_code"`
 	// Whether to run this test step against a temporary repo directory.
 	TempDir bool `yaml:"temp_dir"`
 	// Some tests have machine-specific outputs which makes
@@ -185,6 +187,19 @@ func TestCliScenarios(t *testing.T) {
 				t.Run(tc.Name, func(t *testing.T) {
 
 					output, err := runBinary(tc.GrogArgs, repoPath, tc.EnvVars, coverDir)
+					if tc.ExpectedExitCode != nil {
+						actualExitCode := 0
+						if err != nil {
+							var exitError *exec.ExitError
+							if !errors.As(err, &exitError) {
+								t.Fatalf("could not read exit code: %v", err)
+							}
+							actualExitCode = exitError.ExitCode()
+						}
+						if actualExitCode != *tc.ExpectedExitCode {
+							t.Fatalf("expected exit code %d, got %d\nCommand output:\n%s", *tc.ExpectedExitCode, actualExitCode, output)
+						}
+					}
 
 					if err != nil && !tc.ExpectFail {
 						fmt.Printf("Command output: %s\n", output)

--- a/integration/fixtures/error_platform_flag_and_all_platforms.txt
+++ b/integration/fixtures/error_platform_flag_and_all_platforms.txt
@@ -21,6 +21,7 @@ Global Flags:
       --enable-cache                  Enable cache (default true)
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")

--- a/integration/fixtures/json_invalid_missing_target.txt
+++ b/integration/fixtures/json_invalid_missing_target.txt
@@ -1,0 +1,1 @@
+{"schema_version":"1","type":"error","error":{"code":"invalid_invocation","message":"could not find target //:missing"}}

--- a/integration/fixtures/json_outside_workspace.txt
+++ b/integration/fixtures/json_outside_workspace.txt
@@ -1,0 +1,1 @@
+{"schema_version":"1","type":"error","error":{"code":"runtime_failure","message":"grog.toml not found in any parent directory. Is this a grog workspace?"}}

--- a/integration/fixtures/json_runtime_config_failure.txt
+++ b/integration/fixtures/json_runtime_config_failure.txt
@@ -1,0 +1,1 @@
+{"schema_version":"1","type":"error","error":{"code":"runtime_failure","message":"invalid hash_algorithm: invalid. Must be either xxh3 or sha256"}}

--- a/integration/fixtures/list_json.txt
+++ b/integration/fixtures/list_json.txt
@@ -1,0 +1,1 @@
+{"schema_version":"1","type":"result","data":{"targets":["//:bin","//package_1:bar","//package_1:foo","//package_1:foo_test","//package_2:package_2"]}}

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -35,6 +35,7 @@ Flags:
       --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
       --fail-fast                     Fail fast on first error
   -h, --help                          help for grog
+      --json                          Emit stable newline-delimited JSON
       --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
       --log-level string              Set log level (trace, debug, info, warn, error)
       --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")

--- a/integration/fixtures/run_child_json_flag_is_forwarded.txt
+++ b/integration/fixtures/run_child_json_flag_is_forwarded.txt
@@ -1,0 +1,6 @@
+INFO: 2 packages loaded, 4 targets configured.
+WARN: target //pkg:foo has no inputs, dependencies, output checks or fingerprint causing it to run only once
+INFO: Selected 1 target.
+INFO: //:declares_bin_tool DONE
+INFO: Build completed successfully. 1 target completed (0 cache hits).
+INFO: Running //:declares_bin_tool -> bin_tool.sh with args [bar --json]

--- a/integration/fixtures/test_output_fail_json.txt
+++ b/integration/fixtures/test_output_fail_json.txt
@@ -1,0 +1,8 @@
+{"level":"info","message":"1 package loaded, 2 targets configured.","schema_version":"1","type":"log"}
+{"level":"warn","message":"target //:failing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once","schema_version":"1","type":"log"}
+{"level":"warn","message":"target //:passing_test has no inputs, dependencies, output checks or fingerprint causing it to run only once","schema_version":"1","type":"log"}
+{"level":"info","message":"Selected 1 target.","schema_version":"1","type":"log"}
+{"level":"info","message":"//:failing_test FAILED","schema_version":"1","type":"log"}
+{"level":"error","message":"Test failed. 0 targets completed (0 cache hits), 1 failed:","schema_version":"1","type":"log"}
+{"level":"error","message":"Target //:failing_test failed with exit code 1:\ncommand: \"exit 1\"\n","schema_version":"1","type":"log"}
+{"schema_version":"1","type":"error","error":{"code":"target_failure","message":"1 target failed"}}

--- a/integration/test_scenarios/binary_output.yaml
+++ b/integration/test_scenarios/binary_output.yaml
@@ -53,3 +53,11 @@ cases:
       - //:declares_bin_tool
       - --
       - bar
+
+  - name: run_child_json_flag_is_forwarded
+    grog_args:
+      - run
+      - //:declares_bin_tool
+      - --
+      - bar
+      - --json

--- a/integration/test_scenarios/querying.yaml
+++ b/integration/test_scenarios/querying.yaml
@@ -134,3 +134,28 @@ cases:
       - --files-first
       - --show-files=false
       - --since=5e79b3bc4fc7f1978e78f917126710989bf0deaa
+
+  - name: json_runtime_config_failure
+    grog_args:
+      - list
+      - --json
+    env_vars:
+      - GROG_HASH_ALGORITHM=invalid
+    expect_fail: true
+    expected_exit_code: 1
+
+  - name: json_invalid_missing_target
+    grog_args:
+      - deps
+      - //:missing
+      - --json
+    expect_fail: true
+    expected_exit_code: 2
+
+  - name: json_outside_workspace
+    grog_args:
+      - list
+      - --json
+    temp_dir: true
+    expect_fail: true
+    expected_exit_code: 1

--- a/integration/test_scenarios/querying.yaml
+++ b/integration/test_scenarios/querying.yaml
@@ -50,6 +50,12 @@ cases:
     grog_args:
       - list
 
+  - name: list_json
+    grog_args:
+      - list
+      - //...
+      - --json
+
   # Deps
   ###
   - name: deps_intransitive

--- a/integration/test_scenarios/tests.yaml
+++ b/integration/test_scenarios/tests.yaml
@@ -16,3 +16,10 @@ cases:
       - test
       - //:failing_test
     expect_fail: true
+
+  - name: test_output_fail_json
+    grog_args:
+      - test
+      - //:failing_test
+      - --json
+    expect_fail: true

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -123,6 +123,9 @@ func RunBuildAndAfter(
 		for _, err := range errs {
 			logger.Errorf(err.Error())
 		}
+		if console.JSONEnabled() {
+			console.WriteError(console.ErrorCodeRuntimeFailure, "target constraints failed")
+		}
 		os.Exit(1)
 	}
 
@@ -140,7 +143,7 @@ func RunBuildAndAfter(
 			errString += fmt.Sprintf(" (%s not matching %s host)",
 				console.FCountTargets(skippedCount), config.Global.GetPlatform())
 		}
-		logger.Fatalf(errString)
+		logger.Fatalf("%s", errString)
 	}
 
 	infoStr := fmt.Sprintf("Selected %s.",
@@ -316,6 +319,9 @@ func RunBuildAndAfter(
 	if executionErr != nil {
 		// If this is a cancellation error continue printing out any collected errors
 		if !errors.Is(executionErr, context.Canceled) || completionMap == nil {
+			if console.JSONEnabled() {
+				console.WriteError(console.ErrorCodeRuntimeFailure, executionErr.Error())
+			}
 			os.Exit(1)
 			return
 		}
@@ -343,7 +349,9 @@ func RunBuildAndAfter(
 			}
 
 			var executionError *execution.CommandError
-			color.Red("---------------------------------")
+			if !console.JSONEnabled() {
+				color.Red("---------------------------------")
+			}
 			if completion.Err == nil {
 				logger.Errorf("Target %s failed with no error", target.Label)
 			} else if errors.As(completion.Err, &executionError) {
@@ -356,10 +364,16 @@ func RunBuildAndAfter(
 				logger.Errorf("Target %s failed: %v", target.Label, completion.Err)
 			}
 		}
+		if console.JSONEnabled() {
+			console.WriteError(console.ErrorCodeTargetFailure, console.FCountTargets(len(executionErrors))+" failed")
+		}
 		os.Exit(1)
 	}
 
 	if executionErr != nil {
+		if console.JSONEnabled() {
+			console.WriteError(console.ErrorCodeRuntimeFailure, executionErr.Error())
+		}
 		os.Exit(1)
 	}
 
@@ -368,6 +382,9 @@ func RunBuildAndAfter(
 	}
 
 	if pushHadFailures {
+		if console.JSONEnabled() {
+			console.WriteError(console.ErrorCodeRuntimeFailure, "one or more output pushes failed")
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -51,7 +51,7 @@ var BuildCmd = &cobra.Command{
 
 		targetPatterns, err := label.ParsePatternsOrMatchCurrentPackageAndSubpackages(currentPackagePath, args)
 		if err != nil {
-			logger.Fatalf("could not parse target pattern: %v", err)
+			logger.InvalidInvocationf("could not parse target pattern: %v", err)
 		}
 
 		graph := loading.MustLoadGraphForBuild(ctx, logger)
@@ -143,7 +143,7 @@ func RunBuildAndAfter(
 			errString += fmt.Sprintf(" (%s not matching %s host)",
 				console.FCountTargets(skippedCount), config.Global.GetPlatform())
 		}
-		logger.Fatalf("%s", errString)
+		logger.InvalidInvocationf("%s", errString)
 	}
 
 	infoStr := fmt.Sprintf("Selected %s.",

--- a/internal/cmd/cmds/buildandtest.go
+++ b/internal/cmd/cmds/buildandtest.go
@@ -31,7 +31,7 @@ var BuildAndTestCmd = &cobra.Command{
 
 		targetPatterns, err := label.ParsePatternsOrMatchCurrentPackageAndSubpackages(currentPackagePath, args)
 		if err != nil {
-			logger.Fatalf("could not parse target pattern: %v", err)
+			logger.InvalidInvocationf("could not parse target pattern: %v", err)
 		}
 
 		graph := loading.MustLoadGraphForBuild(ctx, logger)

--- a/internal/cmd/cmds/changes.go
+++ b/internal/cmd/cmds/changes.go
@@ -124,7 +124,7 @@ Can optionally include transitive dependents of changed targets to find all affe
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(changesOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf("%s", err.Error())
+			logger.InvalidInvocationf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 

--- a/internal/cmd/cmds/changes.go
+++ b/internal/cmd/cmds/changes.go
@@ -124,7 +124,7 @@ Can optionally include transitive dependents of changed targets to find all affe
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(changesOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf(err.Error())
+			logger.Fatalf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 

--- a/internal/cmd/cmds/check.go
+++ b/internal/cmd/cmds/check.go
@@ -1,10 +1,11 @@
 package cmds
 
 import (
+	"os"
+
 	"grog/internal/analysis"
 	"grog/internal/console"
 	"grog/internal/loading"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -24,6 +25,9 @@ var CheckCmd = &cobra.Command{
 		if len(errs) > 0 {
 			for _, err := range errs {
 				logger.Errorf(err.Error())
+			}
+			if console.JSONEnabled() {
+				console.WriteError(console.ErrorCodeRuntimeFailure, "target constraints failed")
 			}
 			os.Exit(1)
 		}

--- a/internal/cmd/cmds/deps.go
+++ b/internal/cmd/cmds/deps.go
@@ -64,7 +64,7 @@ Dependencies can be filtered by target type using the --target-type flag.`,
 		// Filter by target type
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(depsOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf(err.Error())
+			logger.Fatalf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		filteredDeps := selector.FilterNodes(dependencies)

--- a/internal/cmd/cmds/deps.go
+++ b/internal/cmd/cmds/deps.go
@@ -35,7 +35,7 @@ Dependencies can be filtered by target type using the --target-type flag.`,
 		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
-			logger.Fatalf("`%s` requires a target label", cmd.UseLine())
+			logger.InvalidInvocationf("`%s` requires a target label", cmd.UseLine())
 		}
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
@@ -45,13 +45,13 @@ Dependencies can be filtered by target type using the --target-type flag.`,
 
 		targetLabel, err := label.ParseTargetLabel(currentPackagePath, args[0])
 		if err != nil {
-			logger.Fatalf("could not parse target label: %v", err)
+			logger.InvalidInvocationf("could not parse target label: %v", err)
 		}
 		graph := loading.MustLoadGraphForQuery(ctx, logger)
 
 		target, hasTarget := graph.GetNodes()[targetLabel]
 		if !hasTarget {
-			logger.Fatalf("could not find target %s", targetLabel)
+			logger.InvalidInvocationf("could not find target %s", targetLabel)
 		}
 
 		var dependencies []model.BuildNode
@@ -64,7 +64,7 @@ Dependencies can be filtered by target type using the --target-type flag.`,
 		// Filter by target type
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(depsOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf("%s", err.Error())
+			logger.InvalidInvocationf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		filteredDeps := selector.FilterNodes(dependencies)

--- a/internal/cmd/cmds/explain_changes.go
+++ b/internal/cmd/cmds/explain_changes.go
@@ -1,7 +1,6 @@
 package cmds
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -150,7 +149,7 @@ func printFileRootedTree(fileToTargets map[string][]*model.Target, graph *dag.Di
 		for _, t := range targets {
 			root.Child(buildDependentTree(t, graph))
 		}
-		fmt.Println(root)
+		console.WriteText(root.String() + "\n")
 	}
 }
 
@@ -175,7 +174,7 @@ func printTargetRootedTree(fileToTargets map[string][]*model.Target, graph *dag.
 	for _, t := range roots {
 		subtree := buildDependentTree(t, graph)
 		applyRootStyle(subtree, downEnumerator)
-		fmt.Println(subtree)
+		console.WriteText(subtree.String() + "\n")
 	}
 }
 
@@ -262,7 +261,7 @@ func printConsumerRootedTree(
 	for _, r := range roots {
 		t := buildUpstreamTree(r, graph, affected, targetToFiles, showFiles)
 		applyRootStyle(t, upEnumerator)
-		fmt.Println(t)
+		console.WriteText(t.String() + "\n")
 	}
 }
 

--- a/internal/cmd/cmds/explain_changes.go
+++ b/internal/cmd/cmds/explain_changes.go
@@ -48,7 +48,7 @@ through the directly-affected targets to their transitive dependents.`,
 		ctx, logger := console.SetupCommand()
 
 		if explainChangesOptions.since == "" {
-			logger.Fatalf("--since flag is required")
+			logger.InvalidInvocationf("--since flag is required")
 		}
 
 		changedFiles, err := getChangedFiles(explainChangesOptions.since)

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"encoding/json"
 	"fmt"
 	"grog/internal/console"
 	"sort"
@@ -99,7 +100,15 @@ Supports tree, JSON, and Mermaid diagram output formats. By default, only direct
 			if err != nil {
 				logger.Fatalf("could not marshal graph to json: %v", err)
 			}
-			fmt.Println(string(jsonData))
+			if console.JSONEnabled() {
+				var graphData any
+				if unmarshalError := json.Unmarshal(jsonData, &graphData); unmarshalError != nil {
+					logger.Fatalf("could not prepare graph json: %v", unmarshalError)
+				}
+				console.WriteResult(map[string]any{"graph": graphData})
+			} else {
+				fmt.Println(string(jsonData))
+			}
 		}
 	},
 }
@@ -185,7 +194,7 @@ func printMermaidDiagram(graph *dag.DirectedTargetGraph) {
 		}
 	}
 
-	fmt.Println(chart.String())
+	console.WriteText(chart.String() + "\n")
 }
 
 func printTree(graph *dag.DirectedTargetGraph) {
@@ -204,7 +213,7 @@ func printTree(graph *dag.DirectedTargetGraph) {
 
 	for _, root := range roots {
 		rootTree := buildTree(root, graph, 0)
-		fmt.Println(rootTree)
+		console.WriteText(rootTree.String() + "\n")
 	}
 }
 

--- a/internal/cmd/cmds/graph.go
+++ b/internal/cmd/cmds/graph.go
@@ -59,7 +59,7 @@ Supports tree, JSON, and Mermaid diagram output formats. By default, only direct
 
 		targetPatterns, err := label.ParsePatternsOrMatchAll(currentPackagePath, args)
 		if err != nil {
-			logger.Fatalf("could not parse target pattern: %v", err)
+			logger.InvalidInvocationf("could not parse target pattern: %v", err)
 		}
 
 		nodes, err := model.BuildNodeMapFromPackages(packages)

--- a/internal/cmd/cmds/info.go
+++ b/internal/cmd/cmds/info.go
@@ -25,34 +25,46 @@ var InfoCmd = &cobra.Command{
 		version := cmd.VersionTemplate()
 		platform := config.Global.GetPlatform()
 
-		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-		defer writer.Flush()
-
 		fsCache, err := backends.NewFileSystemCache(ctx)
 		if err != nil {
 			logger.Fatalf("could not instantiate cache: %v", err)
 		}
-
-		fmt.Fprintf(writer, "Version:\t%s\n", version)
-		fmt.Fprintf(writer, "Platform:\t%s\n", platform)
-		fmt.Fprintf(writer, "Workspace:\t%s\n", config.Global.WorkspaceRoot)
-		fmt.Fprintf(writer, "Workspace Cache:\t%s\n", config.Global.GetWorkspaceCacheDirectory())
-		fmt.Fprintf(writer, "Config:\t%s\n", viper.ConfigFileUsed())
-		fmt.Fprintf(writer, "Grog root:\t%s\n", config.Global.Root)
 
 		workspaceCacheSizeBytes, err := fsCache.GetWorkspaceCacheSizeBytes()
 		if err != nil {
 			logger.Fatalf("could not get workspace cache size: %v", err)
 		}
 		workspaceCacheSizeMB := float64(workspaceCacheSizeBytes) / (1024 * 1024)
-		fmt.Fprintf(writer, "Local workspace cache size:\t%.2f MB\n", workspaceCacheSizeMB)
 
 		totalCacheSizeBytes, err := fsCache.GetCacheSizeBytes()
 		if err != nil {
 			logger.Fatalf("could not get cache size:\t%v", err)
 		}
 		totalCacheSizeMB := float64(totalCacheSizeBytes) / (1024 * 1024)
-		fmt.Fprintf(writer, "Grog root size:\t%.2f MB\n", totalCacheSizeMB)
 
+		if console.JSONEnabled() {
+			console.WriteResult(map[string]any{
+				"version":                    version,
+				"platform":                   platform,
+				"workspace":                  config.Global.WorkspaceRoot,
+				"workspace_cache":            config.Global.GetWorkspaceCacheDirectory(),
+				"config":                     viper.ConfigFileUsed(),
+				"grog_root":                  config.Global.Root,
+				"workspace_cache_size_bytes": workspaceCacheSizeBytes,
+				"grog_root_size_bytes":       totalCacheSizeBytes,
+			})
+			return
+		}
+
+		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+		defer writer.Flush()
+		fmt.Fprintf(writer, "Version:\t%s\n", version)
+		fmt.Fprintf(writer, "Platform:\t%s\n", platform)
+		fmt.Fprintf(writer, "Workspace:\t%s\n", config.Global.WorkspaceRoot)
+		fmt.Fprintf(writer, "Workspace Cache:\t%s\n", config.Global.GetWorkspaceCacheDirectory())
+		fmt.Fprintf(writer, "Config:\t%s\n", viper.ConfigFileUsed())
+		fmt.Fprintf(writer, "Grog root:\t%s\n", config.Global.Root)
+		fmt.Fprintf(writer, "Local workspace cache size:\t%.2f MB\n", workspaceCacheSizeMB)
+		fmt.Fprintf(writer, "Grog root size:\t%.2f MB\n", totalCacheSizeMB)
 	},
 }

--- a/internal/cmd/cmds/list.go
+++ b/internal/cmd/cmds/list.go
@@ -57,7 +57,7 @@ var ListCmd = &cobra.Command{
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(listOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf(err.Error())
+			logger.Fatalf("%s", err.Error())
 		}
 		selector := selection.New(targetPatterns, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		selector.SelectTargets(graph)

--- a/internal/cmd/cmds/list.go
+++ b/internal/cmd/cmds/list.go
@@ -42,14 +42,14 @@ var ListCmd = &cobra.Command{
 			// Default to only showing the targets in the current package
 			currentPackagePattern, err := label.ParseTargetPattern(currentPackagePath, ":all")
 			if err != nil {
-				logger.Fatalf("could not parse target pattern: %v", err)
+				logger.InvalidInvocationf("could not parse target pattern: %v", err)
 			}
 			targetPatterns = []label.TargetPattern{currentPackagePattern}
 		} else {
 			var err error
 			targetPatterns, err = label.ParsePatternsOrMatchAll(currentPackagePath, args)
 			if err != nil {
-				logger.Fatalf("could not parse target pattern: %v", err)
+				logger.InvalidInvocationf("could not parse target pattern: %v", err)
 			}
 		}
 
@@ -57,7 +57,7 @@ var ListCmd = &cobra.Command{
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(listOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf("%s", err.Error())
+			logger.InvalidInvocationf("%s", err.Error())
 		}
 		selector := selection.New(targetPatterns, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		selector.SelectTargets(graph)

--- a/internal/cmd/cmds/logs.go
+++ b/internal/cmd/cmds/logs.go
@@ -35,18 +35,18 @@ Use the --path-only flag to only print the path to the log file instead of its c
 
 		targetLabel, err := label.ParseTargetLabel(currentPackagePath, args[0])
 		if err != nil {
-			logger.Fatalf("could not parse target label: %v", err)
+			logger.InvalidInvocationf("could not parse target label: %v", err)
 		}
 
 		graph := loading.MustLoadGraphForQuery(ctx, logger)
 		node, hasTarget := graph.GetNodes()[targetLabel]
 		if !hasTarget {
-			logger.Fatalf("could not find target %s", targetLabel)
+			logger.InvalidInvocationf("could not find target %s", targetLabel)
 		}
 
 		logTarget, isTarget := node.(*model.Target)
 		if !isTarget {
-			logger.Fatalf("%s is not a target", targetLabel)
+			logger.InvalidInvocationf("%s is not a target", targetLabel)
 		}
 
 		targetLogFile := logs.NewTargetLogFile(*logTarget)

--- a/internal/cmd/cmds/logs.go
+++ b/internal/cmd/cmds/logs.go
@@ -1,7 +1,6 @@
 package cmds
 
 import (
-	"fmt"
 	"grog/internal/completions"
 	"grog/internal/config"
 	"grog/internal/console"
@@ -57,7 +56,26 @@ Use the --path-only flag to only print the path to the log file instead of its c
 		}
 
 		if logsOptions.pathOnly {
-			fmt.Println(targetLogFile.Path())
+			if console.JSONEnabled() {
+				console.WriteResult(map[string]string{
+					"target": targetLabel.String(),
+					"path":   targetLogFile.Path(),
+				})
+			} else {
+				console.WriteText(targetLogFile.Path() + "\n")
+			}
+			return
+		}
+
+		if console.JSONEnabled() {
+			content, readError := targetLogFile.Read()
+			if readError != nil {
+				logger.Fatalf("could not read log file: %v", readError)
+			}
+			console.WriteResult(map[string]string{
+				"target": targetLabel.String(),
+				"log":    string(content),
+			})
 			return
 		}
 

--- a/internal/cmd/cmds/rdeps.go
+++ b/internal/cmd/cmds/rdeps.go
@@ -63,7 +63,7 @@ Dependants can be filtered by target type using the --target-type flag.`,
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(rDepsOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf(err.Error())
+			logger.Fatalf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		filteredRDeps := selector.FilterNodes(rDeps)

--- a/internal/cmd/cmds/rdeps.go
+++ b/internal/cmd/cmds/rdeps.go
@@ -35,7 +35,7 @@ Dependants can be filtered by target type using the --target-type flag.`,
 		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
-			logger.Fatalf("`%s` requires a target label", cmd.UseLine())
+			logger.InvalidInvocationf("`%s` requires a target label", cmd.UseLine())
 		}
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
@@ -45,13 +45,13 @@ Dependants can be filtered by target type using the --target-type flag.`,
 
 		targetLabel, err := label.ParseTargetLabel(currentPackagePath, args[0])
 		if err != nil {
-			logger.Fatalf("could not parse target label: %v", err)
+			logger.InvalidInvocationf("could not parse target label: %v", err)
 		}
 		graph := loading.MustLoadGraphForQuery(ctx, logger)
 
 		target, hasTarget := graph.GetNodes()[targetLabel]
 		if !hasTarget {
-			logger.Fatalf("could not find target %s", targetLabel)
+			logger.InvalidInvocationf("could not find target %s", targetLabel)
 		}
 
 		var rDeps []model.BuildNode
@@ -63,7 +63,7 @@ Dependants can be filtered by target type using the --target-type flag.`,
 
 		targetTypeFilter, err := selection.StringToTargetTypeSelection(rDepsOptions.targetType.Value)
 		if err != nil {
-			logger.Fatalf("%s", err.Error())
+			logger.InvalidInvocationf("%s", err.Error())
 		}
 		selector := selection.New(nil, config.Global.Tags, config.Global.ExcludeTags, targetTypeFilter)
 		filteredRDeps := selector.FilterNodes(rDeps)

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -42,15 +42,15 @@ Use "--" to separate the list of targets from the arguments passed to the binari
 		ctx, logger := console.SetupCommand()
 
 		if len(args) == 0 {
-			logger.Fatalf("`%s` requires a target pattern", cmd.UseLine())
+			logger.InvalidInvocationf("`%s` requires a target pattern", cmd.UseLine())
 		}
 
 		targetArgs, userCommandArgs, err := splitRunArgs(args, cmd.ArgsLenAtDash())
 		if err != nil {
-			logger.Fatalf("%v", err)
+			logger.InvalidInvocationf("%v", err)
 		}
 		if len(targetArgs) == 0 {
-			logger.Fatalf("`%s` requires a target pattern", cmd.UseLine())
+			logger.InvalidInvocationf("`%s` requires a target pattern", cmd.UseLine())
 		}
 
 		currentPackagePath, err := config.Global.GetCurrentPackage()
@@ -183,7 +183,7 @@ func parseMultipleTargetLabels(logger *console.Logger, currentPackagePath string
 	for _, targetArg := range targetArgs {
 		targetLabel, err := label.ParseTargetLabel(currentPackagePath, targetArg)
 		if err != nil {
-			logger.Fatalf("could not parse target label %s: %v. Use '--' to separate target labels from binary arguments.", targetArg, err)
+			logger.InvalidInvocationf("could not parse target label %s: %v. Use '--' to separate target labels from binary arguments.", targetArg, err)
 		}
 		if _, exists := seen[targetLabel]; exists {
 			continue
@@ -213,13 +213,13 @@ func runTargetsByLabels(ctx context.Context, logger *console.Logger, targetLabel
 func resolveRunTarget(logger *console.Logger, graph *dag.DirectedTargetGraph, targetLabel label.TargetLabel) *model.Target {
 	node, hasNode := graph.GetNodes()[targetLabel]
 	if !hasNode {
-		logger.Fatalf("could not find target %s", targetLabel)
+		logger.InvalidInvocationf("could not find target %s", targetLabel)
 	}
 
 	switch typed := node.(type) {
 	case *model.Target:
 		if !typed.HasBinOutput() {
-			logger.Fatalf("target %s does not have a binary output.", targetLabel)
+			logger.InvalidInvocationf("target %s does not have a binary output.", targetLabel)
 		}
 		checkBinaryRequiresPush(logger, typed)
 		return typed
@@ -227,22 +227,22 @@ func resolveRunTarget(logger *console.Logger, graph *dag.DirectedTargetGraph, ta
 		resolvedNode := graph.GetNodes()[typed.Actual]
 		resolvedTarget, ok := resolvedNode.(*model.Target)
 		if !ok {
-			logger.Fatalf("%s resolved from %s is not a target", targetLabel, typed.Actual)
+			logger.InvalidInvocationf("%s resolved from %s is not a target", targetLabel, typed.Actual)
 		}
 		if !resolvedTarget.HasBinOutput() {
-			logger.Fatalf("target %s does not have a binary output.", typed.Actual)
+			logger.InvalidInvocationf("target %s does not have a binary output.", typed.Actual)
 		}
 		checkBinaryRequiresPush(logger, resolvedTarget)
 		return resolvedTarget
 	default:
-		logger.Fatalf("%s is not a target", targetLabel)
+		logger.InvalidInvocationf("%s is not a target", targetLabel)
 	}
 	return nil
 }
 
 func checkBinaryRequiresPush(logger *console.Logger, target *model.Target) {
 	if target.BinaryRequiresPush && !config.Global.Push {
-		logger.Fatalf("target %s requires the --push flag to run", target.Label)
+		logger.InvalidInvocationf("target %s requires the --push flag to run", target.Label)
 	}
 }
 
@@ -265,10 +265,7 @@ func runTargetBinaries(ctx context.Context, logger *console.Logger, runTargets [
 		cmd := newBinaryRunCommand(ctx, runTarget, userCommandArgs)
 		var output *bytes.Buffer
 		if console.JSONEnabled() {
-			output = &bytes.Buffer{}
-			cmd.Stdout = output
-			cmd.Stderr = output
-			cmd.Stdin = nil
+			output = captureBinaryOutput(cmd)
 		}
 		if runOptions.inPackage {
 			logger.Infof("Running %s -> %s with args %s in package directory", runTarget.Label, runTarget.BinOutput.Identifier, userCommandArgs)
@@ -312,6 +309,13 @@ func runTargetBinaries(ctx context.Context, logger *console.Logger, runTargets [
 		return errs[0]
 	}
 	return fmt.Errorf("multiple binaries failed: %w", errors.Join(errs...))
+}
+
+func captureBinaryOutput(command *exec.Cmd) *bytes.Buffer {
+	output := &bytes.Buffer{}
+	command.Stdout = output
+	command.Stderr = output
+	return output
 }
 
 func newBinaryRunCommand(ctx context.Context, runTarget *model.Target, userCommandArgs []string) *exec.Cmd {

--- a/internal/cmd/cmds/run.go
+++ b/internal/cmd/cmds/run.go
@@ -1,6 +1,7 @@
 package cmds
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -256,17 +257,25 @@ func runTargetBinaries(ctx context.Context, logger *console.Logger, runTargets [
 	type binaryRun struct {
 		target *model.Target
 		cmd    *exec.Cmd
+		output *bytes.Buffer
 	}
 	// For each target, create a new Cmd and run it in a goroutine.
 	runs := make([]binaryRun, 0, len(runTargets))
 	for _, runTarget := range runTargets {
 		cmd := newBinaryRunCommand(ctx, runTarget, userCommandArgs)
+		var output *bytes.Buffer
+		if console.JSONEnabled() {
+			output = &bytes.Buffer{}
+			cmd.Stdout = output
+			cmd.Stderr = output
+			cmd.Stdin = nil
+		}
 		if runOptions.inPackage {
 			logger.Infof("Running %s -> %s with args %s in package directory", runTarget.Label, runTarget.BinOutput.Identifier, userCommandArgs)
 		} else {
 			logger.Infof("Running %s -> %s with args %s", runTarget.Label, runTarget.BinOutput.Identifier, userCommandArgs)
 		}
-		runs = append(runs, binaryRun{target: runTarget, cmd: cmd})
+		runs = append(runs, binaryRun{target: runTarget, cmd: cmd, output: output})
 	}
 
 	errCh := make(chan error, len(runs))
@@ -284,6 +293,14 @@ func runTargetBinaries(ctx context.Context, logger *console.Logger, runTargets [
 
 	wg.Wait()
 	close(errCh)
+	if console.JSONEnabled() {
+		for _, run := range runs {
+			console.WriteResult(map[string]string{
+				"target": run.target.Label.String(),
+				"output": run.output.String(),
+			})
+		}
+	}
 	var errs []error
 	for err := range errCh {
 		errs = append(errs, err)

--- a/internal/cmd/cmds/run_test.go
+++ b/internal/cmd/cmds/run_test.go
@@ -1,0 +1,21 @@
+package cmds
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCaptureBinaryOutputPreservesStdin(t *testing.T) {
+	command := exec.Command("ignored")
+	stdin := strings.NewReader("input")
+	command.Stdin = stdin
+
+	output := captureBinaryOutput(command)
+	if command.Stdin != stdin {
+		t.Error("expected stdin to remain attached")
+	}
+	if command.Stdout != output || command.Stderr != output {
+		t.Error("expected stdout and stderr to use the capture buffer")
+	}
+}

--- a/internal/cmd/cmds/taint.go
+++ b/internal/cmd/cmds/taint.go
@@ -34,7 +34,7 @@ This is useful when you want to force a rebuild of specific targets.`,
 
 		targetPatterns, err := label.ParsePatternsOrMatchAll(currentPackagePath, args)
 		if err != nil {
-			logger.Fatalf("could not parse target pattern: %v", err)
+			logger.InvalidInvocationf("could not parse target pattern: %v", err)
 		}
 
 		graph := loading.MustLoadGraphForQuery(ctx, logger)

--- a/internal/cmd/cmds/test.go
+++ b/internal/cmd/cmds/test.go
@@ -49,7 +49,7 @@ Use "--" to separate the list of targets from additional arguments passed to the
 
 		targetPatterns, err := label.ParsePatternsOrMatchCurrentPackageAndSubpackages(currentPackagePath, targetArgs)
 		if err != nil {
-			logger.Fatalf("could not parse target pattern: %v", err)
+			logger.InvalidInvocationf("could not parse target pattern: %v", err)
 		}
 
 		if len(extraArgs) > 0 {

--- a/internal/cmd/cmds/traces/export.go
+++ b/internal/cmd/cmds/traces/export.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"time"
@@ -50,6 +51,10 @@ var exportCmd = &cobra.Command{
 		}
 
 		var w io.Writer = os.Stdout
+		var outputBuffer bytes.Buffer
+		if console.JSONEnabled() && exportOutput == "" {
+			w = &outputBuffer
+		}
 		if exportOutput != "" {
 			f, openErr := os.Create(exportOutput)
 			if openErr != nil {
@@ -68,6 +73,12 @@ var exportCmd = &cobra.Command{
 			if err := tracing.ExportOTLP(ctx, store, entries, w); err != nil {
 				logger.Fatalf("export failed: %v", err)
 			}
+		}
+		if console.JSONEnabled() && exportOutput == "" {
+			console.WriteResult(map[string]string{
+				"format":  exportFormat.Value,
+				"content": outputBuffer.String(),
+			})
 		}
 	},
 }

--- a/internal/cmd/cmds/traces/export.go
+++ b/internal/cmd/cmds/traces/export.go
@@ -35,7 +35,7 @@ var exportCmd = &cobra.Command{
 		if exportSince != "" {
 			sinceTime, err := time.Parse("2006-01-02", exportSince)
 			if err != nil {
-				logger.Fatalf("invalid --since date: %v", err)
+				logger.InvalidInvocationf("invalid --since date: %v", err)
 			}
 			opts.Since = &sinceTime
 		}

--- a/internal/cmd/cmds/traces/list.go
+++ b/internal/cmd/cmds/traces/list.go
@@ -38,7 +38,7 @@ var listCmd = &cobra.Command{
 
 		command, err := normalizeCommand(listCommand.Value)
 		if err != nil {
-			logger.Fatalf("%v", err)
+			logger.InvalidInvocationf("%v", err)
 		}
 
 		opts := tracing.ListOptions{
@@ -49,7 +49,7 @@ var listCmd = &cobra.Command{
 		if listSince != "" {
 			sinceTime, err := time.Parse("2006-01-02", listSince)
 			if err != nil {
-				logger.Fatalf("invalid --since date: %v (use YYYY-MM-DD format)", err)
+				logger.InvalidInvocationf("invalid --since date: %v (use YYYY-MM-DD format)", err)
 			}
 			opts.Since = &sinceTime
 		}

--- a/internal/cmd/cmds/traces/list.go
+++ b/internal/cmd/cmds/traces/list.go
@@ -62,6 +62,10 @@ var listCmd = &cobra.Command{
 			logger.Info("No traces found.")
 			return
 		}
+		if console.JSONEnabled() {
+			console.WriteResult(map[string]any{"traces": entries})
+			return
+		}
 
 		headers := []string{"TRACE ID", "DATE", "CMD", "TARGETS", "HITS", "FAILS", "DURATION", "COMMIT"}
 		var rows [][]string

--- a/internal/cmd/cmds/traces/prune.go
+++ b/internal/cmd/cmds/traces/prune.go
@@ -24,7 +24,7 @@ var pruneCmd = &cobra.Command{
 
 		duration, err := parseDuration(pruneOlderThan)
 		if err != nil {
-			logger.Fatalf("invalid --older-than value: %v", err)
+			logger.InvalidInvocationf("invalid --older-than value: %v", err)
 		}
 
 		cutoff := time.Now().Add(-duration)

--- a/internal/cmd/cmds/traces/show.go
+++ b/internal/cmd/cmds/traces/show.go
@@ -39,6 +39,13 @@ var showCmd = &cobra.Command{
 		}
 
 		sortSpans(trace.Spans, showSortBy.Value)
+		if console.JSONEnabled() {
+			console.WriteResult(map[string]any{
+				"build": trace.Build,
+				"spans": trace.Spans,
+			})
+			return
+		}
 
 		printBuildSummary(&trace.Build)
 		printSpanTable(trace.Spans)

--- a/internal/cmd/cmds/traces/stats.go
+++ b/internal/cmd/cmds/traces/stats.go
@@ -35,11 +35,11 @@ var statsCmd = &cobra.Command{
 
 		command, err := normalizeStatsCommandType(statsCommandType.Value)
 		if err != nil {
-			logger.Fatalf("%v", err)
+			logger.InvalidInvocationf("%v", err)
 		}
 		isCI, err := normalizeStatsCI(statsCI.Value)
 		if err != nil {
-			logger.Fatalf("%v", err)
+			logger.InvalidInvocationf("%v", err)
 		}
 
 		statsOptions := tracing.StatsOptions{

--- a/internal/cmd/cmds/traces/stats.go
+++ b/internal/cmd/cmds/traces/stats.go
@@ -57,15 +57,28 @@ var statsCmd = &cobra.Command{
 			return
 		}
 
-		printStatsSummary(stats)
-
 		if statsDetailed {
 			report, err := store.Bottlenecks(ctx, statsOptions)
 			if err != nil {
 				logger.Fatalf("failed to compute bottleneck analysis: %v", err)
 			}
+			if console.JSONEnabled() {
+				console.WriteResult(map[string]any{
+					"stats":       stats,
+					"bottlenecks": report,
+				})
+				return
+			}
+			printStatsSummary(stats)
 			printBottleneckReport(report)
+			return
 		}
+
+		if console.JSONEnabled() {
+			console.WriteResult(map[string]any{"stats": stats})
+			return
+		}
+		printStatsSummary(stats)
 	},
 }
 

--- a/internal/cmd/cmds/version.go
+++ b/internal/cmd/cmds/version.go
@@ -1,7 +1,7 @@
 package cmds
 
 import (
-	"fmt"
+	"grog/internal/console"
 
 	"github.com/spf13/cobra"
 )
@@ -13,6 +13,10 @@ var VersionCmd = &cobra.Command{
 	Example: `  grog version  # Show the version information`,
 	Args:    cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(cmd.VersionTemplate())
+		if console.JSONEnabled() {
+			console.WriteResult(map[string]string{"version": cmd.VersionTemplate()})
+			return
+		}
+		console.WriteText(cmd.VersionTemplate() + "\n")
 	},
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,17 +31,20 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
-		workspaceRoot := config.MustFindWorkspaceRoot()
+		workspaceRoot, err := config.FindWorkspaceRoot()
+		if err != nil {
+			return console.RuntimeFailure(err)
+		}
 		viper.Set("workspace_root", workspaceRoot)
 		viper.AddConfigPath(workspaceRoot)
 
 		// Initialize config (read file, env, flags)
 		if err := initConfig(cmd); err != nil {
-			return err
+			return console.RuntimeFailure(err)
 		}
 
 		if err := config.Global.Validate(); err != nil {
-			return err
+			return console.RuntimeFailure(err)
 		}
 
 		if !console.UseTea() {
@@ -49,7 +52,7 @@ var RootCmd = &cobra.Command{
 		}
 
 		if err := config.Global.ValidateGrogVersion(Version); err != nil {
-			console.InitLogger().Fatalf("Invalid grog version: %v", err)
+			return console.RuntimeFailure(fmt.Errorf("invalid grog version: %w", err))
 		}
 		return nil
 	},
@@ -296,12 +299,12 @@ func initConfig(cmd *cobra.Command) error {
 
 	platform := viper.GetString("platform")
 	if config.Global.AllPlatforms && platform != "" {
-		return fmt.Errorf("--platform cannot be used with --all-platforms")
+		return console.InvalidInvocation(fmt.Errorf("--platform cannot be used with --all-platforms"))
 	}
 	if platform != "" {
 		parts := strings.SplitN(platform, "/", 2)
 		if len(parts) != 2 {
-			return fmt.Errorf("invalid platform %s, expected os/arch", platform)
+			return console.InvalidInvocation(fmt.Errorf("invalid platform %s, expected os/arch", platform))
 		}
 		config.Global.OS = parts[0]
 		config.Global.Arch = parts[1]

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -110,6 +110,9 @@ func configureRoot() bool {
 	RootCmd.PersistentFlags().CountP("verbose", "v", "Set verbosity level (-v, -vv)")
 	_ = viper.BindPFlag("verbose", RootCmd.PersistentFlags().Lookup("verbose"))
 
+	RootCmd.PersistentFlags().Bool("json", false, "Emit stable newline-delimited JSON")
+	_ = viper.BindPFlag("json", RootCmd.PersistentFlags().Lookup("json"))
+
 	// log_level
 	RootCmd.PersistentFlags().Var(flagtypes.NewEnum("", "trace", "debug", "info", "warn", "error"), "log-level", "Set log level (trace, debug, info, warn, error)")
 	_ = viper.BindPFlag("log_level", RootCmd.PersistentFlags().Lookup("log-level"))
@@ -278,6 +281,12 @@ func initConfig(cmd *cobra.Command) error {
 	// Merge all config sources into the global
 	if err := viper.Unmarshal(&config.Global); err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	if console.JSONEnabled() {
+		viper.Set("color", "no")
+		viper.Set("disable_tea", true)
+		config.Global.DisableProgressTracker = true
 	}
 
 	config.Global.HashAlgorithm = strings.ToLower(config.Global.HashAlgorithm)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -24,23 +24,19 @@ func GetWorkspaceCachePrefix(workspaceDir string) string {
 	return fmt.Sprintf("%s-%s", repoHash, workspaceName)
 }
 
-// MustFindWorkspaceRoot searches for the repository root by looking for "grog.toml"
-// in the current working directory and its parents. It panics if it
-// does not find the file.
-func MustFindWorkspaceRoot() string {
+// FindWorkspaceRoot searches for a grog.toml in the current directory and its parents.
+func FindWorkspaceRoot() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		fmt.Printf("%s failed to get current working directory: %v\n", color.RedString("FATAL:"), err)
-		os.Exit(1)
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
 	}
 
 	for {
 		configPath := filepath.Join(cwd, "grog.toml")
 		if _, err := os.Stat(configPath); err == nil {
-			return cwd
+			return cwd, nil
 		} else if !os.IsNotExist(err) {
-			fmt.Printf("%s failed to check for grog.toml: %v\n", color.RedString("FATAL:"), err)
-			os.Exit(1)
+			return "", fmt.Errorf("failed to check for grog.toml: %w", err)
 		}
 
 		parent := filepath.Dir(cwd)
@@ -50,9 +46,17 @@ func MustFindWorkspaceRoot() string {
 		cwd = parent
 	}
 
-	fmt.Printf("%s grog.toml not found in any parent directory. Is this a grog workspace?\n", color.RedString("FATAL:"))
-	os.Exit(1)
-	return "" // unreachable but needed to satisfy compiler
+	return "", fmt.Errorf("grog.toml not found in any parent directory. Is this a grog workspace?")
+}
+
+// MustFindWorkspaceRoot returns the workspace root or exits.
+func MustFindWorkspaceRoot() string {
+	workspaceRoot, err := FindWorkspaceRoot()
+	if err != nil {
+		fmt.Printf("%s %v\n", color.RedString("FATAL:"), err)
+		os.Exit(1)
+	}
+	return workspaceRoot
 }
 
 func GetPathRelativeToWorkspaceRoot(path string) (string, error) {

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func TestFindWorkspaceRootReturnsError(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	workspaceRoot, err := FindWorkspaceRoot()
+	if err == nil {
+		t.Fatalf("expected error, got workspace root %q", workspaceRoot)
+	}
+}
+
 func TestGetWorkspaceCachePrefix_IsPathUnique(t *testing.T) {
 	// Logs and the workspace lock rely on this prefix staying unique per
 	// absolute path so that parallel grog invocations in different

--- a/internal/console/logger.go
+++ b/internal/console/logger.go
@@ -3,6 +3,7 @@ package console
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"grog/internal/config"
@@ -52,6 +53,26 @@ func (l *Logger) DebugEnabled() bool {
 		return false
 	}
 	return l.Desugar().Core().Enabled(zap.DebugLevel)
+}
+
+// Fatalf logs a fatal error or emits a stable JSON error before exiting.
+func (l *Logger) Fatalf(template string, args ...any) {
+	if JSONEnabled() {
+		WriteError(ErrorCodeRuntimeFailure, fmt.Sprintf(template, args...))
+		_ = l.Sync()
+		os.Exit(1)
+	}
+	l.SugaredLogger.Fatalf(template, args...)
+}
+
+// Fatal logs a fatal error or emits a stable JSON error before exiting.
+func (l *Logger) Fatal(args ...any) {
+	if JSONEnabled() {
+		WriteError(ErrorCodeRuntimeFailure, fmt.Sprint(args...))
+		_ = l.Sync()
+		os.Exit(1)
+	}
+	l.SugaredLogger.Fatal(args...)
 }
 
 func (l *Logger) With(args ...any) *Logger {
@@ -126,8 +147,19 @@ func InitLoggerWithTea(program *tea.Program) *Logger {
 		level = zap.InfoLevel
 	}
 
-	// do not use structured logging by default
 	cfg.Encoding = "console"
+	if JSONEnabled() {
+		cfg.Encoding = "json"
+		encoderConfig = zapcore.EncoderConfig{
+			MessageKey:  "message",
+			LevelKey:    "level",
+			EncodeLevel: zapcore.LowercaseLevelEncoder,
+		}
+		cfg.InitialFields = map[string]any{
+			"schema_version": JSONSchemaVersion,
+			"type":           "log",
+		}
+	}
 
 	cfg.OutputPaths = []string{
 		logPath,

--- a/internal/console/logger.go
+++ b/internal/console/logger.go
@@ -75,6 +75,16 @@ func (l *Logger) Fatal(args ...any) {
 	l.SugaredLogger.Fatal(args...)
 }
 
+// InvalidInvocationf exits with a stable invalid-invocation error in JSON mode.
+func (l *Logger) InvalidInvocationf(template string, args ...any) {
+	if JSONEnabled() {
+		WriteError(ErrorCodeInvalidInvocation, fmt.Sprintf(template, args...))
+		_ = l.Sync()
+		os.Exit(2)
+	}
+	l.SugaredLogger.Fatalf(template, args...)
+}
+
 func (l *Logger) With(args ...any) *Logger {
 	return &Logger{
 		SugaredLogger: l.SugaredLogger.With(args...),

--- a/internal/console/output.go
+++ b/internal/console/output.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -35,6 +36,19 @@ type JSONError struct {
 	Message string `json:"message"`
 }
 
+type classifiedError struct {
+	code  string
+	cause error
+}
+
+func (classified *classifiedError) Error() string {
+	return classified.cause.Error()
+}
+
+func (classified *classifiedError) Unwrap() error {
+	return classified.cause
+}
+
 // JSONEnabled reports whether stable JSON output is active.
 func JSONEnabled() bool {
 	return viper.GetBool("json")
@@ -43,12 +57,49 @@ func JSONEnabled() bool {
 // ConfigureJSONFromArguments enables JSON before Cobra parses arguments.
 func ConfigureJSONFromArguments(arguments []string) bool {
 	for _, argument := range arguments {
+		if argument == "--" {
+			break
+		}
 		if argument == "--json" || strings.EqualFold(argument, "--json=true") {
 			viper.Set("json", true)
 			return true
 		}
 	}
 	return false
+}
+
+// InvalidInvocation classifies an argument or command-usage error.
+func InvalidInvocation(err error) error {
+	return classifyError(ErrorCodeInvalidInvocation, err)
+}
+
+// RuntimeFailure classifies a configuration or operational error.
+func RuntimeFailure(err error) error {
+	return classifyError(ErrorCodeRuntimeFailure, err)
+}
+
+// ClassifyError returns the stable code and exit status for an error.
+func ClassifyError(err error) (string, int) {
+	var classified *classifiedError
+	if errors.As(err, &classified) {
+		return classified.code, exitStatus(classified.code)
+	}
+	return ErrorCodeInvalidInvocation, exitStatus(ErrorCodeInvalidInvocation)
+}
+
+func classifyError(code string, err error) error {
+	var classified *classifiedError
+	if errors.As(err, &classified) {
+		return err
+	}
+	return &classifiedError{code: code, cause: err}
+}
+
+func exitStatus(code string) int {
+	if code == ErrorCodeInvalidInvocation {
+		return 2
+	}
+	return 1
 }
 
 // WriteResult emits one JSON result envelope.

--- a/internal/console/output.go
+++ b/internal/console/output.go
@@ -1,0 +1,88 @@
+package console
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// JSONSchemaVersion identifies the stable CLI envelope schema.
+const JSONSchemaVersion = "1"
+
+const (
+	// ErrorCodeInvalidInvocation identifies invalid command usage.
+	ErrorCodeInvalidInvocation = "invalid_invocation"
+	// ErrorCodeRuntimeFailure identifies configuration or operational failures.
+	ErrorCodeRuntimeFailure = "runtime_failure"
+	// ErrorCodeTargetFailure identifies failed build or test targets.
+	ErrorCodeTargetFailure = "target_failure"
+)
+
+// JSONEnvelope wraps every structured CLI result and error.
+type JSONEnvelope struct {
+	SchemaVersion string `json:"schema_version"`
+	Type          string `json:"type"`
+	Data          any    `json:"data,omitempty"`
+	Error         any    `json:"error,omitempty"`
+}
+
+// JSONError describes a stable machine-readable invocation error.
+type JSONError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// JSONEnabled reports whether stable JSON output is active.
+func JSONEnabled() bool {
+	return viper.GetBool("json")
+}
+
+// ConfigureJSONFromArguments enables JSON before Cobra parses arguments.
+func ConfigureJSONFromArguments(arguments []string) bool {
+	for _, argument := range arguments {
+		if argument == "--json" || strings.EqualFold(argument, "--json=true") {
+			viper.Set("json", true)
+			return true
+		}
+	}
+	return false
+}
+
+// WriteResult emits one JSON result envelope.
+func WriteResult(data any) {
+	writeEnvelope(JSONEnvelope{
+		SchemaVersion: JSONSchemaVersion,
+		Type:          "result",
+		Data:          data,
+	})
+}
+
+// WriteText emits text directly or inside a JSON result envelope.
+func WriteText(text string) {
+	if JSONEnabled() {
+		WriteResult(map[string]string{"text": text})
+		return
+	}
+	fmt.Print(text)
+}
+
+// WriteError emits one JSON error envelope.
+func WriteError(code string, message string) {
+	writeEnvelope(JSONEnvelope{
+		SchemaVersion: JSONSchemaVersion,
+		Type:          "error",
+		Error: JSONError{
+			Code:    code,
+			Message: message,
+		},
+	})
+}
+
+func writeEnvelope(envelope JSONEnvelope) {
+	if encodeError := json.NewEncoder(os.Stdout).Encode(envelope); encodeError != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode JSON output: %v\n", encodeError)
+	}
+}

--- a/internal/console/output_test.go
+++ b/internal/console/output_test.go
@@ -1,0 +1,81 @@
+package console
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestConfigureJSONFromArgumentsStopsAtDelimiter(t *testing.T) {
+	testCases := []struct {
+		name      string
+		arguments []string
+		expected  bool
+	}{
+		{
+			name:      "grog flag",
+			arguments: []string{"run", "--json", "//:tool", "--", "input"},
+			expected:  true,
+		},
+		{
+			name:      "child flag",
+			arguments: []string{"run", "//:tool", "--", "--json"},
+			expected:  false,
+		},
+		{
+			name:      "child true flag",
+			arguments: []string{"run", "//:tool", "--", "--json=true"},
+			expected:  false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			viper.Set("json", false)
+			if actual := ConfigureJSONFromArguments(testCase.arguments); actual != testCase.expected {
+				t.Errorf("expected %t, got %t", testCase.expected, actual)
+			}
+			if JSONEnabled() != testCase.expected {
+				t.Errorf("expected JSON enabled to be %t", testCase.expected)
+			}
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	testCases := []struct {
+		name           string
+		err            error
+		expectedCode   string
+		expectedStatus int
+	}{
+		{
+			name:           "cobra errors default to invocation",
+			err:            errors.New("unknown flag"),
+			expectedCode:   ErrorCodeInvalidInvocation,
+			expectedStatus: 2,
+		},
+		{
+			name:           "runtime failure",
+			err:            RuntimeFailure(errors.New("invalid config")),
+			expectedCode:   ErrorCodeRuntimeFailure,
+			expectedStatus: 1,
+		},
+		{
+			name:           "existing classification is preserved",
+			err:            RuntimeFailure(InvalidInvocation(errors.New("invalid platform"))),
+			expectedCode:   ErrorCodeInvalidInvocation,
+			expectedStatus: 2,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actualCode, actualStatus := ClassifyError(testCase.err)
+			if actualCode != testCase.expectedCode || actualStatus != testCase.expectedStatus {
+				t.Errorf("expected %s/%d, got %s/%d", testCase.expectedCode, testCase.expectedStatus, actualCode, actualStatus)
+			}
+		})
+	}
+}

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -3,6 +3,7 @@ package dag
 import (
 	"encoding/json"
 	"fmt"
+	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/model"
 	"slices"
@@ -357,6 +358,15 @@ type GraphJSON struct {
 }
 
 func (g *DirectedTargetGraph) LogSelectedNodes() {
+	if console.JSONEnabled() {
+		nodes := g.nodes.SelectedNodesAlphabetically()
+		labels := make([]string, 0, len(nodes))
+		for _, node := range nodes {
+			labels = append(labels, node.GetLabel().String())
+		}
+		console.WriteResult(map[string]any{"targets": labels})
+		return
+	}
 	for _, node := range g.nodes.SelectedNodesAlphabetically() {
 		fmt.Println(node.GetLabel())
 	}

--- a/internal/label/target_label.go
+++ b/internal/label/target_label.go
@@ -2,6 +2,7 @@ package label
 
 import (
 	"fmt"
+	"grog/internal/console"
 	"sort"
 	"strings"
 )
@@ -111,6 +112,10 @@ func PrintSorted(labels []TargetLabel) {
 	}
 
 	sort.Strings(result)
+	if console.JSONEnabled() {
+		console.WriteResult(map[string]any{"targets": result})
+		return
+	}
 	for _, s := range result {
 		fmt.Println(s)
 	}

--- a/internal/logs/target_log_file.go
+++ b/internal/logs/target_log_file.go
@@ -60,3 +60,8 @@ func (tl *TargetLogFile) Print() error {
 	_, err = io.Copy(os.Stdout, file)
 	return err
 }
+
+// Read returns the complete target log.
+func (tl *TargetLogFile) Read() ([]byte, error) {
+	return os.ReadFile(tl.Path())
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"grog/internal/cmd"
+	"grog/internal/console"
 	"os"
 )
 
@@ -15,8 +15,16 @@ var (
 
 func main() {
 	cmd.Stamp(version, commit, buildDate)
+	if console.ConfigureJSONFromArguments(os.Args[1:]) {
+		cmd.RootCmd.SilenceErrors = true
+		cmd.RootCmd.SilenceUsage = true
+	}
 	if err := cmd.RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		if console.JSONEnabled() {
+			console.WriteError(console.ErrorCodeInvalidInvocation, err.Error())
+		} else {
+			console.WriteText(err.Error() + "\n")
+		}
+		os.Exit(2)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,11 +20,12 @@ func main() {
 		cmd.RootCmd.SilenceUsage = true
 	}
 	if err := cmd.RootCmd.Execute(); err != nil {
+		errorCode, exitStatus := console.ClassifyError(err)
 		if console.JSONEnabled() {
-			console.WriteError(console.ErrorCodeInvalidInvocation, err.Error())
+			console.WriteError(errorCode, err.Error())
 		} else {
 			console.WriteText(err.Error() + "\n")
 		}
-		os.Exit(2)
+		os.Exit(exitStatus)
 	}
 }


### PR DESCRIPTION
## Summary
- add `--json` across query, build, run, logs, graph, and trace commands
- emit versioned NDJSON result, log, and error envelopes with stable symbolic codes
- document schema, exit statuses, and automation examples

## Validation
- `go test ./internal/...`
- targeted CLI integration scenarios and JSON error smokes
- `npm run build` in `docs/`