### PR TITLE
feat(oci): tee oci_push blob streams off the cache-write pipeline

### DIFF
--- a/docs/src/content/docs/topics/docker-outputs.mdx
+++ b/docs/src/content/docs/topics/docker-outputs.mdx
@@ -333,6 +333,14 @@ digest. `--push` applies transitively across the build selection, so a
 The `oci_push` map is **not** part of the cache key, so bumping the tag in
 your destination string reuses the cached image and only re-runs the push.
 
+On a cache miss with the default (filesystem/S3/GCS/Azure) backend, layer
+blobs are streamed to every push destination _while_ they stream into the
+cache — each layer's bytes leave the daemon once instead of being read back
+from the cache for the push. The push step that follows then just verifies
+the blobs arrived and writes the manifest; if any streamed upload failed it
+falls back to uploading from the cache, so a flaky destination costs
+bandwidth, never correctness.
+
 ### Insecure registries
 
 By default Grog pushes over HTTPS. To allow plain HTTP destinations (local

--- a/internal/oci_push/tee.go
+++ b/internal/oci_push/tee.go
@@ -1,0 +1,234 @@
+package oci_push
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+
+	"grog/internal/ociproxy"
+)
+
+// Tee opportunistically streams blobs to oci_push destination repositories
+// while the daemon is still uploading them to the cache. Any failure just
+// leaves blobs for the subsequent push plan to re-upload from the CAS.
+type Tee struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	repos  []name.Repository
+
+	uploads sync.WaitGroup
+
+	mu          sync.Mutex
+	uploadCount int
+	failedRepos map[string]error
+}
+
+var _ ociproxy.BlobTee = (*Tee)(nil)
+
+// NewTee parses and deduplicates the destination references into repositories.
+// isInsecure reports whether a destination is a declared plain-HTTP registry.
+func NewTee(ctx context.Context, destinations []string, isInsecure func(string) bool) (*Tee, error) {
+	seen := make(map[string]bool)
+	var repos []name.Repository
+	for _, destination := range destinations {
+		ref, err := parseRef(destination, isInsecure(destination))
+		if err != nil {
+			return nil, fmt.Errorf("parse push destination %q: %w", destination, err)
+		}
+		repo := ref.Context()
+		if seen[repo.String()] {
+			continue
+		}
+		seen[repo.String()] = true
+		repos = append(repos, repo)
+	}
+	teeCtx, cancel := context.WithCancel(ctx)
+	return &Tee{ctx: teeCtx, cancel: cancel, repos: repos, failedRepos: make(map[string]error)}, nil
+}
+
+// OpenBlob starts one streaming upload per destination repository and returns
+// a sink that fans the blob's bytes out to all of them.
+func (t *Tee) OpenBlob() ociproxy.BlobSink {
+	sink := &blobSink{}
+	for _, repo := range t.repos {
+		if t.hasFailed(repo) {
+			continue
+		}
+		pipeReader, pipeWriter := io.Pipe()
+		blob := &streamedBlob{reader: pipeReader}
+		t.uploads.Add(1)
+		go func(repo name.Repository) {
+			defer t.uploads.Done()
+			err := remote.WriteLayer(repo, blob,
+				remote.WithContext(t.ctx),
+				remote.WithAuthFromKeychain(authn.DefaultKeychain),
+			)
+			if err != nil {
+				t.recordFailure(repo, err)
+				_ = pipeReader.CloseWithError(err)
+				return
+			}
+			t.recordUpload()
+		}(repo)
+		sink.uploads = append(sink.uploads, &blobUpload{writer: pipeWriter, blob: blob})
+	}
+	if len(sink.uploads) == 0 {
+		return nil
+	}
+	return sink
+}
+
+// Abort cancels all in-flight uploads, e.g. when the daemon push that feeds
+// the tee has failed and abandoned upload sessions would otherwise leave
+// destination uploads blocked forever.
+func (t *Tee) Abort() {
+	t.cancel()
+}
+
+// Wait blocks until every started upload has settled and reports the number
+// of successful blob uploads across all destination repositories plus the
+// first error per failed repository.
+func (t *Tee) Wait() (int, map[string]error) {
+	t.uploads.Wait()
+	t.cancel()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.uploadCount, maps.Clone(t.failedRepos)
+}
+
+func (t *Tee) hasFailed(repo name.Repository) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, failed := t.failedRepos[repo.String()]
+	return failed
+}
+
+func (t *Tee) recordFailure(repo name.Repository, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, exists := t.failedRepos[repo.String()]; !exists {
+		t.failedRepos[repo.String()] = err
+	}
+}
+
+func (t *Tee) recordUpload() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.uploadCount++
+}
+
+type blobUpload struct {
+	writer *io.PipeWriter
+	blob   *streamedBlob
+	dead   bool
+}
+
+// blobSink fans one blob's bytes out to every destination upload. Per the
+// ociproxy.BlobSink contract it is best-effort: a failed destination is
+// dropped and Write always reports success to the proxy.
+type blobSink struct {
+	uploads []*blobUpload
+	size    int64
+}
+
+func (s *blobSink) Write(p []byte) (int, error) {
+	for _, upload := range s.uploads {
+		if upload.dead {
+			continue
+		}
+		if _, err := upload.writer.Write(p); err != nil {
+			upload.dead = true
+		}
+	}
+	s.size += int64(len(p))
+	return len(p), nil
+}
+
+func (s *blobSink) Commit(digest string) {
+	hash, err := v1.NewHash(digest)
+	if err != nil {
+		s.Cancel()
+		return
+	}
+	for _, upload := range s.uploads {
+		upload.blob.finalize(hash, s.size)
+		_ = upload.writer.Close()
+	}
+}
+
+func (s *blobSink) Cancel() {
+	for _, upload := range s.uploads {
+		_ = upload.writer.CloseWithError(errors.New("blob upload cancelled"))
+	}
+}
+
+// streamedBlob is a v1.Layer over an in-flight blob upload. Digest/Size answer
+// stream.ErrNotComputed until finalize, which makes remote.WriteLayer stream
+// the bytes first and only then ask for the digest to commit the upload.
+type streamedBlob struct {
+	reader *io.PipeReader
+
+	mu       sync.Mutex
+	consumed bool
+	done     bool
+	digest   v1.Hash
+	size     int64
+}
+
+func (b *streamedBlob) finalize(digest v1.Hash, size int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.digest = digest
+	b.size = size
+	b.done = true
+}
+
+func (b *streamedBlob) Compressed() (io.ReadCloser, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.consumed {
+		return nil, stream.ErrConsumed
+	}
+	b.consumed = true
+	return b.reader, nil
+}
+
+func (b *streamedBlob) Uncompressed() (io.ReadCloser, error) {
+	return nil, errors.New("streamed blob: uncompressed access not supported")
+}
+
+func (b *streamedBlob) Digest() (v1.Hash, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.done {
+		return v1.Hash{}, stream.ErrNotComputed
+	}
+	return b.digest, nil
+}
+
+func (b *streamedBlob) DiffID() (v1.Hash, error) {
+	return v1.Hash{}, stream.ErrNotComputed
+}
+
+func (b *streamedBlob) Size() (int64, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.done {
+		return 0, stream.ErrNotComputed
+	}
+	return b.size, nil
+}
+
+func (b *streamedBlob) MediaType() (types.MediaType, error) {
+	return types.DockerLayer, nil
+}

