### PR TITLE
fix(oci): make --push actually push on every completion path

### DIFF
--- a/docs/src/content/docs/topics/docker-outputs.mdx
+++ b/docs/src/content/docs/topics/docker-outputs.mdx
@@ -326,9 +326,21 @@ grog build --push :build_api_image
 Cache misses build the image, cache it, and ship it. Cache hits skip the build,
 restore the image, and still ship it — the destination is HEAD-probed first
 and the push is short-circuited when the registry already holds the same
-digest. `--push` applies transitively across the build selection, so a
+digest. Cache hits under `load_outputs=minimal` ship too: the push reads the
+image from the cache, so it does not depend on the outputs being loaded.
+`--push` applies transitively across the build selection, so a
 `grog build --push //services/api` invocation ships every `oci_push` entry on
 `//services/api` and on every dependency it reached.
+
+Whatever the build produced is what lands at the destination, byte for byte —
+a multi-platform image is copied as a full index rather than collapsed to one
+platform, and the destination digest matches the one Grog cached.
+
+Targets tagged `no-cache` — and every target under `--enable-cache=false` —
+never stage their outputs, so there is no cached copy to copy from. Their
+pushes go straight from the local Docker daemon instead, which means they use
+the daemon's own credentials and its `insecure-registries` list rather than
+the `oci.insecure_registries` setting below.
 
 The `oci_push` map is **not** part of the cache key, so bumping the tag in
 your destination string reuses the cached image and only re-runs the push.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/containerd/errdefs v1.0.0
-	github.com/docker/cli v29.4.3+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/duckdb/duckdb-go/v2 v2.10501.0
 	github.com/fatih/color v1.18.0