--- a/internal/oci_push/tee_test.go
+++ b/internal/oci_push/tee_test.go
@@ -1,0 +1,202 @@
+package oci_push_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"grog/internal/caching"
+	"grog/internal/caching/backends"
+	"grog/internal/oci_push"
+	"grog/internal/ociproxy"
+)
+
+func newDestinationRegistry(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	server := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(server.Close)
+	return server, strings.TrimPrefix(server.URL, "http://")
+}
+
+func digestOf(payload []byte) string {
+	sum := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func insecureAlways(string) bool { return true }
+
+func TestTeeStreamsBlobToAllDestinationRepos(t *testing.T) {
+	server, host := newDestinationRegistry(t)
+	ctx := context.Background()
+
+	// Two tags on the same repo must dedupe into one upload; the second repo
+	// gets its own.
+	tee, err := oci_push.NewTee(ctx, []string{
+		host + "/test/app:v1",
+		host + "/test/app:v2",
+		host + "/other/app:v1",
+	}, insecureAlways)
+	require.NoError(t, err)
+
+	payload := []byte("fake compressed layer bytes")
+	digest := digestOf(payload)
+
+	sink := tee.OpenBlob()
+	require.NotNil(t, sink)
+	for _, chunk := range [][]byte{payload[:9], payload[9:]} {
+		written, err := sink.Write(chunk)
+		require.NoError(t, err)
+		require.Equal(t, len(chunk), written)
+	}
+	sink.Commit(digest)
+
+	uploadCount, failures := tee.Wait()
+	assert.Empty(t, failures)
+	assert.Equal(t, 2, uploadCount, "one upload per deduplicated destination repo")
+
+	for _, repo := range []string{"test/app", "other/app"} {
+		resp, err := http.Get(server.URL + "/v2/" + repo + "/blobs/" + digest)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, repo)
+		assert.Equal(t, payload, body, repo)
+	}
+}
+
+func TestTeeCancelDropsBlob(t *testing.T) {
+	server, host := newDestinationRegistry(t)
+	ctx := context.Background()
+
+	tee, err := oci_push.NewTee(ctx, []string{host + "/test/app:v1"}, insecureAlways)
+	require.NoError(t, err)
+
+	payload := []byte("bytes that never complete")
+
+	sink := tee.OpenBlob()
+	require.NotNil(t, sink)
+	_, _ = sink.Write(payload)
+	sink.Cancel()
+
+	uploadCount, _ := tee.Wait()
+	assert.Zero(t, uploadCount)
+
+	resp, err := http.Get(server.URL + "/v2/test/app/blobs/" + digestOf(payload))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestTeeRecordsFailureAndStopsOpeningUploads(t *testing.T) {
+	server, host := newDestinationRegistry(t)
+	server.Close() // destination is dead from the start
+	ctx := context.Background()
+
+	tee, err := oci_push.NewTee(ctx, []string{host + "/test/app:v1"}, insecureAlways)
+	require.NoError(t, err)
+
+	payload := []byte("payload for a dead registry")
+	sink := tee.OpenBlob()
+	require.NotNil(t, sink)
+	_, _ = sink.Write(payload)
+	sink.Commit(digestOf(payload))
+
+	uploadCount, failures := tee.Wait()
+	assert.Zero(t, uploadCount)
+	assert.Len(t, failures, 1)
+
+	// The failed repo is skipped for subsequent blobs.
+	assert.Nil(t, tee.OpenBlob())
+}
+
+func TestTeeAbortUnblocksWait(t *testing.T) {
+	hung := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(hung.Close)
+	host := strings.TrimPrefix(hung.URL, "http://")
+	ctx := context.Background()
+
+	tee, err := oci_push.NewTee(ctx, []string{host + "/test/app:v1"}, insecureAlways)
+	require.NoError(t, err)
+
+	sink := tee.OpenBlob()
+	require.NotNil(t, sink)
+
+	tee.Abort()
+	_, failures := tee.Wait() // must not deadlock
+	assert.Len(t, failures, 1)
+}
+
+func TestTeeRejectsUnparsableDestination(t *testing.T) {
+	_, err := oci_push.NewTee(context.Background(), []string{"registry.example/UPPER CASE"}, insecureAlways)
+	require.Error(t, err)
+}
+
+// TestProxyUploadStreamsToDestinationWhileCaching wires the real proxy to a
+// real Tee: a chunked upload (as the docker daemon would send it) must land in
+// the CAS and, concurrently, in the destination registry.
+func TestProxyUploadStreamsToDestinationWhileCaching(t *testing.T) {
+	server, host := newDestinationRegistry(t)
+	ctx := context.Background()
+
+	cas := caching.NewCas(backends.NewFileSystemCacheForTest(t.TempDir(), t.TempDir()))
+	proxy, err := ociproxy.New(ctx, cas)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proxy.Close() })
+
+	tee, err := oci_push.NewTee(ctx, []string{host + "/test/app:v1"}, insecureAlways)
+	require.NoError(t, err)
+	proxy.SetTee("grog-cache/abc", tee)
+
+	payload := bytes.Repeat([]byte("layer-bytes-"), 4096)
+	digest := digestOf(payload)
+
+	startResp, err := http.Post("http://"+proxy.Addr()+"/v2/grog-cache/abc/blobs/uploads/", "application/octet-stream", nil)
+	require.NoError(t, err)
+	startResp.Body.Close()
+	location := startResp.Header.Get("Location")
+
+	patchReq, err := http.NewRequest(http.MethodPatch, "http://"+proxy.Addr()+location, bytes.NewReader(payload))
+	require.NoError(t, err)
+	patchResp, err := http.DefaultClient.Do(patchReq)
+	require.NoError(t, err)
+	patchResp.Body.Close()
+	require.Equal(t, http.StatusAccepted, patchResp.StatusCode)
+
+	putReq, err := http.NewRequest(http.MethodPut, "http://"+proxy.Addr()+location+"?digest="+digest, nil)
+	require.NoError(t, err)
+	putResp, err := http.DefaultClient.Do(putReq)
+	require.NoError(t, err)
+	putResp.Body.Close()
+	require.Equal(t, http.StatusCreated, putResp.StatusCode)
+
+	proxy.ClearTee("grog-cache/abc")
+	uploadCount, failures := tee.Wait()
+	assert.Empty(t, failures)
+	assert.Equal(t, 1, uploadCount)
+
+	cached, err := cas.LoadBytes(ctx, digest)
+	require.NoError(t, err)
+	assert.Equal(t, payload, cached)
+
+	resp, err := http.Get(server.URL + "/v2/test/app/blobs/" + digest)
+	require.NoError(t, err)
+	pushed, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, payload, pushed)
+}