@@ -33,6 +32,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/subosito/gotenv v1.6.0
@@ -94,6 +94,7 @@ require (
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/cli v29.4.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.4 // indirect
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -146,7 +147,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/integration/fixtures/oci_push_cache_hit_destination_current.txt
+++ b/integration/fixtures/oci_push_cache_hit_destination_current.txt
@@ -1,4 +1,4 @@
-INFO: 1 package loaded, 2 targets configured.
+INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
 INFO: //:smoke DONE (cached)
 INFO: Build completed successfully. 1 target completed (1 cache hits).

--- a/integration/fixtures/oci_push_failed_push.txt
+++ b/integration/fixtures/oci_push_failed_push.txt
@@ -1,4 +1,4 @@
-INFO: 1 package loaded, 2 targets configured.
+INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
 INFO: //:fail DONE
 WARN: //:fail: push to 127.0.0.1:5560/grog-smoke/fail:1.0.0 failed: Get "https://127.0.0.1:5560/v2/": dial tcp 127.0.0.1:5560: connect: connection refused; Get "http://127.0.0.1:5560/v2/": dial tcp 127.0.0.1:5560: connect: connection refused

--- a/integration/fixtures/oci_push_minimal_load_outputs.txt
+++ b/integration/fixtures/oci_push_minimal_load_outputs.txt
@@ -1,0 +1,6 @@
+INFO: 1 package loaded, 5 targets configured.
+INFO: Selected 1 target.
+INFO: //:minimal DONE (cached)
+INFO: Build completed successfully. 1 target completed (1 cache hits).
+INFO: Pushes: 1 pushed, 0 already current, 0 failed.
+INFO:   PUSHED //:minimal -> 127.0.0.1:5555/grog-smoke/minimal:1.0.0

--- a/integration/fixtures/oci_push_minimal_seed_cache.txt
+++ b/integration/fixtures/oci_push_minimal_seed_cache.txt
@@ -1,6 +1,4 @@
 INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
-INFO: //:smoke DONE
+INFO: //:minimal DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).
-INFO: Pushes: 1 pushed, 0 already current, 0 failed.
-INFO:   PUSHED //:smoke -> 127.0.0.1:5555/grog-smoke/image:1.0.0

--- a/integration/fixtures/oci_push_no_cache_target.txt
+++ b/integration/fixtures/oci_push_no_cache_target.txt
@@ -1,6 +1,6 @@
 INFO: 1 package loaded, 5 targets configured.
 INFO: Selected 1 target.
-INFO: //:smoke DONE
+INFO: //:nocache DONE
 INFO: Build completed successfully. 1 target completed (0 cache hits).
 INFO: Pushes: 1 pushed, 0 already current, 0 failed.
-INFO:   PUSHED //:smoke -> 127.0.0.1:5555/grog-smoke/image:1.0.0
+INFO:   PUSHED //:nocache -> 127.0.0.1:5555/grog-smoke/nocache:1.0.0

--- a/integration/fixtures/oci_push_warns_on_unproduced_image.txt
+++ b/integration/fixtures/oci_push_warns_on_unproduced_image.txt
@@ -1,0 +1,7 @@
+INFO: 1 package loaded, 5 targets configured.
+INFO: Selected 1 target.
+WARN: //:stale: oci output grog-smoke-stale is unchanged after running the command. If the command does not load its result into the local Docker daemon (e.g. buildx with a docker-container or cloud driver and no --load), grog caches and pushes the image that was already there.
+INFO: //:stale DONE
+INFO: Build completed successfully. 1 target completed (0 cache hits).
+INFO: Pushes: 1 pushed, 0 already current, 0 failed.
+INFO:   PUSHED //:stale -> 127.0.0.1:5555/grog-smoke/stale:1.0.0

--- a/integration/test_repos/oci_push_output/BUILD.yaml
+++ b/integration/test_repos/oci_push_output/BUILD.yaml
@@ -13,6 +13,47 @@ targets:
     oci_push:
       grog-smoke-image: 127.0.0.1:5555/grog-smoke/image:1.0.0
 
+  # A no-cache target never stages its oci output, so its push has to
+  # source the image from the local daemon instead of the cache.
+  - name: nocache
+    tags: ["no-cache"]
+    command: |
+      docker buildx build --platform=linux/amd64 -t grog-smoke-nocache .
+    inputs:
+      - script.sh
+      - Dockerfile
+    outputs:
+      - oci::grog-smoke-nocache
+    oci_push:
+      grog-smoke-nocache: 127.0.0.1:5555/grog-smoke/nocache:1.0.0
+
+  # Pushed from a cache hit under load_outputs=minimal, where the outputs
+  # are deliberately never loaded.
+  - name: minimal
+    command: |
+      docker buildx build --platform=linux/amd64 -t grog-smoke-minimal .
+    inputs:
+      - script.sh
+      - Dockerfile
+    outputs:
+      - oci::grog-smoke-minimal
+    oci_push:
+      grog-smoke-minimal: 127.0.0.1:5555/grog-smoke/minimal:1.0.0
+
+  # Builds without loading the result, the way a docker-container or cloud
+  # buildx driver does, so the local tag keeps pointing at the image the
+  # setup step left behind.
+  - name: stale
+    command: |
+      docker buildx build --platform=linux/amd64 --output=type=cacheonly -t grog-smoke-stale .
+    inputs:
+      - script.sh
+      - Dockerfile
+    outputs:
+      - oci::grog-smoke-stale
+    oci_push:
+      grog-smoke-stale: 127.0.0.1:5555/grog-smoke/stale:1.0.0
+
   # Builds the same image but pushes to a port nothing is listening on,
   # exercising the failure path of the push summary.
   - name: fail

--- a/integration/test_repos/oci_push_output/Dockerfile.stale
+++ b/integration/test_repos/oci_push_output/Dockerfile.stale
@@ -1,0 +1,5 @@
+FROM scratch
+
+# Stands in for an image left behind by a previous build system.
+LABEL grog.test.builder="previous-tool"
+COPY script.sh /script.sh

--- a/integration/test_scenarios/oci_push_cross_repo.yaml
+++ b/integration/test_scenarios/oci_push_cross_repo.yaml
@@ -60,12 +60,12 @@ cases:
   - name: verify_same_host_destination
     setup_command: |
       curl -fsS -o /dev/null \
-        -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json' \
         http://127.0.0.1:5556/v2/prod/same/manifests/1
   - name: verify_cross_host_destination
     setup_command: |
       curl -fsS -o /dev/null \
-        -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json' \
         http://127.0.0.1:5557/v2/prod/cross/manifests/1
 
   - name: stop_cross_repo_registries

--- a/integration/test_scenarios/oci_push_output.yaml
+++ b/integration/test_scenarios/oci_push_output.yaml
@@ -63,8 +63,61 @@ cases:
   - name: verify_registry_has_manifest
     setup_command: |
       curl -fsS -o /dev/null \
-        -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json' \
         http://127.0.0.1:5555/v2/grog-smoke/image/manifests/1.0.0
+
+  # A no-cache target skips output staging entirely, so its push has no
+  # cached source and must ship from the local daemon. It used to report
+  # nothing at all and exit 0 without touching the registry.
+  - name: oci_push_no_cache_target
+    grog_args:
+      - build
+      - --push
+      - :nocache
+
+  - name: verify_no_cache_target_pushed
+    setup_command: |
+      curl -fsS -o /dev/null \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json' \
+        http://127.0.0.1:5555/v2/grog-smoke/nocache/manifests/1.0.0
+
+  # Build :minimal without --push so the next run is a cache hit whose
+  # destination is empty.
+  - name: oci_push_minimal_seed_cache
+    grog_args:
+      - build
+      - :minimal
+
+  # load_outputs=minimal short-circuits the cache hit before outputs are
+  # loaded. The push sources from the cache, not from the loaded outputs,
+  # so it still has to run — this used to silently push nothing.
+  - name: oci_push_minimal_load_outputs
+    grog_args:
+      - build
+      - --push
+      - --load-outputs=minimal
+      - :minimal
+
+  - name: verify_minimal_load_outputs_pushed
+    setup_command: |
+      curl -fsS -o /dev/null \
+        -H 'Accept: application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json' \
+        http://127.0.0.1:5555/v2/grog-smoke/minimal/manifests/1.0.0
+
+  # Seed a local tag from a different Dockerfile, standing in for an image
+  # a previous build system left in the daemon.
+  - name: seed_stale_local_image
+    setup_command: |
+      docker buildx build --platform=linux/amd64 -f Dockerfile.stale -t grog-smoke-stale --load . >/dev/null
+
+  # The target's command never loads its result, so the tag still points at
+  # the seeded image. Grog cannot tell that apart from a byte-identical
+  # rebuild, but it must say so rather than cache and push it silently.
+  - name: oci_push_warns_on_unproduced_image
+    grog_args:
+      - build
+      - --push
+      - :stale
 
   # Push to a port nothing is listening on; the build itself succeeds but
   # the push fails and the summary reports the destination + the underlying
@@ -83,4 +136,8 @@ cases:
       # (per design Q9: no local-tag cleanup). Remove it here so the
       # test machine does not accumulate tags across runs.
       docker rmi 127.0.0.1:5555/grog-smoke/image:1.0.0 >/dev/null 2>&1 || true
+      docker rmi 127.0.0.1:5555/grog-smoke/nocache:1.0.0 >/dev/null 2>&1 || true
+      docker rmi 127.0.0.1:5555/grog-smoke/minimal:1.0.0 >/dev/null 2>&1 || true
+      docker rmi 127.0.0.1:5555/grog-smoke/stale:1.0.0 >/dev/null 2>&1 || true
+      docker rmi grog-smoke-stale >/dev/null 2>&1 || true
       docker rmi 127.0.0.1:5560/grog-smoke/fail:1.0.0 >/dev/null 2>&1 || true

--- a/internal/cmd/cmds/build.go
+++ b/internal/cmd/cmds/build.go
@@ -25,6 +25,8 @@ import (
 	"grog/internal/locking"
 	"grog/internal/model"
 	"grog/internal/output"
+	"grog/internal/output/handlers"
+	"grog/internal/output/push"
 	"grog/internal/selection"
 	"grog/internal/tracing"
 )
@@ -165,6 +167,19 @@ func RunBuildAndAfter(
 	taintCache := caching.NewTaintStore()
 	registry := output.NewRegistry(ctx, cas)
 
+	ociHandler, ok := registry.Handler(handlers.OCIHandler)
+	if !ok {
+		logger.Fatalf("oci output handler is not registered")
+	}
+	pusher, err := push.New(
+		ociHandler,
+		func() bool { return config.Global.Push },
+		func() bool { return config.Global.FailFast },
+	)
+	if err != nil {
+		logger.Fatalf("could not instantiate image pusher: %v", err)
+	}
+
 	// Only lock the workspace once necessary, i.e., before we start building.
 	// releaseWorkspaceLock is invoked explicitly before afterBuildSuccess so a
 	// user binary that itself shells out to grog doesn't deadlock on the lock.
@@ -191,6 +206,7 @@ func RunBuildAndAfter(
 		targetCache,
 		taintCache,
 		registry,
+		pusher,
 		graph,
 		failFast,
 		streamLogs,
@@ -232,7 +248,7 @@ func RunBuildAndAfter(
 	}
 	if afterBuildSuccess != nil && buildOK {
 		releaseWorkspaceLock()
-		if pushBeforeAfter && registry.PushReporter().HasFailures() {
+		if pushBeforeAfter && pusher.Reporter().HasFailures() {
 			logger.Errorf("Skipping post-build callback because one or more pushes failed.")
 		} else {
 			afterBuildErr = afterBuildSuccess(executor)
@@ -243,7 +259,7 @@ func RunBuildAndAfter(
 		executor.WaitForAsyncWrites(ctx)
 	}
 
-	pushHadFailures := registry.PushReporter().RenderSummary(logger)
+	pushHadFailures := pusher.Reporter().RenderSummary(logger)
 
 	// Close output handlers (notably the loopback docker registry) only after
 	// async writes have drained. Closing earlier would tear the proxy down

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -13,6 +13,7 @@ import (
 	"grog/internal/model"
 	"grog/internal/output"
 	"grog/internal/output/handlers"
+	"grog/internal/output/push"
 	"grog/internal/proto/gen"
 	"grog/internal/worker"
 	"path/filepath"
@@ -37,6 +38,7 @@ type Executor struct {
 	targetCache      *caching.TargetResultCache
 	taintStore       *caching.TaintStore
 	registry         *output.Registry
+	pusher           *push.Pusher
 	graph            *dag.DirectedTargetGraph
 	failFast         bool
 	enableCache      bool
@@ -57,6 +59,7 @@ func NewExecutor(
 	targetCache *caching.TargetResultCache,
 	taintStore *caching.TaintStore,
 	registry *output.Registry,
+	pusher *push.Pusher,
 	graph *dag.DirectedTargetGraph,
 	failFast bool,
 	streamLogs bool,
@@ -67,6 +70,7 @@ func NewExecutor(
 		targetCache:      targetCache,
 		taintStore:       taintStore,
 		registry:         registry,
+		pusher:           pusher,
 		graph:            graph,
 		failFast:         failFast,
 		enableCache:      enableCache,
@@ -411,10 +415,9 @@ func (e *Executor) getTaskFunc(
 				// Pushes read the image from the cache rather than from the
 				// loaded outputs, so --push still has to run for a target
 				// whose outputs we deliberately never load.
-				pushProgress := worker.NewProgressTracker(fmt.Sprintf("%s: pushing", target.Label), 0, update)
-				if pushErr := e.registry.PushCachedOutputs(ctx, target, targetResult, pushProgress); pushErr != nil {
-					logger.Errorf("%s: %v", target.Label, pushErr)
-				}
+				e.pushCachedTarget(ctx, target, targetResult, worker.NewProgressTracker(
+					fmt.Sprintf("%s: pushing", target.Label), 0, update,
+				))
 				logTargetCached(ctx, logger, target, float64(targetResult.ExecutionDurationMillis)/1000)
 				return dag.CacheHit, nil
 			}
@@ -434,6 +437,7 @@ func (e *Executor) getTaskFunc(
 				// Don't return so that we instead break out and continue executing the target
 				logger.Errorf("%s re-running due to output loading failure: %v", target.Label, loadingErr)
 			} else {
+				e.pushCachedTarget(ctx, target, targetResult, progress)
 				// Log the cached execution time recorded when the target was
 				// originally built, not the (near-zero) cache-load time.
 				logTargetCached(ctx, logger, target, float64(targetResult.ExecutionDurationMillis)/1000)
@@ -458,6 +462,20 @@ func (e *Executor) getTaskFunc(
 		}
 
 		return e.executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, update, isTainted)
+	}
+}
+
+// pushCachedTarget ships a cache-hit target's oci_push destinations. Push
+// failures belong in the end-of-build summary, so they must not turn a cache
+// hit into a re-run; only a malformed oci_push map is worth logging here.
+func (e *Executor) pushCachedTarget(
+	ctx context.Context,
+	target *model.Target,
+	targetResult *gen.TargetResult,
+	progress *worker.ProgressTracker,
+) {
+	if err := e.pusher.PushFromCache(ctx, target, targetResult, progress); err != nil {
+		console.GetLogger(ctx).Errorf("%s: %v", target.Label, err)
 	}
 }
 
@@ -597,7 +615,7 @@ func (e *Executor) OnTargetComplete(ctx context.Context, target *model.Target, u
 				TargetResult: targetResult,
 				// Nothing was staged to the cache, so oci_push has to ship the
 				// image straight out of the local docker daemon.
-				WritePlans: e.registry.BuildLocalPushPlans(target),
+				WritePlans: e.pusher.PlansFromDaemon(target),
 			}
 		}
 		// TODO should we even store this in the cache given that the target
@@ -630,6 +648,14 @@ func (e *Executor) OnTargetComplete(ctx context.Context, target *model.Target, u
 			return writeErr
 		}
 		preparedTarget = writeResult
+
+		// Appended after the cache plans so that image_id and manifest_digest
+		// are populated before a push tries to source them.
+		pushPlans, pushPlanErr := e.pusher.PlansFromCache(target, preparedTarget.TargetResult.GetOutputs())
+		if pushPlanErr != nil {
+			return pushPlanErr
+		}
+		preparedTarget.WritePlans = append(preparedTarget.WritePlans, pushPlans...)
 	}
 	if err != nil {
 		return err

--- a/internal/execution/execute.go
+++ b/internal/execution/execute.go
@@ -408,6 +408,13 @@ func (e *Executor) getTaskFunc(
 				target.OutputHash = targetResult.OutputHash
 				update(worker.Status(fmt.Sprintf("%s: cache hit, skipping output load (load_outputs=minimal)", target.Label)))
 				logger.Debugf("%s: cache hit. skipped loading %s because load_ outputs=minimal", target.Label, console.FCountOutputs(len(target.AllOutputs())))
+				// Pushes read the image from the cache rather than from the
+				// loaded outputs, so --push still has to run for a target
+				// whose outputs we deliberately never load.
+				pushProgress := worker.NewProgressTracker(fmt.Sprintf("%s: pushing", target.Label), 0, update)
+				if pushErr := e.registry.PushCachedOutputs(ctx, target, targetResult, pushProgress); pushErr != nil {
+					logger.Errorf("%s: %v", target.Label, pushErr)
+				}
 				logTargetCached(ctx, logger, target, float64(targetResult.ExecutionDurationMillis)/1000)
 				return dag.CacheHit, nil
 			}
@@ -519,7 +526,11 @@ func (e *Executor) executeTarget(
 		if err == nil {
 			update(worker.Status(fmt.Sprintf("%s: running \"%s\"", target.Label, target.CommandEllipsis())))
 			logger.Debugf("running target %s: %s", target.Label, target.CommandEllipsis())
+			ociImagesBefore := e.registry.SnapshotOciImages(ctx, target)
 			err = executeTarget(ctx, target, binToolPaths, outputIdentifiers, transitiveOutputs, taggedOutputs, resourceEnvironment, e.streamLogsToggle.Enabled())
+			if err == nil {
+				e.registry.WarnOnUnproducedOciImages(ctx, target, ociImagesBefore)
+			}
 		}
 	} else {
 		logger.Debugf("skipped target %s due to no command", target.Label)
@@ -584,6 +595,9 @@ func (e *Executor) OnTargetComplete(ctx context.Context, target *model.Target, u
 		if err == nil {
 			preparedTarget = &output.PreparedTargetResult{
 				TargetResult: targetResult,
+				// Nothing was staged to the cache, so oci_push has to ship the
+				// image straight out of the local docker daemon.
+				WritePlans: e.registry.BuildLocalPushPlans(target),
 			}
 		}
 		// TODO should we even store this in the cache given that the target

--- a/internal/execution/execute_test.go
+++ b/internal/execution/execute_test.go
@@ -534,6 +534,7 @@ func TestExecutorDeferAsyncWaitKeepsIOPoolAliveAfterExecute(t *testing.T) {
 		targetCache,
 		taintCache,
 		registry,
+		nil,
 		graph,
 		false,
 		false,

--- a/internal/oci_push/copy.go
+++ b/internal/oci_push/copy.go
@@ -48,33 +48,27 @@ func Copy(ctx context.Context, source, destination string, opts Options) (bool, 
 		return false, fmt.Errorf("parse destination %q: %w", destination, err)
 	}
 
-	srcImg, err := remote.Image(srcRef,
-		remote.WithContext(ctx),
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-	)
+	srcDesc, err := remote.Get(srcRef, remoteOptions(ctx)...)
 	if err != nil {
 		return false, fmt.Errorf("fetch source manifest %q: %w", source, err)
 	}
 
-	srcDigest, err := srcImg.Digest()
+	sourceManifest, err := sourceFor(srcDesc)
 	if err != nil {
-		return false, fmt.Errorf("read source digest: %w", err)
+		return false, fmt.Errorf("read source %q: %w", source, err)
 	}
 
-	dstDesc, err := remote.Head(dstRef,
-		remote.WithContext(ctx),
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-	)
-	if err == nil && dstDesc != nil && dstDesc.Digest == srcDigest {
+	dstDesc, err := remote.Head(dstRef, remoteOptions(ctx)...)
+	if err == nil && dstDesc != nil && dstDesc.Digest == srcDesc.Digest {
 		return true, nil
 	}
 
 	backoff := opts.InitialBackoff
 	var lastErr error
 	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
-		err := writeImage(ctx, dstRef, srcImg)
+		err := remote.Push(dstRef, sourceManifest, remoteOptions(ctx)...)
 		if err == nil {
-			return false, nil
+			return false, verifyDestination(ctx, dstRef, srcDesc.Digest, destination)
 		}
 		lastErr = err
 		if !isTransient(err) || attempt == opts.MaxAttempts {
@@ -90,11 +84,34 @@ func Copy(ctx context.Context, source, destination string, opts Options) (bool, 
 	return false, wrapInsecureHint(destination, opts.DestinationInsecure, lastErr)
 }
 
-func writeImage(ctx context.Context, dst name.Reference, img v1.Image) error {
-	return remote.Write(dst, img,
+// verifyDestination guards the one failure a green build log cannot reveal: a
+// write the registry accepted without making it visible under the tag.
+func verifyDestination(ctx context.Context, dst name.Reference, want v1.Hash, destination string) error {
+	desc, err := remote.Head(dst, remoteOptions(ctx)...)
+	if err != nil {
+		return fmt.Errorf("push to %q reported success but the destination could not be read back: %w", destination, err)
+	}
+	if desc.Digest != want {
+		return fmt.Errorf("push to %q reported success but the registry serves %s, not the pushed %s",
+			destination, desc.Digest, want)
+	}
+	return nil
+}
+
+func remoteOptions(ctx context.Context) []remote.Option {
+	return []remote.Option{
 		remote.WithContext(ctx),
 		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-	)
+	}
+}
+
+// sourceFor keeps a multi-platform index whole. Resolving it to a single child
+// image would ship one platform and land a digest the build never produced.
+func sourceFor(desc *remote.Descriptor) (remote.Taggable, error) {
+	if desc.MediaType.IsIndex() {
+		return desc.ImageIndex()
+	}
+	return desc.Image()
 }
 
 func parseRef(ref string, insecure bool) (name.Reference, error) {

--- a/internal/oci_push/copy.go
+++ b/internal/oci_push/copy.go
@@ -63,25 +63,41 @@ func Copy(ctx context.Context, source, destination string, opts Options) (bool, 
 		return true, nil
 	}
 
+	if err := retryTransient(ctx, opts, func() error {
+		return remote.Push(dstRef, sourceManifest, remoteOptions(ctx)...)
+	}); err != nil {
+		return false, wrapInsecureHint(destination, opts.DestinationInsecure, err)
+	}
+
+	// The write landed, so a read-back that fails or lags gets the same
+	// patience the write itself got before the push is called a failure.
+	return false, retryTransient(ctx, opts, func() error {
+		return verifyDestination(ctx, dstRef, srcDesc.Digest, destination)
+	})
+}
+
+// retryTransient runs attempt until it succeeds, fails for a reason not worth
+// retrying, or runs out of attempts.
+func retryTransient(ctx context.Context, opts Options, attempt func() error) error {
 	backoff := opts.InitialBackoff
 	var lastErr error
-	for attempt := 1; attempt <= opts.MaxAttempts; attempt++ {
-		err := remote.Push(dstRef, sourceManifest, remoteOptions(ctx)...)
+	for try := 1; try <= opts.MaxAttempts; try++ {
+		err := attempt()
 		if err == nil {
-			return false, verifyDestination(ctx, dstRef, srcDesc.Digest, destination)
+			return nil
 		}
 		lastErr = err
-		if !isTransient(err) || attempt == opts.MaxAttempts {
-			return false, wrapInsecureHint(destination, opts.DestinationInsecure, err)
+		if !isTransient(err) || try == opts.MaxAttempts {
+			return err
 		}
 		select {
 		case <-ctx.Done():
-			return false, ctx.Err()
+			return ctx.Err()
 		case <-time.After(backoff):
 		}
 		backoff *= 2
 	}
-	return false, wrapInsecureHint(destination, opts.DestinationInsecure, lastErr)
+	return lastErr
 }
 
 // verifyDestination guards the one failure a green build log cannot reveal: a

--- a/internal/oci_push/copy_index_test.go
+++ b/internal/oci_push/copy_index_test.go
@@ -1,0 +1,187 @@
+package oci_push
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func startRegistry(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(registry.New())
+	t.Cleanup(server.Close)
+	return strings.TrimPrefix(server.URL, "http://")
+}
+
+func mustParse(t *testing.T, ref string) name.Reference {
+	t.Helper()
+	parsed, err := name.ParseReference(ref, name.Insecure)
+	if err != nil {
+		t.Fatalf("parse %q: %v", ref, err)
+	}
+	return parsed
+}
+
+func mustRandomImage(t *testing.T, byteSize, layers int64) v1.Image {
+	t.Helper()
+	img, err := random.Image(byteSize, layers)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	return img
+}
+
+func mustRandomIndex(t *testing.T, children int64) v1.ImageIndex {
+	t.Helper()
+	index, err := random.Index(256, 1, children)
+	if err != nil {
+		t.Fatalf("random index: %v", err)
+	}
+	return index
+}
+
+func mustDigest(t *testing.T, artifact interface{ Digest() (v1.Hash, error) }) v1.Hash {
+	t.Helper()
+	digest, err := artifact.Digest()
+	if err != nil {
+		t.Fatalf("digest: %v", err)
+	}
+	return digest
+}
+
+func headDigest(t *testing.T, ref string) v1.Hash {
+	t.Helper()
+	desc, err := remote.Head(mustParse(t, ref), remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		t.Fatalf("head %q: %v", ref, err)
+	}
+	return desc.Digest
+}
+
+// TestCopyPreservesMultiPlatformIndex locks the contract that a copy lands the
+// exact manifest the build produced. Resolving the index to a single child
+// would ship one platform and a digest the user never built.
+func TestCopyPreservesMultiPlatformIndex(t *testing.T) {
+	sourceHost := startRegistry(t)
+	destinationHost := startRegistry(t)
+
+	sourceIndex := mustRandomIndex(t, 3)
+	source := sourceHost + "/grog/source:1"
+	if err := remote.WriteIndex(mustParse(t, source), sourceIndex); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	sourceDigest := mustDigest(t, sourceIndex)
+
+	destination := destinationHost + "/grog/destination:1"
+	skipped, err := Copy(context.Background(), source, destination, Options{
+		SourceInsecure:      true,
+		DestinationInsecure: true,
+	})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if skipped {
+		t.Fatal("Copy reported a skip against an empty destination")
+	}
+
+	if got := headDigest(t, destination); got != sourceDigest {
+		t.Errorf("destination digest = %s, want the source index digest %s", got, sourceDigest)
+	}
+
+	pushedIndex, err := remote.Index(mustParse(t, destination))
+	if err != nil {
+		t.Fatalf("read destination index: %v", err)
+	}
+	pushedManifest, err := pushedIndex.IndexManifest()
+	if err != nil {
+		t.Fatalf("read destination index manifest: %v", err)
+	}
+	if len(pushedManifest.Manifests) != 3 {
+		t.Errorf("destination holds %d children, want all 3 platforms", len(pushedManifest.Manifests))
+	}
+}
+
+// TestVerifyDestinationRejectsMismatch covers the case a green push log cannot
+// show: the write returned success but the tag serves something else.
+func TestVerifyDestinationRejectsMismatch(t *testing.T) {
+	destinationHost := startRegistry(t)
+
+	served := mustRandomImage(t, 256, 1)
+	destination := destinationHost + "/grog/destination:1"
+	if err := remote.Write(mustParse(t, destination), served); err != nil {
+		t.Fatalf("seed destination: %v", err)
+	}
+
+	otherDigest := mustDigest(t, mustRandomImage(t, 512, 2))
+	if err := verifyDestination(context.Background(), mustParse(t, destination), otherDigest, destination); err == nil {
+		t.Fatal("verifyDestination accepted a destination serving a different digest")
+	}
+
+	if err := verifyDestination(context.Background(), mustParse(t, destination), mustDigest(t, served), destination); err != nil {
+		t.Errorf("verifyDestination rejected a matching destination: %v", err)
+	}
+}
+
+func TestCopySkipsWhenDestinationIsCurrent(t *testing.T) {
+	sourceHost := startRegistry(t)
+	destinationHost := startRegistry(t)
+
+	sourceIndex := mustRandomIndex(t, 2)
+	source := sourceHost + "/grog/source:1"
+	if err := remote.WriteIndex(mustParse(t, source), sourceIndex); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	destination := destinationHost + "/grog/destination:1"
+	opts := Options{SourceInsecure: true, DestinationInsecure: true}
+	if _, err := Copy(context.Background(), source, destination, opts); err != nil {
+		t.Fatalf("first Copy: %v", err)
+	}
+
+	skipped, err := Copy(context.Background(), source, destination, opts)
+	if err != nil {
+		t.Fatalf("second Copy: %v", err)
+	}
+	if !skipped {
+		t.Error("second Copy re-pushed an already current destination")
+	}
+}
+
+func TestCopyUpdatesStaleDestination(t *testing.T) {
+	sourceHost := startRegistry(t)
+	destinationHost := startRegistry(t)
+
+	destination := destinationHost + "/grog/destination:1"
+	if err := remote.Write(mustParse(t, destination), mustRandomImage(t, 256, 1)); err != nil {
+		t.Fatalf("seed destination: %v", err)
+	}
+
+	fresh := mustRandomImage(t, 256, 1)
+	source := sourceHost + "/grog/source:1"
+	if err := remote.Write(mustParse(t, source), fresh); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+	freshDigest := mustDigest(t, fresh)
+
+	skipped, err := Copy(context.Background(), source, destination, Options{
+		SourceInsecure:      true,
+		DestinationInsecure: true,
+	})
+	if err != nil {
+		t.Fatalf("Copy: %v", err)
+	}
+	if skipped {
+		t.Fatal("Copy skipped a stale destination")
+	}
+	if got := headDigest(t, destination); got != freshDigest {
+		t.Errorf("destination digest = %s, want %s", got, freshDigest)
+	}
+}

--- a/internal/oci_push/copy_test.go
+++ b/internal/oci_push/copy_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
@@ -34,4 +35,53 @@ func TestIsTransient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetryTransient(t *testing.T) {
+	opts := Options{MaxAttempts: 3, InitialBackoff: time.Millisecond}
+
+	t.Run("retries until success", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), opts, func() error {
+			calls++
+			if calls < 3 {
+				return &transport.Error{StatusCode: http.StatusServiceUnavailable}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryTransient: %v", err)
+		}
+		if calls != 3 {
+			t.Errorf("attempted %d times, want 3", calls)
+		}
+	})
+
+	t.Run("gives up on a permanent error", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), opts, func() error {
+			calls++
+			return &transport.Error{StatusCode: http.StatusForbidden}
+		})
+		if err == nil {
+			t.Fatal("expected the permanent error to surface")
+		}
+		if calls != 1 {
+			t.Errorf("attempted %d times, want 1 — 403 is not worth retrying", calls)
+		}
+	})
+
+	t.Run("stops at MaxAttempts", func(t *testing.T) {
+		calls := 0
+		err := retryTransient(context.Background(), opts, func() error {
+			calls++
+			return errors.New("dial tcp: connection refused")
+		})
+		if err == nil {
+			t.Fatal("expected the last error to surface")
+		}
+		if calls != opts.MaxAttempts {
+			t.Errorf("attempted %d times, want %d", calls, opts.MaxAttempts)
+		}
+	})
 }

--- a/internal/output/handlers/daemon_push.go
+++ b/internal/output/handlers/daemon_push.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+
+	"grog/internal/worker"
+)
+
+// pushImageFromDaemon is the fallback for images that never reached the cache.
+// Unlike the daemon-free copy path it takes credentials and plain-HTTP
+// decisions from the daemon's own configuration.
+func pushImageFromDaemon(
+	ctx context.Context,
+	dockerClient *client.Client,
+	localTag string,
+	destination string,
+	tracker *worker.ProgressTracker,
+) error {
+	if err := dockerClient.ImageTag(ctx, localTag, destination); err != nil {
+		return fmt.Errorf("failed to tag image %q as %q: %w", localTag, destination, err)
+	}
+
+	auth, err := makeRegistryAuth(destination)
+	if err != nil {
+		return err
+	}
+
+	pushReader, err := dockerClient.ImagePush(ctx, destination, image.PushOptions{RegistryAuth: auth})
+	if err != nil {
+		return fmt.Errorf("failed to push image %q to %q: %w", localTag, destination, err)
+	}
+	defer pushReader.Close()
+
+	pushedDigest, err := consumeDockerProgress(pushReader, tracker, fmt.Sprintf("pushing %s", destination))
+	if err != nil {
+		return fmt.Errorf("error reading push response: %w", err)
+	}
+	// The daemon reports a digest only once the registry has acknowledged the
+	// manifest, so its absence means nothing is known to have landed.
+	if pushedDigest == "" {
+		return fmt.Errorf("push to %q finished without a registry digest, so the image is not known to have landed", destination)
+	}
+	return nil
+}

--- a/internal/output/handlers/docker_output_handler.go
+++ b/internal/output/handlers/docker_output_handler.go
@@ -216,7 +216,7 @@ func (d *DockerOutputHandler) Load(
 	}
 	defer pullReader.Close()
 
-	if err := consumeDockerProgress(pullReader, tracker, fmt.Sprintf("%s: pulling cache for %s", target.Label, localImageName)); err != nil {
+	if _, err := consumeDockerProgress(pullReader, tracker, fmt.Sprintf("%s: pulling cache for %s", target.Label, localImageName)); err != nil {
 		return fmt.Errorf("error reading pull response: %w", err)
 	}
 
@@ -253,6 +253,14 @@ func (d *DockerOutputHandler) PushImage(ctx context.Context, image *gen.OCIImage
 		SourceInsecure:      true,
 		DestinationInsecure: matchesInsecureRegistry(destination, d.insecureRegistries),
 	})
+}
+
+func (d *DockerOutputHandler) PushLocalImage(ctx context.Context, localTag, destination string, tracker *worker.ProgressTracker) (bool, error) {
+	cli, err := d.ensureClient()
+	if err != nil {
+		return false, err
+	}
+	return false, pushImageFromDaemon(ctx, cli, localTag, destination, tracker)
 }
 
 // dockerImageWritePlan defers the actual `docker push` to the cache-write phase.
@@ -293,7 +301,7 @@ func (d *dockerImageWritePlan) Execute(ctx context.Context, tracker *worker.Prog
 	}
 	defer pushReader.Close()
 
-	if err := consumeDockerProgress(pushReader, tracker, baseStatus); err != nil {
+	if _, err := consumeDockerProgress(pushReader, tracker, baseStatus); err != nil {
 		return fmt.Errorf("error reading push response: %w", err)
 	}
 

--- a/internal/output/handlers/docker_progress_test.go
+++ b/internal/output/handlers/docker_progress_test.go
@@ -1,6 +1,11 @@
 package handlers
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+)
 
 func TestFormatPhaseSummary_NoLayers(t *testing.T) {
 	got := formatPhaseSummary(map[string]string{})
@@ -83,4 +88,35 @@ func TestFormatPhaseSummary_PullStateLabels(t *testing.T) {
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}
+}
+
+// The two image stores report a completed push differently: the classic store
+// sends a structured aux payload, the containerd store only the status line.
+func TestRegistryConfirmedDigest(t *testing.T) {
+	const digest = "sha256:fa647fc1e5d5df7d8d923fb6332aab8e78783f8fca1a1394efb4011f68f5a793"
+
+	aux := json.RawMessage(`{"Tag":"1.0.0","Digest":"` + digest + `","Size":1917}`)
+	cases := []struct {
+		name    string
+		message jsonmessage.JSONMessage
+		want    string
+	}{
+		{"classic aux", jsonmessage.JSONMessage{Aux: &aux}, digest},
+		{"containerd status line", jsonmessage.JSONMessage{Status: "1.0.0: digest: " + digest + " size: 1917"}, digest},
+		{"layer progress", jsonmessage.JSONMessage{ID: "abc", Status: "Pushing"}, ""},
+		{"unrelated aux", jsonmessage.JSONMessage{Aux: rawMessage(`{"manifestPushedInsteadOfIndex":true}`)}, ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := registryConfirmedDigest(c.message); got != c.want {
+				t.Errorf("registryConfirmedDigest = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func rawMessage(s string) *json.RawMessage {
+	raw := json.RawMessage(s)
+	return &raw
 }

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -61,7 +62,7 @@ func (d *dockerRegistryWritePlan) Execute(ctx context.Context, tracker *worker.P
 	}
 	defer pushReader.Close()
 
-	if err := consumeDockerProgress(pushReader, tracker, baseStatus); err != nil {
+	if _, err := consumeDockerProgress(pushReader, tracker, baseStatus); err != nil {
 		return fmt.Errorf("error reading push response: %w", err)
 	}
 
@@ -133,6 +134,14 @@ func (d *DockerRegistryOutputHandler) PushImage(ctx context.Context, image *gen.
 		SourceInsecure:      matchesInsecureRegistry(src, d.config.InsecureRegistries),
 		DestinationInsecure: matchesInsecureRegistry(destination, d.config.InsecureRegistries),
 	})
+}
+
+func (d *DockerRegistryOutputHandler) PushLocalImage(ctx context.Context, localTag, destination string, tracker *worker.ProgressTracker) (bool, error) {
+	cli, err := d.lazyClient()
+	if err != nil {
+		return false, err
+	}
+	return false, pushImageFromDaemon(ctx, cli, localTag, destination, tracker)
 }
 
 func (d *DockerRegistryOutputHandler) cacheImageName(digest string) string {
@@ -278,7 +287,7 @@ func (d *DockerRegistryOutputHandler) Load(
 	}()
 
 	// Read and bridge the Docker JSON progress from pull before tagging
-	if err := consumeDockerProgress(pull, tracker, fmt.Sprintf("%s: pulling cache for %s", target.Label, localImageName)); err != nil {
+	if _, err := consumeDockerProgress(pull, tracker, fmt.Sprintf("%s: pulling cache for %s", target.Label, localImageName)); err != nil {
 		return fmt.Errorf("error reading pull response: %w", err)
 	}
 
@@ -288,6 +297,28 @@ func (d *DockerRegistryOutputHandler) Load(
 
 	logger.Debugf("successfully loaded Docker image %s from registry tag %s", localImageName, remoteImageName)
 	return nil
+}
+
+// statusDigestPattern matches the trailing "1.0.0: digest: sha256:… size: 1917"
+// line the daemon emits once the registry has acknowledged a manifest.
+var statusDigestPattern = regexp.MustCompile(`digest:\s+(sha256:[0-9a-f]{64})`)
+
+// The classic image store reports the acknowledged digest as a structured aux
+// payload; the containerd store reports only the status line, so both shapes
+// have to be read.
+func registryConfirmedDigest(jsonMessage jsonmessage.JSONMessage) string {
+	if jsonMessage.Aux != nil {
+		var pushResult struct {
+			Digest string `json:"Digest"`
+		}
+		if err := json.Unmarshal(*jsonMessage.Aux, &pushResult); err == nil && pushResult.Digest != "" {
+			return pushResult.Digest
+		}
+	}
+	if match := statusDigestPattern.FindStringSubmatch(jsonMessage.Status); match != nil {
+		return match[1]
+	}
+	return ""
 }
 
 // dockerLayerProgress holds per-layer tracking state for bridging JSON progress.
@@ -313,13 +344,16 @@ type dockerLayerProgress struct {
 // The base status string is set on the parent immediately so the UI reflects
 // the current plan even before the first daemon message arrives. If parent is
 // nil, the stream is still drained but no progress is emitted.
+//
+// The returned digest is the one the registry confirmed for a push; it is
+// empty for pulls and for pushes the daemon never got a digest for.
 func consumeDockerProgress(
 	reader io.Reader,
 	parent *worker.ProgressTracker,
 	status string,
-) error {
+) (string, error) {
 	if reader == nil {
-		return nil
+		return "", nil
 	}
 
 	// Seed the parent status so the UI shows something meaningful immediately,
@@ -335,17 +369,22 @@ func consumeDockerProgress(
 	layerStates := make(map[string]string)
 	lastPhaseSummary := ""
 
+	pushedDigest := ""
 	for {
 		var jsonMessage jsonmessage.JSONMessage
 		if err := dec.Decode(&jsonMessage); err != nil {
 			if err == io.EOF {
 				break
 			}
-			return err
+			return "", err
 		}
 
 		if jsonMessage.Error != nil {
-			return jsonMessage.Error
+			return "", jsonMessage.Error
+		}
+
+		if digest := registryConfirmedDigest(jsonMessage); digest != "" {
+			pushedDigest = digest
 		}
 
 		// Update the plan-level phase summary whenever a layer transitions to
@@ -401,7 +440,7 @@ func consumeDockerProgress(
 	for _, st := range layers {
 		st.tracker.Complete()
 	}
-	return nil
+	return pushedDigest, nil
 }
 
 // layerPhaseLabels maps the verbose docker daemon status strings to short,

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -11,9 +11,10 @@ import (
 	"strings"
 
 	cerrdefs "github.com/containerd/errdefs"
-	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
 
 	"grog/internal/caching"
 	"grog/internal/config"
@@ -206,23 +207,27 @@ func (d *DockerRegistryOutputHandler) Write(
 	return &PreparedOutput{Output: genOutput, WritePlan: writePlan}, nil
 }
 
+// makeRegistryAuth builds the base64 auth header the daemon expects for ref.
+// Credentials resolve through the same keychain as the daemon-free push path,
+// which is what maps a shorthand reference like "alice/app" onto Docker Hub —
+// splitting the string on "/" would look up a registry named "alice".
 func makeRegistryAuth(ref string) (string, error) {
-	// Extract registry hostname (e.g. "gcr.io" or "myregistry.example.com")
-	registry, _, _ := strings.Cut(ref, "/")
-
-	// Load CLI config (respects DOCKER_CONFIG / XDG_CONFIG_HOME / ~/.docker)
-	cfg, err := dockerconfig.Load("")
+	parsed, err := name.ParseReference(ref)
 	if err != nil {
-		return "", fmt.Errorf("loading docker config: %w", err)
+		return "", fmt.Errorf("parsing reference %q: %w", ref, err)
+	}
+	registry := parsed.Context()
+
+	authenticator, err := authn.DefaultKeychain.Resolve(registry)
+	if err != nil {
+		return "", fmt.Errorf("getting auth config for registry %q: %w", registry.RegistryStr(), err)
 	}
 
-	// Get the AuthConfig for this registry
-	authConfig, err := cfg.GetAuthConfig(registry)
+	authConfig, err := authenticator.Authorization()
 	if err != nil {
-		return "", fmt.Errorf("getting auth config for registry %q: %w", registry, err)
+		return "", fmt.Errorf("reading credentials for registry %q: %w", registry.RegistryStr(), err)
 	}
 
-	// JSON-encode and base64-encode it for the daemon API
 	raw, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", fmt.Errorf("marshaling auth config: %w", err)

--- a/internal/output/handlers/handler.go
+++ b/internal/output/handlers/handler.go
@@ -46,6 +46,10 @@ type Handler interface {
 // destination. Driven by target.OciPush entries after Write/Load.
 type ImagePusher interface {
 	PushImage(ctx context.Context, image *gen.OCIImageOutput, destination string, tracker *worker.ProgressTracker) (skipped bool, err error)
+
+	// PushLocalImage ships an image that exists only in the local docker
+	// daemon, for targets that never stage their oci outputs to the cache.
+	PushLocalImage(ctx context.Context, localTag, destination string, tracker *worker.ProgressTracker) (skipped bool, err error)
 }
 
 type HandlerType string

--- a/internal/output/handlers/oci_push_plan.go
+++ b/internal/output/handlers/oci_push_plan.go
@@ -9,11 +9,11 @@ import (
 	"grog/internal/worker"
 )
 
-// OciPushPlan ships a cached image to a user-facing destination via the oci
-// handler's PushImage.
+// OciPushPlan ships an image to a user-facing destination via the oci handler.
+// The image is sourced either from the cache (NewOciPushPlan) or straight from
+// the local docker daemon (NewLocalOciPushPlan).
 type OciPushPlan struct {
-	pusher      ImagePusher
-	dockerOut   *gen.OCIImageOutput
+	push        func(context.Context, *worker.ProgressTracker) (bool, error)
 	destination string
 	targetLabel string
 	reporter    *PushReporter
@@ -21,8 +21,23 @@ type OciPushPlan struct {
 
 func NewOciPushPlan(pusher ImagePusher, image *gen.OCIImageOutput, destination, targetLabel string, reporter *PushReporter) *OciPushPlan {
 	return &OciPushPlan{
-		pusher:      pusher,
-		dockerOut:   image,
+		push: func(ctx context.Context, tracker *worker.ProgressTracker) (bool, error) {
+			return pusher.PushImage(ctx, image, destination, tracker)
+		},
+		destination: destination,
+		targetLabel: targetLabel,
+		reporter:    reporter,
+	}
+}
+
+// NewLocalOciPushPlan pushes an image that only exists in the local docker
+// daemon. Targets that skip the cache never stage their oci outputs, so there
+// is no cached copy for the daemon-free path to read.
+func NewLocalOciPushPlan(pusher ImagePusher, localTag, destination, targetLabel string, reporter *PushReporter) *OciPushPlan {
+	return &OciPushPlan{
+		push: func(ctx context.Context, tracker *worker.ProgressTracker) (bool, error) {
+			return pusher.PushLocalImage(ctx, localTag, destination, tracker)
+		},
 		destination: destination,
 		targetLabel: targetLabel,
 		reporter:    reporter,
@@ -38,9 +53,13 @@ func (p *OciPushPlan) Execute(ctx context.Context, tracker *worker.ProgressTrack
 		return err
 	}
 
+	if !p.reporter.Claim(p.targetLabel, p.destination) {
+		return nil
+	}
+
 	tracker.SetStatus(fmt.Sprintf("%s: pushing %s", p.targetLabel, p.destination))
 
-	skipped, err := p.pusher.PushImage(ctx, p.dockerOut, p.destination, tracker)
+	skipped, err := p.push(ctx, tracker)
 	p.reporter.Record(PushReport{
 		TargetLabel: p.targetLabel,
 		Destination: p.destination,

--- a/internal/output/handlers/oci_push_plan.go
+++ b/internal/output/handlers/oci_push_plan.go
@@ -53,10 +53,6 @@ func (p *OciPushPlan) Execute(ctx context.Context, tracker *worker.ProgressTrack
 		return err
 	}
 
-	if !p.reporter.Claim(p.targetLabel, p.destination) {
-		return nil
-	}
-
 	tracker.SetStatus(fmt.Sprintf("%s: pushing %s", p.targetLabel, p.destination))
 
 	skipped, err := p.push(ctx, tracker)

--- a/internal/output/handlers/oci_push_plan_test.go
+++ b/internal/output/handlers/oci_push_plan_test.go
@@ -125,21 +125,3 @@ func TestLocalOciPushPlan_PushesFromDaemon(t *testing.T) {
 		t.Errorf("expected one pushed report, got %+v", r)
 	}
 }
-
-func TestOciPushPlan_PushesOncePerDestination(t *testing.T) {
-	pusher := &fakeImagePusher{}
-	reporter := NewPushReporter(nil)
-
-	for range 2 {
-		if err := newTestPlan(pusher, reporter, "repo/image:1").Execute(context.Background(), newTestProgress(t)); err != nil {
-			t.Fatalf("Execute: %v", err)
-		}
-	}
-
-	if len(pusher.calls) != 1 {
-		t.Errorf("PushImage called %d times, want 1 — the same destination must not be pushed twice", len(pusher.calls))
-	}
-	if r := reporter.Reports(); len(r) != 1 {
-		t.Errorf("summary lists %d entries, want 1: %+v", len(r), r)
-	}
-}

--- a/internal/output/handlers/oci_push_plan_test.go
+++ b/internal/output/handlers/oci_push_plan_test.go
@@ -15,18 +15,25 @@ import (
 // the test set. It satisfies the ImagePusher interface without bringing up a
 // docker daemon or a real registry.
 type fakeImagePusher struct {
-	calls   []pushCall
-	skipped bool
-	err     error
+	calls      []pushCall
+	localCalls []pushCall
+	skipped    bool
+	err        error
 }
 
 type pushCall struct {
 	destination string
 	imageID     string
+	localTag    string
 }
 
 func (f *fakeImagePusher) PushImage(_ context.Context, image *gen.OCIImageOutput, dest string, _ *worker.ProgressTracker) (bool, error) {
 	f.calls = append(f.calls, pushCall{destination: dest, imageID: image.GetImageId()})
+	return f.skipped, f.err
+}
+
+func (f *fakeImagePusher) PushLocalImage(_ context.Context, localTag, dest string, _ *worker.ProgressTracker) (bool, error) {
+	f.localCalls = append(f.localCalls, pushCall{destination: dest, localTag: localTag})
 	return f.skipped, f.err
 }
 
@@ -97,5 +104,42 @@ func TestOciPushPlan_FailFastAborts(t *testing.T) {
 	}
 	if len(subsequent.calls) != 0 {
 		t.Errorf("PushImage was invoked after abort (%d calls)", len(subsequent.calls))
+	}
+}
+
+func TestLocalOciPushPlan_PushesFromDaemon(t *testing.T) {
+	pusher := &fakeImagePusher{}
+	reporter := NewPushReporter(nil)
+
+	plan := NewLocalOciPushPlan(pusher, "app-image", "repo/image:1", "//pkg:tgt", reporter)
+	if err := plan.Execute(context.Background(), newTestProgress(t)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(pusher.calls) != 0 {
+		t.Errorf("cache-sourced PushImage was used for a no-cache target: %+v", pusher.calls)
+	}
+	if len(pusher.localCalls) != 1 || pusher.localCalls[0].localTag != "app-image" {
+		t.Fatalf("PushLocalImage calls = %+v, want one for app-image", pusher.localCalls)
+	}
+	if r := reporter.Reports(); len(r) != 1 || r[0].Err != nil {
+		t.Errorf("expected one pushed report, got %+v", r)
+	}
+}
+
+func TestOciPushPlan_PushesOncePerDestination(t *testing.T) {
+	pusher := &fakeImagePusher{}
+	reporter := NewPushReporter(nil)
+
+	for range 2 {
+		if err := newTestPlan(pusher, reporter, "repo/image:1").Execute(context.Background(), newTestProgress(t)); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	}
+
+	if len(pusher.calls) != 1 {
+		t.Errorf("PushImage called %d times, want 1 — the same destination must not be pushed twice", len(pusher.calls))
+	}
+	if r := reporter.Reports(); len(r) != 1 {
+		t.Errorf("summary lists %d entries, want 1: %+v", len(r), r)
 	}
 }

--- a/internal/output/handlers/push_report.go
+++ b/internal/output/handlers/push_report.go
@@ -22,15 +22,33 @@ type PushReporter struct {
 
 	mu      sync.Mutex
 	entries []PushReport
+	claimed map[string]bool
 
 	aborted atomic.Bool
+}
+
+// Claim reserves a (target, destination) pair and reports whether the caller
+// owns the push. A build can reach the same pair from more than one path — a
+// cache-hit load and a dependency load, say — and only the first should ship.
+func (p *PushReporter) Claim(targetLabel, destination string) bool {
+	if p == nil {
+		return true
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	key := targetLabel + " -> " + destination
+	if p.claimed[key] {
+		return false
+	}
+	p.claimed[key] = true
+	return true
 }
 
 func NewPushReporter(failFast func() bool) *PushReporter {
 	if failFast == nil {
 		failFast = func() bool { return false }
 	}
-	return &PushReporter{failFast: failFast}
+	return &PushReporter{failFast: failFast, claimed: make(map[string]bool)}
 }
 
 func (p *PushReporter) Record(report PushReport) {

--- a/internal/output/handlers/push_report.go
+++ b/internal/output/handlers/push_report.go
@@ -22,33 +22,15 @@ type PushReporter struct {
 
 	mu      sync.Mutex
 	entries []PushReport
-	claimed map[string]bool
 
 	aborted atomic.Bool
-}
-
-// Claim reserves a (target, destination) pair and reports whether the caller
-// owns the push. A build can reach the same pair from more than one path — a
-// cache-hit load and a dependency load, say — and only the first should ship.
-func (p *PushReporter) Claim(targetLabel, destination string) bool {
-	if p == nil {
-		return true
-	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	key := targetLabel + " -> " + destination
-	if p.claimed[key] {
-		return false
-	}
-	p.claimed[key] = true
-	return true
 }
 
 func NewPushReporter(failFast func() bool) *PushReporter {
 	if failFast == nil {
 		failFast = func() bool { return false }
 	}
-	return &PushReporter{failFast: failFast, claimed: make(map[string]bool)}
+	return &PushReporter{failFast: failFast}
 }
 
 func (p *PushReporter) Record(report PushReport) {

--- a/internal/output/handlers/registry_auth_test.go
+++ b/internal/output/handlers/registry_auth_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeDockerConfig(t *testing.T, auths string) {
+	t.Helper()
+	configDir := t.TempDir()
+	config := fmt.Sprintf(`{"auths":{%s}}`, auths)
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(config), 0600); err != nil {
+		t.Fatalf("write docker config: %v", err)
+	}
+	t.Setenv("DOCKER_CONFIG", configDir)
+}
+
+func decodeRegistryAuth(t *testing.T, header string) (username, password string) {
+	t.Helper()
+	raw, err := base64.URLEncoding.DecodeString(header)
+	if err != nil {
+		t.Fatalf("decode auth header: %v", err)
+	}
+	var authConfig struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+	if err := json.Unmarshal(raw, &authConfig); err != nil {
+		t.Fatalf("unmarshal auth header %q: %v", raw, err)
+	}
+	return authConfig.Username, authConfig.Password
+}
+
+func encodeAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+// A shorthand destination names a Docker Hub repository, not a registry host,
+// so splitting it on "/" would look up credentials for "alice".
+func TestMakeRegistryAuthResolvesShorthandToDockerHub(t *testing.T) {
+	writeDockerConfig(t, fmt.Sprintf(`"https://index.docker.io/v1/":{"auth":%q}`, encodeAuth("alice", "hunter2")))
+
+	header, err := makeRegistryAuth("alice/app:latest")
+	if err != nil {
+		t.Fatalf("makeRegistryAuth: %v", err)
+	}
+
+	username, password := decodeRegistryAuth(t, header)
+	if username != "alice" || password != "hunter2" {
+		t.Errorf("resolved %q/%q, want the Docker Hub credentials alice/hunter2", username, password)
+	}
+}
+
+func TestMakeRegistryAuthResolvesExplicitHost(t *testing.T) {
+	writeDockerConfig(t, fmt.Sprintf(
+		`"myregistry.example.com":{"auth":%q},"https://index.docker.io/v1/":{"auth":%q}`,
+		encodeAuth("robot", "s3cret"), encodeAuth("alice", "hunter2"),
+	))
+
+	header, err := makeRegistryAuth("myregistry.example.com/team/app:1")
+	if err != nil {
+		t.Fatalf("makeRegistryAuth: %v", err)
+	}
+
+	username, password := decodeRegistryAuth(t, header)
+	if username != "robot" || password != "s3cret" {
+		t.Errorf("resolved %q/%q, want the host credentials robot/s3cret", username, password)
+	}
+}
+
+func TestMakeRegistryAuthWithoutCredentials(t *testing.T) {
+	writeDockerConfig(t, "")
+
+	header, err := makeRegistryAuth("myregistry.example.com/team/app:1")
+	if err != nil {
+		t.Fatalf("makeRegistryAuth: %v", err)
+	}
+
+	username, password := decodeRegistryAuth(t, header)
+	if username != "" || password != "" {
+		t.Errorf("resolved %q/%q for an unauthenticated registry, want empty", username, password)
+	}
+}

--- a/internal/output/push/pusher.go
+++ b/internal/output/push/pusher.go
@@ -1,0 +1,143 @@
+// Package push turns a target's oci_push map into the work that ships its
+// images. Keeping it out of the output registry means a push is triggered by
+// the completion path a target took, not by the fact that its outputs were
+// touched — loading a dependency's outputs is not a completion.
+package push
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"grog/internal/model"
+	"grog/internal/output/handlers"
+	"grog/internal/proto/gen"
+	"grog/internal/worker"
+)
+
+// Pusher owns everything --push: which images ship where, and the summary the
+// build prints once it is done.
+type Pusher struct {
+	images   handlers.ImagePusher
+	reporter *handlers.PushReporter
+	enabled  func() bool
+}
+
+// New wires a Pusher to the oci output handler. An oci handler that cannot
+// push is a wiring mistake in grog itself, not a user error.
+func New(ociHandler handlers.Handler, enabled, failFast func() bool) (*Pusher, error) {
+	images, ok := ociHandler.(handlers.ImagePusher)
+	if !ok {
+		return nil, fmt.Errorf("oci handler %T does not implement handlers.ImagePusher", ociHandler)
+	}
+	if enabled == nil {
+		enabled = func() bool { return false }
+	}
+	return &Pusher{
+		images:   images,
+		reporter: handlers.NewPushReporter(failFast),
+		enabled:  enabled,
+	}, nil
+}
+
+// Reporter aggregates every push outcome for the end-of-build summary.
+func (p *Pusher) Reporter() *handlers.PushReporter {
+	if p == nil {
+		return nil
+	}
+	return p.reporter
+}
+
+// Enabled reports whether --push is on. A nil Pusher never pushes, so callers
+// that do not wire one keep working.
+func (p *Pusher) Enabled() bool {
+	return p != nil && p.enabled()
+}
+
+// PlansFromCache returns one plan per (oci output, destination), each sourcing
+// the image grog staged in the cache. A key matching no oci:: output is a
+// recipe bug, so it fails the target rather than landing in the push summary.
+func (p *Pusher) PlansFromCache(target *model.Target, outputs []*gen.Output) ([]handlers.OutputWritePlan, error) {
+	if !p.Enabled() {
+		return nil, nil
+	}
+	var plans []handlers.OutputWritePlan
+	for _, destination := range destinationsOf(target) {
+		image := findOciImageByLocalTag(outputs, destination.localName)
+		if image == nil {
+			return nil, fmt.Errorf("%s: oci_push key %q does not match any oci:: output", target.Label, destination.localName)
+		}
+		plans = append(plans, handlers.NewOciPushPlan(
+			p.images, image, destination.reference, target.Label.String(), p.reporter,
+		))
+	}
+	return plans, nil
+}
+
+// PlansFromDaemon sources straight from the local docker daemon: targets that
+// skip the cache never stage their oci outputs, so the plans from
+// PlansFromCache would have nothing to read.
+func (p *Pusher) PlansFromDaemon(target *model.Target) []handlers.OutputWritePlan {
+	if !p.Enabled() {
+		return nil
+	}
+	var plans []handlers.OutputWritePlan
+	for _, destination := range destinationsOf(target) {
+		plans = append(plans, handlers.NewLocalOciPushPlan(
+			p.images, destination.localName, destination.reference, target.Label.String(), p.reporter,
+		))
+	}
+	return plans
+}
+
+// PushFromCache ships a cache-hit target's destinations inline. The image comes
+// from the cache, so this runs whether or not the outputs were loaded. A
+// registry hiccup lands in the reporter rather than invalidating the cache
+// restore, so only a malformed oci_push map returns an error.
+func (p *Pusher) PushFromCache(
+	ctx context.Context,
+	target *model.Target,
+	targetResult *gen.TargetResult,
+	progress *worker.ProgressTracker,
+) error {
+	plans, err := p.PlansFromCache(target, targetResult.GetOutputs())
+	if err != nil {
+		return err
+	}
+	for _, plan := range plans {
+		_ = plan.Execute(ctx, progress)
+	}
+	return nil
+}
+
+type destination struct {
+	localName string
+	reference string
+}
+
+// destinationsOf flattens target.OciPush in a stable order, so neither the
+// order pushes run in nor the summary that reports them depends on map
+// iteration order.
+func destinationsOf(target *model.Target) []destination {
+	var destinations []destination
+	for _, localName := range slices.Sorted(maps.Keys(target.OciPush)) {
+		for _, reference := range target.OciPush[localName] {
+			destinations = append(destinations, destination{localName: localName, reference: reference})
+		}
+	}
+	return destinations
+}
+
+func findOciImageByLocalTag(outputs []*gen.Output, localTag string) *gen.OCIImageOutput {
+	for _, output := range outputs {
+		image := output.GetOciImage()
+		if image == nil {
+			continue
+		}
+		if image.GetLocalTag() == localTag {
+			return image
+		}
+	}
+	return nil
+}

--- a/internal/output/push/pusher_test.go
+++ b/internal/output/push/pusher_test.go
@@ -1,0 +1,168 @@
+package push
+
+import (
+	"context"
+	"testing"
+
+	"grog/internal/label"
+	"grog/internal/model"
+	"grog/internal/output/handlers"
+	"grog/internal/proto/gen"
+	"grog/internal/worker"
+)
+
+type fakeOciHandler struct {
+	pushed      []string
+	localPushed []string
+}
+
+func (f *fakeOciHandler) Type() handlers.HandlerType { return handlers.OCIHandler }
+
+func (f *fakeOciHandler) Write(context.Context, model.Target, model.Output, *worker.ProgressTracker) (*handlers.PreparedOutput, error) {
+	return nil, nil
+}
+
+func (f *fakeOciHandler) Hash(context.Context, model.Target, model.Output) (string, error) {
+	return "", nil
+}
+
+func (f *fakeOciHandler) Load(context.Context, model.Target, *gen.Output, *worker.ProgressTracker) error {
+	return nil
+}
+
+func (f *fakeOciHandler) PushImage(_ context.Context, _ *gen.OCIImageOutput, destination string, _ *worker.ProgressTracker) (bool, error) {
+	f.pushed = append(f.pushed, destination)
+	return false, nil
+}
+
+func (f *fakeOciHandler) PushLocalImage(_ context.Context, _ string, destination string, _ *worker.ProgressTracker) (bool, error) {
+	f.localPushed = append(f.localPushed, destination)
+	return false, nil
+}
+
+// nonPushingHandler is a Handler that lacks the ImagePusher capability.
+type nonPushingHandler struct{ handlers.Handler }
+
+func TestNewRejectsHandlerThatCannotPush(t *testing.T) {
+	if _, err := New(nonPushingHandler{}, func() bool { return true }, nil); err == nil {
+		t.Fatal("expected an error for an oci handler that does not implement ImagePusher")
+	}
+}
+
+func newTestPusher(t *testing.T, enabled bool) (*Pusher, *fakeOciHandler) {
+	t.Helper()
+	handler := &fakeOciHandler{}
+	pusher, err := New(handler, func() bool { return enabled }, nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return pusher, handler
+}
+
+func testTarget(ociPush map[string][]string) *model.Target {
+	return &model.Target{Label: label.TL("pkg", "tgt"), OciPush: ociPush}
+}
+
+func cachedOutputs(localTags ...string) []*gen.Output {
+	outputs := make([]*gen.Output, 0, len(localTags))
+	for _, localTag := range localTags {
+		outputs = append(outputs, &gen.Output{
+			Kind: &gen.Output_OciImage{OciImage: &gen.OCIImageOutput{LocalTag: localTag}},
+		})
+	}
+	return outputs
+}
+
+func TestPlansFromCacheOnePerDestination(t *testing.T) {
+	pusher, _ := newTestPusher(t, true)
+	target := testTarget(map[string][]string{"app": {"registry.test/app:1", "registry.test/app:latest"}})
+
+	plans, err := pusher.PlansFromCache(target, cachedOutputs("app"))
+	if err != nil {
+		t.Fatalf("PlansFromCache: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("got %d plans, want one per destination", len(plans))
+	}
+}
+
+func TestPlansFromCacheRejectsUnknownLocalName(t *testing.T) {
+	pusher, _ := newTestPusher(t, true)
+	target := testTarget(map[string][]string{"typo": {"registry.test/app:1"}})
+
+	if _, err := pusher.PlansFromCache(target, cachedOutputs("app")); err == nil {
+		t.Fatal("an oci_push key matching no oci:: output must fail the target")
+	}
+}
+
+func TestPlansAreEmptyWithoutPushFlag(t *testing.T) {
+	pusher, _ := newTestPusher(t, false)
+	target := testTarget(map[string][]string{"app": {"registry.test/app:1"}})
+
+	plans, err := pusher.PlansFromCache(target, cachedOutputs("app"))
+	if err != nil {
+		t.Fatalf("PlansFromCache: %v", err)
+	}
+	if len(plans) != 0 || len(pusher.PlansFromDaemon(target)) != 0 {
+		t.Error("--push is off, so no target should produce push plans")
+	}
+}
+
+// A no-cache target has nothing staged, so its plans must read the daemon.
+func TestPlansFromDaemonBypassTheCache(t *testing.T) {
+	pusher, handler := newTestPusher(t, true)
+	target := testTarget(map[string][]string{"app": {"registry.test/app:1"}})
+
+	for _, plan := range pusher.PlansFromDaemon(target) {
+		if err := plan.Execute(context.Background(), newProgress()); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	}
+
+	if len(handler.pushed) != 0 {
+		t.Errorf("cache-sourced push used for a no-cache target: %v", handler.pushed)
+	}
+	if len(handler.localPushed) != 1 {
+		t.Errorf("daemon pushes = %v, want one", handler.localPushed)
+	}
+}
+
+func TestPushFromCacheShipsEveryDestinationInOrder(t *testing.T) {
+	pusher, handler := newTestPusher(t, true)
+	target := testTarget(map[string][]string{
+		"beta":  {"registry.test/beta:1"},
+		"alpha": {"registry.test/alpha:1"},
+	})
+	targetResult := &gen.TargetResult{Outputs: cachedOutputs("alpha", "beta")}
+
+	if err := pusher.PushFromCache(context.Background(), target, targetResult, newProgress()); err != nil {
+		t.Fatalf("PushFromCache: %v", err)
+	}
+
+	want := []string{"registry.test/alpha:1", "registry.test/beta:1"}
+	if len(handler.pushed) != len(want) {
+		t.Fatalf("pushed %v, want %v", handler.pushed, want)
+	}
+	for index := range want {
+		if handler.pushed[index] != want[index] {
+			t.Fatalf("pushed %v, want %v (map iteration order must not leak)", handler.pushed, want)
+		}
+	}
+}
+
+func TestNilPusherNeverPushes(t *testing.T) {
+	var pusher *Pusher
+	target := testTarget(map[string][]string{"app": {"registry.test/app:1"}})
+
+	plans, err := pusher.PlansFromCache(target, cachedOutputs("app"))
+	if err != nil || len(plans) != 0 {
+		t.Errorf("PlansFromCache on a nil Pusher = (%v, %v), want no plans and no error", plans, err)
+	}
+	if pusher.Enabled() || pusher.Reporter() != nil {
+		t.Error("a nil Pusher must report itself as disabled")
+	}
+}
+
+func newProgress() *worker.ProgressTracker {
+	return worker.NewProgressTracker("test", 0, func(worker.StatusUpdate) {})
+}

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -8,6 +8,8 @@ import (
 	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/hashing"
+	stdmaps "maps"
+
 	"grog/internal/maps"
 	"grog/internal/model"
 	"grog/internal/output/handlers"
@@ -90,26 +92,120 @@ func NewRegistry(
 	return r
 }
 
-// buildPushPlans assembles one push plan per (oci output, destination) for
-// every entry in target.OciPush. Returns an error if a key references a name
-// that is not produced by the target's oci:: outputs — that's a recipe bug.
+type pushDestination struct {
+	localName   string
+	destination string
+}
+
+// pushDestinations flattens target.OciPush in a stable order, so neither the
+// order pushes run in nor the summary that reports them depends on map
+// iteration order.
+func pushDestinations(target *model.Target) []pushDestination {
+	var destinations []pushDestination
+	for _, localName := range slices.Sorted(stdmaps.Keys(target.OciPush)) {
+		for _, destination := range target.OciPush[localName] {
+			destinations = append(destinations, pushDestination{localName: localName, destination: destination})
+		}
+	}
+	return destinations
+}
+
+// buildPushPlans assembles one push plan per (oci output, destination), each
+// sourcing the image grog cached. Returns an error if a key references a name
+// the target's oci:: outputs do not produce — that's a recipe bug.
 func (r *Registry) buildPushPlans(target *model.Target, outputs []*gen.Output) ([]handlers.OutputWritePlan, error) {
-	if len(target.OciPush) == 0 {
+	if !r.pushIsEnabled() {
 		return nil, nil
 	}
 	var plans []handlers.OutputWritePlan
-	for localName, destinations := range target.OciPush {
-		ociImage := findOciImageByLocalTag(outputs, localName)
+	for _, push := range pushDestinations(target) {
+		ociImage := findOciImageByLocalTag(outputs, push.localName)
 		if ociImage == nil {
-			return nil, fmt.Errorf("%s: oci_push key %q does not match any oci:: output", target.Label, localName)
+			return nil, fmt.Errorf("%s: oci_push key %q does not match any oci:: output", target.Label, push.localName)
 		}
-		for _, dest := range destinations {
-			plans = append(plans, handlers.NewOciPushPlan(
-				r.imagePusher, ociImage, dest, target.Label.String(), r.pushReporter,
-			))
-		}
+		plans = append(plans, handlers.NewOciPushPlan(
+			r.imagePusher, ociImage, push.destination, target.Label.String(), r.pushReporter,
+		))
 	}
 	return plans, nil
+}
+
+// BuildLocalPushPlans sources straight from the local docker daemon: targets
+// that skip the cache never stage their oci outputs, so the plans from
+// buildPushPlans would have nothing to read.
+func (r *Registry) BuildLocalPushPlans(target *model.Target) []handlers.OutputWritePlan {
+	if !r.pushIsEnabled() {
+		return nil
+	}
+	var plans []handlers.OutputWritePlan
+	for _, push := range pushDestinations(target) {
+		plans = append(plans, handlers.NewLocalOciPushPlan(
+			r.imagePusher, push.localName, push.destination, target.Label.String(), r.pushReporter,
+		))
+	}
+	return plans
+}
+
+// PushCachedOutputs ships a cache-hit target's oci_push destinations. The push
+// reads the image from the cache, so it runs whether or not the outputs were
+// loaded. A registry hiccup lands in the reporter rather than invalidating the
+// cache restore, so only a malformed oci_push map returns an error.
+func (r *Registry) PushCachedOutputs(
+	ctx context.Context,
+	target *model.Target,
+	targetResult *gen.TargetResult,
+	progress *worker.ProgressTracker,
+) error {
+	plans, err := r.buildPushPlans(target, targetResult.GetOutputs())
+	if err != nil {
+		return err
+	}
+	for _, plan := range plans {
+		_ = plan.Execute(ctx, progress)
+	}
+	return nil
+}
+
+func (r *Registry) pushIsEnabled() bool {
+	return r.pushEnabled != nil && r.pushEnabled()
+}
+
+// SnapshotOciImages records the image id the local docker daemon holds for
+// each of the target's oci:: outputs. Outputs the daemon cannot resolve are
+// left out entirely.
+func (r *Registry) SnapshotOciImages(ctx context.Context, target *model.Target) map[string]string {
+	snapshot := make(map[string]string)
+	for _, outputRef := range target.AllOutputs() {
+		if outputRef.Type != string(handlers.OCIHandler) {
+			continue
+		}
+		imageID, err := r.mustGetHandler(outputRef.Type).Hash(ctx, *target, outputRef)
+		if err != nil {
+			continue
+		}
+		snapshot[outputRef.Identifier] = imageID
+	}
+	return snapshot
+}
+
+// WarnOnUnproducedOciImages flags oci:: outputs the command left exactly as it
+// found them. Grog would go on to cache — and under --push ship — an image the
+// build never produced, which is near-impossible to spot from the outside.
+func (r *Registry) WarnOnUnproducedOciImages(ctx context.Context, target *model.Target, before map[string]string) {
+	after := r.SnapshotOciImages(ctx, target)
+	logger := console.GetLogger(ctx)
+	for _, identifier := range slices.Sorted(stdmaps.Keys(before)) {
+		if after[identifier] != before[identifier] {
+			continue
+		}
+		logger.Warnf(
+			"%s: oci output %s is unchanged after running the command. "+
+				"If the command does not load its result into the local Docker daemon "+
+				"(e.g. buildx with a docker-container or cloud driver and no --load), "+
+				"grog caches and pushes the image that was already there.",
+			target.Label, identifier,
+		)
+	}
 }
 
 func findOciImageByLocalTag(outputs []*gen.Output, localTag string) *gen.OCIImageOutput {
@@ -238,16 +334,13 @@ func (r *Registry) PrepareOutputs(
 		}
 	}
 
-	// Append a push plan per (oci output, destination) for any oci_push entry
-	// declared on the target. Each plan runs after the cache plans so that
-	// image_id and manifest_digest are populated before it tries to source.
-	if r.pushEnabled != nil && r.pushEnabled() {
-		pushPlans, err := r.buildPushPlans(target, targetOutputs)
-		if err != nil {
-			return nil, err
-		}
-		writePlans = append(writePlans, pushPlans...)
+	// Push plans run after the cache plans so that image_id and
+	// manifest_digest are populated before a push tries to source them.
+	pushPlans, err := r.buildPushPlans(target, targetOutputs)
+	if err != nil {
+		return nil, err
 	}
+	writePlans = append(writePlans, pushPlans...)
 
 	outputHash, err := getOutputHash(targetOutputs)
 	if err != nil {
@@ -357,18 +450,10 @@ func (r *Registry) LoadOutputs(
 		return err
 	}
 
-	// Fire pushes for every oci_push entry on the current target. The cached
-	// proto only carries the local image; destinations come from the live
-	// target. Push errors are recorded to the reporter but never propagated
-	// — a transient registry hiccup must not invalidate a cache restore.
-	if r.pushEnabled != nil && r.pushEnabled() && len(target.OciPush) > 0 {
-		plans, err := r.buildPushPlans(target, targetResult.Outputs)
-		if err != nil {
-			return err
-		}
-		for _, plan := range plans {
-			_ = plan.Execute(ctx, progress)
-		}
+	// The cached proto only carries the local image; destinations come from
+	// the live target.
+	if err := r.PushCachedOutputs(ctx, target, targetResult, progress); err != nil {
+		return err
 	}
 
 	logger.Debugf("%s: outputs loaded", target.Label)

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -46,10 +46,6 @@ type Registry struct {
 	hashCache       map[string]string
 	outputHashMutex sync.RWMutex
 	outputHashCache map[string]map[model.Output]string
-
-	pushReporter *handlers.PushReporter
-	pushEnabled  func() bool
-	imagePusher  handlers.ImagePusher
 }
 
 // NewRegistry creates a new registry with default handlers.
@@ -57,9 +53,6 @@ func NewRegistry(
 	ctx context.Context,
 	cas *caching.Cas,
 ) *Registry {
-	pushReporter := handlers.NewPushReporter(func() bool { return config.Global.FailFast })
-	pushEnabled := func() bool { return config.Global.Push }
-
 	r := &Registry{
 		handlers:        make(map[string]handlers.Handler),
 		targetMutexMap:  maps.NewMutexMap(),
@@ -68,106 +61,17 @@ func NewRegistry(
 		pool: pond.NewPool(
 			runtime.NumCPU() * 2,
 		),
-		pushReporter: pushReporter,
 	}
 
 	r.Register(handlers.NewFileOutputHandler(cas))
 	r.Register(handlers.NewDirectoryOutputHandler(cas))
 
-	var ociHandler handlers.Handler
 	if config.Global.OCI.Backend == "registry" {
-		ociHandler = handlers.NewDockerRegistryOutputHandler(cas, config.Global.OCI)
+		r.Register(handlers.NewDockerRegistryOutputHandler(cas, config.Global.OCI))
 	} else {
-		ociHandler = handlers.NewDockerOutputHandler(ctx, cas, config.Global.OCI.InsecureRegistries)
+		r.Register(handlers.NewDockerOutputHandler(ctx, cas, config.Global.OCI.InsecureRegistries))
 	}
-	r.Register(ociHandler)
-	// The oci handler also pushes images; record the ImagePusher facet so
-	// the per-target push hook can find it without re-traversing handlers.
-	pusher, ok := ociHandler.(handlers.ImagePusher)
-	if !ok {
-		panic(fmt.Sprintf("oci handler %T does not implement ImagePusher", ociHandler))
-	}
-	r.imagePusher = pusher
-	r.pushEnabled = pushEnabled
 	return r
-}
-
-type pushDestination struct {
-	localName   string
-	destination string
-}
-
-// pushDestinations flattens target.OciPush in a stable order, so neither the
-// order pushes run in nor the summary that reports them depends on map
-// iteration order.
-func pushDestinations(target *model.Target) []pushDestination {
-	var destinations []pushDestination
-	for _, localName := range slices.Sorted(stdmaps.Keys(target.OciPush)) {
-		for _, destination := range target.OciPush[localName] {
-			destinations = append(destinations, pushDestination{localName: localName, destination: destination})
-		}
-	}
-	return destinations
-}
-
-// buildPushPlans assembles one push plan per (oci output, destination), each
-// sourcing the image grog cached. Returns an error if a key references a name
-// the target's oci:: outputs do not produce — that's a recipe bug.
-func (r *Registry) buildPushPlans(target *model.Target, outputs []*gen.Output) ([]handlers.OutputWritePlan, error) {
-	if !r.pushIsEnabled() {
-		return nil, nil
-	}
-	var plans []handlers.OutputWritePlan
-	for _, push := range pushDestinations(target) {
-		ociImage := findOciImageByLocalTag(outputs, push.localName)
-		if ociImage == nil {
-			return nil, fmt.Errorf("%s: oci_push key %q does not match any oci:: output", target.Label, push.localName)
-		}
-		plans = append(plans, handlers.NewOciPushPlan(
-			r.imagePusher, ociImage, push.destination, target.Label.String(), r.pushReporter,
-		))
-	}
-	return plans, nil
-}
-
-// BuildLocalPushPlans sources straight from the local docker daemon: targets
-// that skip the cache never stage their oci outputs, so the plans from
-// buildPushPlans would have nothing to read.
-func (r *Registry) BuildLocalPushPlans(target *model.Target) []handlers.OutputWritePlan {
-	if !r.pushIsEnabled() {
-		return nil
-	}
-	var plans []handlers.OutputWritePlan
-	for _, push := range pushDestinations(target) {
-		plans = append(plans, handlers.NewLocalOciPushPlan(
-			r.imagePusher, push.localName, push.destination, target.Label.String(), r.pushReporter,
-		))
-	}
-	return plans
-}
-
-// PushCachedOutputs ships a cache-hit target's oci_push destinations. The push
-// reads the image from the cache, so it runs whether or not the outputs were
-// loaded. A registry hiccup lands in the reporter rather than invalidating the
-// cache restore, so only a malformed oci_push map returns an error.
-func (r *Registry) PushCachedOutputs(
-	ctx context.Context,
-	target *model.Target,
-	targetResult *gen.TargetResult,
-	progress *worker.ProgressTracker,
-) error {
-	plans, err := r.buildPushPlans(target, targetResult.GetOutputs())
-	if err != nil {
-		return err
-	}
-	for _, plan := range plans {
-		_ = plan.Execute(ctx, progress)
-	}
-	return nil
-}
-
-func (r *Registry) pushIsEnabled() bool {
-	return r.pushEnabled != nil && r.pushEnabled()
 }
 
 // SnapshotOciImages records the image id the local docker daemon holds for
@@ -208,23 +112,6 @@ func (r *Registry) WarnOnUnproducedOciImages(ctx context.Context, target *model.
 	}
 }
 
-func findOciImageByLocalTag(outputs []*gen.Output, localTag string) *gen.OCIImageOutput {
-	for _, out := range outputs {
-		img := out.GetOciImage()
-		if img == nil {
-			continue
-		}
-		if img.GetLocalTag() == localTag {
-			return img
-		}
-	}
-	return nil
-}
-
-func (r *Registry) PushReporter() *handlers.PushReporter {
-	return r.pushReporter
-}
-
 // Close releases resources held by output handlers (notably the in-process
 // loopback Docker registry). Must be called only after all async cache writes
 // have drained — otherwise an in-flight `docker push` may race the proxy
@@ -255,6 +142,16 @@ func (r *Registry) Register(handler handlers.Handler) {
 		panic(fmt.Sprintf("handler for type %s already registered", handler.Type()))
 	}
 	r.handlers[string(handler.Type())] = handler
+}
+
+// Handler exposes a registered handler so callers can use capabilities the
+// registry itself has no business driving, such as pushing oci images.
+func (r *Registry) Handler(outputType handlers.HandlerType) (handlers.Handler, bool) {
+	r.handlerMutex.RLock()
+	defer r.handlerMutex.RUnlock()
+
+	handler, exists := r.handlers[string(outputType)]
+	return handler, exists
 }
 
 // GetHandler retrieves a handler by type.
@@ -333,14 +230,6 @@ func (r *Registry) PrepareOutputs(
 			writePlans = append(writePlans, preparedOutput.WritePlan)
 		}
 	}
-
-	// Push plans run after the cache plans so that image_id and
-	// manifest_digest are populated before a push tries to source them.
-	pushPlans, err := r.buildPushPlans(target, targetOutputs)
-	if err != nil {
-		return nil, err
-	}
-	writePlans = append(writePlans, pushPlans...)
 
 	outputHash, err := getOutputHash(targetOutputs)
 	if err != nil {
@@ -447,12 +336,6 @@ func (r *Registry) LoadOutputs(
 	}
 
 	if err := ensureBinOutputExecutable(target); err != nil {
-		return err
-	}
-
-	// The cached proto only carries the local image; destinations come from
-	// the live target.
-	if err := r.PushCachedOutputs(ctx, target, targetResult, progress); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`grog build --push` could finish green while the registry kept stale content. Reproduced against a local registry; each fix has a regression test.

## Pushes that never happened
- **`no-cache` targets** (and everything under `--enable-cache=false`) took the `GetNoCacheOutputHash` branch, which builds no write plans — so no push plan was ever constructed. No push, no summary line, exit 0. These now push straight from the local daemon, since nothing was staged for the daemon-free path to read.
- **`load_outputs=minimal` cache hits** returned before `LoadOutputs`, the only place cache-hit pushes lived. They now push from the cache without loading outputs.
- **Multi-platform images** were resolved to their `linux/amd64` child by `remote.Image`, landing a digest the build never produced — or failing outright on arm64 hosts. Indexes now copy whole.

## Pushes that are now verified
- `Copy` reads the destination back after writing and fails if the registry does not serve the digest it just shipped; the daemon path requires the digest the registry acknowledged (both image stores report it differently).
- A target whose command leaves its `oci::` image untouched warns — grog would otherwise cache and push an image the build never produced. Warning, not error: the daemon cannot distinguish that from a byte-identical rebuild.
- A `push.Pusher` now owns plan construction and the executor triggers it at each completion path, so pushing is no longer a side effect of loading outputs — and a re-run after a failed output load ships the image it just rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