--- a/internal/ociproxy/registry.go
+++ b/internal/ociproxy/registry.go
@@ -50,6 +50,22 @@ import (
 	"grog/internal/console"
 )
 
+// BlobTee mirrors blob uploads for one repository name to an additional
+// destination while they stream into the CAS. Registered via SetTee.
+type BlobTee interface {
+	// OpenBlob is called once per incoming blob upload; nil means skip.
+	OpenBlob() BlobSink
+}
+
+// BlobSink receives one blob's byte stream alongside the CAS staged writer.
+// Sinks are best-effort by contract: the proxy ignores Write errors, and a
+// sink failure must never fail the CAS write it shadows.
+type BlobSink interface {
+	io.Writer
+	Commit(digest string)
+	Cancel()
+}
+
 // Registry is an in-process OCI Distribution v2 server backed by a CAS.
 type Registry struct {
 	cas      *caching.Cas
@@ -71,6 +87,9 @@ type Registry struct {
 	uploadsMu sync.Mutex
 	uploads   map[string]*pendingUpload
 
+	teesMu sync.Mutex
+	tees   map[string]BlobTee
+
 	// manifestsByName remembers the digest of the most recent manifest PUT
 	// per repository name. The DockerOutputHandler reads this back after
 	// `docker push` to learn the manifest digest the daemon produced.
@@ -85,6 +104,7 @@ type Registry struct {
 type pendingUpload struct {
 	mu       sync.Mutex
 	writer   caching.StagedWriter
+	sink     BlobSink // optional tee destination; nil when no tee is registered
 	digester hash.Hash
 	written  int64
 	finished bool // true after Commit/Cancel; further Writes are rejected
@@ -110,6 +130,7 @@ func New(ctx context.Context, cas *caching.Cas) (*Registry, error) {
 		sessionCtx:      sessionCtx,
 		sessionCancel:   sessionCancel,
 		uploads:         make(map[string]*pendingUpload),
+		tees:            make(map[string]BlobTee),
 		manifestsByName: make(map[string]string),
 	}
 
@@ -314,8 +335,12 @@ func (r *Registry) startBlobUpload(w http.ResponseWriter, req *http.Request, nam
 			writeError(w, http.StatusBadRequest, "DIGEST_INVALID", "invalid digest format")
 			return
 		}
-		if err := r.writeBlobMonolithic(req.Context(), digest, req.Body); err != nil {
-			writeError(w, http.StatusInternalServerError, "BLOB_UPLOAD_INVALID", err.Error())
+		if err := r.writeBlobMonolithic(req.Context(), name, digest, req.Body); err != nil {
+			if errors.Is(err, errDigestMismatch) {
+				writeError(w, http.StatusBadRequest, "DIGEST_INVALID", err.Error())
+			} else {
+				writeError(w, http.StatusInternalServerError, "BLOB_UPLOAD_INVALID", err.Error())
+			}
 			return
 		}
 		w.Header().Set("Location", "/v2/"+name+"/blobs/"+digest)
@@ -330,7 +355,7 @@ func (r *Registry) startBlobUpload(w http.ResponseWriter, req *http.Request, nam
 	// POST handler returns 202 immediately and net/http cancels its
 	// request context, but the staged writer needs to keep accepting
 	// bytes through subsequent PATCH/PUT requests.
-	id, err := r.openUpload()
+	id, err := r.openUpload(name)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "BLOB_UPLOAD_INVALID", err.Error())
 		return
@@ -344,26 +369,16 @@ func (r *Registry) startBlobUpload(w http.ResponseWriter, req *http.Request, nam
 // writeBlobMonolithic streams a single-request blob upload into the CAS and
 // verifies the supplied digest at the end. Used by the rare monolithic POST
 // path; chunked PATCH/PUT goes through the upload-session machinery instead.
-func (r *Registry) writeBlobMonolithic(ctx context.Context, digest string, body io.Reader) error {
-	stagedWriter, err := r.cas.BeginWrite(ctx)
+func (r *Registry) writeBlobMonolithic(ctx context.Context, name, digest string, body io.Reader) error {
+	upload, err := r.newUpload(ctx, name)
 	if err != nil {
-		return fmt.Errorf("begin staged write: %w", err)
+		return err
 	}
-	digester := sha256.New()
-	tee := io.TeeReader(body, digester)
-	if _, err := io.Copy(stagedWriter, tee); err != nil {
-		_ = stagedWriter.Cancel(ctx)
+	if _, err := io.Copy(upload, body); err != nil {
+		upload.cancel(ctx)
 		return fmt.Errorf("stream body to staged writer: %w", err)
 	}
-	actual := "sha256:" + hex.EncodeToString(digester.Sum(nil))
-	if actual != digest {
-		_ = stagedWriter.Cancel(ctx)
-		return fmt.Errorf("digest mismatch: client=%s actual=%s", digest, actual)
-	}
-	if err := stagedWriter.Commit(ctx, "cas", digest); err != nil {
-		return fmt.Errorf("commit blob: %w", err)
-	}
-	return nil
+	return upload.commit(ctx, digest)
 }
 
 func (r *Registry) patchBlobUpload(w http.ResponseWriter, req *http.Request, name, uploadId string) {
@@ -444,8 +459,6 @@ func (r *Registry) finishBlobUpload(w http.ResponseWriter, req *http.Request, na
 			return
 		}
 	}
-	actualDigest := "sha256:" + hex.EncodeToString(upload.digester.Sum(nil))
-	writer := upload.writer
 	upload.mu.Unlock()
 
 	// Always remove the upload from the registry's session map, regardless
@@ -455,15 +468,12 @@ func (r *Registry) finishBlobUpload(w http.ResponseWriter, req *http.Request, na
 	// Use the session ctx for Commit/Cancel — these run on a backend
 	// goroutine that may outlive the request, and we don't want a client
 	// disconnect to interrupt a final commit.
-	if actualDigest != digest {
-		_ = writer.Cancel(r.sessionCtx)
-		writeError(w, http.StatusBadRequest, "DIGEST_INVALID",
-			fmt.Sprintf("digest mismatch: client=%s actual=%s", digest, actualDigest))
-		return
-	}
-
-	if err := writer.Commit(r.sessionCtx, "cas", digest); err != nil {
-		writeError(w, http.StatusInternalServerError, "BLOB_UPLOAD_INVALID", err.Error())
+	if err := upload.commit(r.sessionCtx, digest); err != nil {
+		if errors.Is(err, errDigestMismatch) {
+			writeError(w, http.StatusBadRequest, "DIGEST_INVALID", err.Error())
+		} else {
+			writeError(w, http.StatusInternalServerError, "BLOB_UPLOAD_INVALID", err.Error())
+		}
 		return
 	}
 
@@ -543,6 +553,32 @@ func (r *Registry) putManifest(w http.ResponseWriter, req *http.Request, name, r
 	w.WriteHeader(http.StatusCreated)
 }
 
+// SetTee registers a tee for blob uploads under the given repository name.
+// Callers must ClearTee once the push the tee shadows has completed. A
+// second SetTee for the same name replaces the first (last writer wins).
+func (r *Registry) SetTee(name string, tee BlobTee) {
+	r.teesMu.Lock()
+	defer r.teesMu.Unlock()
+	r.tees[name] = tee
+}
+
+// ClearTee unregisters the tee for the given repository name.
+func (r *Registry) ClearTee(name string) {
+	r.teesMu.Lock()
+	defer r.teesMu.Unlock()
+	delete(r.tees, name)
+}
+
+func (r *Registry) openSink(name string) BlobSink {
+	r.teesMu.Lock()
+	tee := r.tees[name]
+	r.teesMu.Unlock()
+	if tee == nil {
+		return nil
+	}
+	return tee.OpenBlob()
+}
+
 // LastManifestDigest returns the digest of the most recent manifest PUT
 // against the given repository name, or "" if none has been received.
 // Used by the docker output handler to discover the manifest digest the
@@ -555,23 +591,33 @@ func (r *Registry) LastManifestDigest(name string) string {
 
 // upload session management ---------------------------------------------------
 
-// openUpload starts a new chunked upload session by opening a CAS staged
-// writer up front. Subsequent PATCH calls stream their bodies straight into
-// this writer, and PUT either Commits or Cancels it depending on whether the
-// daemon-supplied digest matches the running SHA256.
+// newUpload opens a CAS staged writer plus the registered tee sink (if any)
+// for the given repository name and bundles them into a pendingUpload.
+func (r *Registry) newUpload(ctx context.Context, name string) (*pendingUpload, error) {
+	stagedWriter, err := r.cas.BeginWrite(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open staged writer: %w", err)
+	}
+	return &pendingUpload{
+		writer:   stagedWriter,
+		sink:     r.openSink(name),
+		digester: sha256.New(),
+	}, nil
+}
+
+// openUpload starts a new chunked upload session. Subsequent PATCH calls
+// stream their bodies straight into the staged writer, and PUT either Commits
+// or Cancels it depending on whether the daemon-supplied digest matches the
+// running SHA256.
 //
 // The staged writer is opened with the registry's long-lived sessionCtx so
 // it survives the POST handler returning. Backends like S3/GCS/Azure run a
 // background goroutine for the upload that observes ctx cancellation; using
 // req.Context() here would tear the upload down before the first PATCH.
-func (r *Registry) openUpload() (string, error) {
-	stagedWriter, err := r.cas.BeginWrite(r.sessionCtx)
+func (r *Registry) openUpload(name string) (string, error) {
+	upload, err := r.newUpload(r.sessionCtx, name)
 	if err != nil {
-		return "", fmt.Errorf("open staged writer: %w", err)
-	}
-	upload := &pendingUpload{
-		writer:   stagedWriter,
-		digester: sha256.New(),
+		return "", err
 	}
 	id := uuid.NewString()
 	r.uploadsMu.Lock()
@@ -619,9 +665,38 @@ func (u *pendingUpload) Write(p []byte) (int, error) {
 	n, err := u.writer.Write(p)
 	if n > 0 {
 		u.digester.Write(p[:n])
+		if u.sink != nil {
+			_, _ = u.sink.Write(p[:n])
+		}
 		u.written += int64(n)
 	}
 	return n, err
+}
+
+var errDigestMismatch = errors.New("digest mismatch")
+
+// commit verifies the client-supplied digest against the running SHA256 and
+// then finalises the staged writer and the tee sink together. The caller must
+// have marked the upload finished (or own it exclusively) before calling.
+func (u *pendingUpload) commit(ctx context.Context, digest string) error {
+	actual := "sha256:" + hex.EncodeToString(u.digester.Sum(nil))
+	if actual != digest {
+		_ = u.writer.Cancel(ctx)
+		if u.sink != nil {
+			u.sink.Cancel()
+		}
+		return fmt.Errorf("%w: client=%s actual=%s", errDigestMismatch, digest, actual)
+	}
+	if err := u.writer.Commit(ctx, "cas", digest); err != nil {
+		if u.sink != nil {
+			u.sink.Cancel()
+		}
+		return fmt.Errorf("commit blob: %w", err)
+	}
+	if u.sink != nil {
+		u.sink.Commit(digest)
+	}
+	return nil
 }
 
 // cancel discards the staged writer. Safe to call from any goroutine; the
@@ -634,6 +709,10 @@ func (u *pendingUpload) cancel(ctx context.Context) {
 		return
 	}
 	_ = u.writer.Cancel(ctx)
+	if u.sink != nil {
+		u.sink.Cancel()
+		u.sink = nil
+	}
 	u.writer = nil
 	u.finished = true
 }

--- a/internal/ociproxy/registry_test.go
+++ b/internal/ociproxy/registry_test.go
@@ -519,3 +519,204 @@ func TestConcurrentChunkedUploadsAreIsolated(t *testing.T) {
 		assert.Equal(t, payloads[i], got, "session %d", i)
 	}
 }
+
+// blob tee -------------------------------------------------------------------
+
+type recordingSink struct {
+	mu         sync.Mutex
+	data       bytes.Buffer
+	committed  string
+	cancelled  bool
+	failWrites bool
+}
+
+func (s *recordingSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.failWrites {
+		return 0, fmt.Errorf("sink write failure")
+	}
+	return s.data.Write(p)
+}
+
+func (s *recordingSink) Commit(digest string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.committed = digest
+}
+
+func (s *recordingSink) Cancel() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelled = true
+}
+
+type recordingTee struct {
+	mu         sync.Mutex
+	sinks      []*recordingSink
+	failWrites bool
+}
+
+func (t *recordingTee) OpenBlob() ociproxy.BlobSink {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	sink := &recordingSink{failWrites: t.failWrites}
+	t.sinks = append(t.sinks, sink)
+	return sink
+}
+
+func TestChunkedUploadTeesToSink(t *testing.T) {
+	reg, cas := newTestRegistry(t)
+	ctx := context.Background()
+
+	tee := &recordingTee{}
+	reg.SetTee("some/repo", tee)
+
+	payload := bytes.Repeat([]byte("0123456789"), 1500)
+	digest := digestOf(payload)
+
+	startResp, err := http.Post(urlFor(reg, "/v2/some/repo/blobs/uploads/"), "application/octet-stream", nil)
+	require.NoError(t, err)
+	startResp.Body.Close()
+	location := startResp.Header.Get("Location")
+
+	for _, chunk := range [][]byte{payload[:7000], payload[7000:]} {
+		req, err := http.NewRequest(http.MethodPatch, urlFor(reg, location), bytes.NewReader(chunk))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	}
+
+	putReq, err := http.NewRequest(http.MethodPut, urlFor(reg, location)+"?digest="+digest, nil)
+	require.NoError(t, err)
+	putResp, err := http.DefaultClient.Do(putReq)
+	require.NoError(t, err)
+	putResp.Body.Close()
+	require.Equal(t, http.StatusCreated, putResp.StatusCode)
+
+	require.Len(t, tee.sinks, 1)
+	assert.Equal(t, payload, tee.sinks[0].data.Bytes())
+	assert.Equal(t, digest, tee.sinks[0].committed)
+	assert.False(t, tee.sinks[0].cancelled)
+
+	got, err := cas.LoadBytes(ctx, digest)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}
+
+func TestMonolithicUploadTeesToSink(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+
+	tee := &recordingTee{}
+	reg.SetTee("some/repo", tee)
+
+	payload := []byte("monolithic tee payload")
+	digest := digestOf(payload)
+
+	resp, err := http.Post(
+		urlFor(reg, "/v2/some/repo/blobs/uploads/?digest="+digest),
+		"application/octet-stream",
+		bytes.NewReader(payload),
+	)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	require.Len(t, tee.sinks, 1)
+	assert.Equal(t, payload, tee.sinks[0].data.Bytes())
+	assert.Equal(t, digest, tee.sinks[0].committed)
+}
+
+func TestUploadDigestMismatchCancelsSink(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+
+	tee := &recordingTee{}
+	reg.SetTee("some/repo", tee)
+
+	startResp, err := http.Post(urlFor(reg, "/v2/some/repo/blobs/uploads/"), "application/octet-stream", nil)
+	require.NoError(t, err)
+	startResp.Body.Close()
+	location := startResp.Header.Get("Location")
+
+	patchReq, err := http.NewRequest(http.MethodPatch, urlFor(reg, location), strings.NewReader("abc"))
+	require.NoError(t, err)
+	patchResp, err := http.DefaultClient.Do(patchReq)
+	require.NoError(t, err)
+	patchResp.Body.Close()
+
+	putReq, err := http.NewRequest(http.MethodPut, urlFor(reg, location)+"?digest="+digestOf([]byte("xyz")), nil)
+	require.NoError(t, err)
+	putResp, err := http.DefaultClient.Do(putReq)
+	require.NoError(t, err)
+	putResp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, putResp.StatusCode)
+
+	require.Len(t, tee.sinks, 1)
+	assert.True(t, tee.sinks[0].cancelled)
+	assert.Empty(t, tee.sinks[0].committed)
+}
+
+func TestClearTeeStopsTeeing(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+
+	tee := &recordingTee{}
+	reg.SetTee("some/repo", tee)
+	reg.ClearTee("some/repo")
+
+	payload := []byte("no tee expected")
+	resp, err := http.Post(
+		urlFor(reg, "/v2/some/repo/blobs/uploads/?digest="+digestOf(payload)),
+		"application/octet-stream",
+		bytes.NewReader(payload),
+	)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	assert.Empty(t, tee.sinks)
+}
+
+func TestTeeOnlyAppliesToItsRepo(t *testing.T) {
+	reg, _ := newTestRegistry(t)
+
+	tee := &recordingTee{}
+	reg.SetTee("teed/repo", tee)
+
+	payload := []byte("other repo payload")
+	resp, err := http.Post(
+		urlFor(reg, "/v2/other/repo/blobs/uploads/?digest="+digestOf(payload)),
+		"application/octet-stream",
+		bytes.NewReader(payload),
+	)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	assert.Empty(t, tee.sinks)
+}
+
+func TestFailingSinkDoesNotFailUpload(t *testing.T) {
+	reg, cas := newTestRegistry(t)
+	ctx := context.Background()
+
+	tee := &recordingTee{failWrites: true}
+	reg.SetTee("some/repo", tee)
+
+	payload := []byte("payload that the sink rejects")
+	digest := digestOf(payload)
+
+	resp, err := http.Post(
+		urlFor(reg, "/v2/some/repo/blobs/uploads/?digest="+digest),
+		"application/octet-stream",
+		bytes.NewReader(payload),
+	)
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	got, err := cas.LoadBytes(ctx, digest)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+}

--- a/internal/output/handlers/docker_output_handler.go
+++ b/internal/output/handlers/docker_output_handler.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"grog/internal/caching"
+	"grog/internal/config"
 	"grog/internal/console"
 	"grog/internal/model"
 	"grog/internal/oci_push"
@@ -147,13 +148,15 @@ func (d *DockerOutputHandler) Write(
 	}
 
 	plan := &dockerImageWritePlan{
-		dockerClient:   cli,
-		proxy:          proxy,
-		output:         dockerImageOutput,
-		loopbackRef:    loopbackRef,
-		repoName:       repoName,
-		localImageName: imageName,
-		targetLabel:    target.Label.String(),
+		dockerClient:       cli,
+		proxy:              proxy,
+		output:             dockerImageOutput,
+		loopbackRef:        loopbackRef,
+		repoName:           repoName,
+		localImageName:     imageName,
+		targetLabel:        target.Label.String(),
+		pushDestinations:   pushDestinations(target, imageName),
+		insecureRegistries: d.insecureRegistries,
 	}
 
 	return &PreparedOutput{Output: genOutput, WritePlan: plan}, nil
@@ -272,9 +275,73 @@ type dockerImageWritePlan struct {
 	repoName       string // path part of loopbackRef, used to look up the manifest digest
 	localImageName string
 	targetLabel    string
+
+	// pushDestinations, when non-empty, makes Execute tee the daemon's blob
+	// stream to these oci_push destinations while it lands in the CAS.
+	pushDestinations   []string
+	insecureRegistries []string
 }
 
+// pushDestinations returns the oci_push destinations declared for the image,
+// or nil when --push is off and blobs should only flow to the cache.
+func pushDestinations(target model.Target, imageName string) []string {
+	if !config.Global.Push {
+		return nil
+	}
+	return target.OciPush[imageName]
+}
+
+// Execute wraps the daemon push with the push tee's lifecycle: blobs stream
+// to every oci_push destination while they stream into the CAS, and the later
+// push plan only has to verify blobs and write the manifest.
 func (d *dockerImageWritePlan) Execute(ctx context.Context, tracker *worker.ProgressTracker) error {
+	tee := d.attachPushTee(ctx)
+	err := d.pushThroughProxy(ctx, tracker)
+	if tee != nil {
+		d.proxy.ClearTee(d.repoName)
+		if err != nil {
+			// Abandoned upload sessions never Commit/Cancel their sinks, so
+			// cancel outright rather than leaving destination uploads pending.
+			tee.Abort()
+		}
+		d.reportTee(ctx, tee)
+	}
+	return err
+}
+
+// attachPushTee registers a blob tee for the plan's push destinations, or
+// returns nil when there is nothing to tee (or the destinations don't parse —
+// the push plan surfaces that as a proper per-destination failure later).
+func (d *dockerImageWritePlan) attachPushTee(ctx context.Context) *oci_push.Tee {
+	if len(d.pushDestinations) == 0 {
+		return nil
+	}
+	tee, err := oci_push.NewTee(ctx, d.pushDestinations, func(destination string) bool {
+		return matchesInsecureRegistry(destination, d.insecureRegistries)
+	})
+	if err != nil {
+		console.GetLogger(ctx).Warnf("%s: %v", d.targetLabel, err)
+		return nil
+	}
+	d.proxy.SetTee(d.repoName, tee)
+	return tee
+}
+
+func (d *dockerImageWritePlan) reportTee(ctx context.Context, tee *oci_push.Tee) {
+	logger := console.GetLogger(ctx)
+	uploadCount, failures := tee.Wait()
+	for repo, err := range failures {
+		// Debug, not warn: the tee is best-effort and the push plan reports
+		// the authoritative per-destination outcome right after.
+		logger.Debugf("%s: streaming blobs to %s failed (the push will retry from the cache): %v",
+			d.targetLabel, repo, err)
+	}
+	if uploadCount > 0 {
+		logger.Debugf("%s: streamed %d blob uploads to push destinations during the cache write", d.targetLabel, uploadCount)
+	}
+}
+
+func (d *dockerImageWritePlan) pushThroughProxy(ctx context.Context, tracker *worker.ProgressTracker) error {
 	logger := console.GetLogger(ctx)
 
 	baseStatus := fmt.Sprintf("%s: caching docker image %s", d.targetLabel, d.localImageName)

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -239,8 +239,9 @@ func (r *Registry) PrepareOutputs(
 	}
 
 	// Append a push plan per (oci output, destination) for any oci_push entry
-	// declared on the target. Each plan runs after the cache plans so that
-	// image_id and manifest_digest are populated before it tries to source.
+	// declared on the target. Each plan runs after the cache plans, which
+	// populate image_id/manifest_digest and tee blobs to the destinations —
+	// leaving the push plan to verify blobs and write the manifest.
 	if r.pushEnabled != nil && r.pushEnabled() {
 		pushPlans, err := r.buildPushPlans(target, targetOutputs)
 		if err != nil {


### PR DESCRIPTION
Closes #161.

## What it does

- As the daemon pushes layers to the loopback ociproxy, each blob's bytes are now teed to every declared `oci_push` destination while they stream into the CAS — layer bytes leave the daemon once instead of being read back from the cache for the push.
- The tee is purely opportunistic: `oci_push.Copy` still runs afterwards as the reconciler, HEAD-checks blobs (finding the teed ones already present), re-uploads anything a flaky destination missed, and writes the manifest — so a tee failure costs bandwidth, never correctness, and no auth or retry logic moves into the proxy.
- Implemented as a small `BlobTee`/`BlobSink` seam in ociproxy plus an `oci_push.Tee` built on `remote.WriteLayer` with a streaming `v1.Layer` (`stream.ErrNotComputed` until the proxy verifies the digest); cache-hit pushes and the registry backend are untouched.

## Tests

- Proxy tee unit tests (chunked, monolithic, mismatch-cancel, per-repo scoping, failing-sink isolation) and `Tee` tests against gcr's in-memory registry, incl. an end-to-end proxy↔tee wiring test; all pass with `-race`.
- Integration scenarios `OCI Push Smoke Test` and `OCI Push Cross-Repo` pass; a live `--push` build logs `streamed 4 blob uploads to push destinations during the cache write` followed by `1 pushed`.
- Drive-by: the proxy's monolithic and chunked commit paths are unified, so monolithic digest mismatches now return 400 `DIGEST_INVALID` instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)