### PR TITLE
ci: gate on NilAway nil-panic analysis

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,20 +7,7 @@ on:
   pull_request:
 
 jobs:
-  prek:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up mise
-        uses: jdx/mise-action@v4
-
-      - name: Run prek
-        run: prek run --all-files
-        env:
-          TREEFMT_CI: true # Don't use formatter cache
-
-  nilaway:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -34,9 +21,11 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-nilaway-${{ hashFiles('go.sum') }}
+          key: ${{ runner.os }}-lint-${{ hashFiles('go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-nilaway-
+            ${{ runner.os }}-lint-
 
-      - name: Run NilAway
-        run: make nilaway
+      - name: Run lint
+        run: make lint
+        env:
+          TREEFMT_CI: true # Don't use formatter cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,24 @@ jobs:
         run: prek run --all-files
         env:
           TREEFMT_CI: true # Don't use formatter cache
+
+  nilaway:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up mise
+        uses: jdx/mise-action@v4
+
+      - name: Cache Go dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-nilaway-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-nilaway-
+
+      - name: Run NilAway
+        run: make nilaway

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 ## Testing expectations
 
 - For Go code changes run `go test ./...` (or at least the relevant packages). This is the baseline check that must pass before completion.
+- Also run `make nilaway` for Go changes: CI gates on it. Fix the reported nil flow where it is real, and only suppress genuine false positives with `//nolint:nilaway // <reason>` on the offending line.
 - If you modify integration test code, test scenarios, or behavior that affects CLI output, also run `go test ./integration/...` to ensure the CLI fixtures stay green. Use `make test update=<test_case>` if you need to refresh a single fixture.
 - When you regenerate the CLI docs (`docs/gen_docs.go`), verify that the generated files build by running `npm install` (once) and `npm run build` inside `docs/` if you touched the Astro site or its assets.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@
 ## Testing expectations
 
 - For Go code changes run `go test ./...` (or at least the relevant packages). This is the baseline check that must pass before completion.
-- Also run `make nilaway` for Go changes: CI gates on it. Fix the reported nil flow where it is real, and only suppress genuine false positives with `//nolint:nilaway // <reason>` on the offending line.
+- Also run `make lint` (formatting plus [NilAway](https://github.com/uber-go/nilaway)): CI gates on the same command. Fix the reported nil flow where it is real, and only suppress genuine false positives with `//nolint:nilaway // <reason>` on the offending line.
 - If you modify integration test code, test scenarios, or behavior that affects CLI output, also run `go test ./integration/...` to ensure the CLI fixtures stay green. Use `make test update=<test_case>` if you need to refresh a single fixture.
 - When you regenerate the CLI docs (`docs/gen_docs.go`), verify that the generated files build by running `npm install` (once) and `npm run build` inside `docs/` if you touched the Astro site or its assets.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,11 @@ When opening a Pull Request, check that:
 
 ## Linting
 
-Both of these run in CI (`.github/workflows/lint.yml`):
+`make lint` is the single entrypoint and is exactly what CI runs
+(`.github/workflows/lint.yml`). It chains:
 
-- `prek run --all-files` formats the tree with `treefmt`.
-- `make nilaway` runs [NilAway](https://github.com/uber-go/nilaway) over the non-test
+- `make prek` — formats the tree with `treefmt` and runs the `prek` hooks.
+- `make nilaway` — runs [NilAway](https://github.com/uber-go/nilaway) over the non-test
   packages to catch potential nil panics. When a report is a false positive, silence it
   with a `//nolint:nilaway // <reason>` comment on the offending line.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,15 @@ When opening a Pull Request, check that:
 - The branch name follows our convention
 - Commits are squashed and follow our conventions
 
+## Linting
+
+Both of these run in CI (`.github/workflows/lint.yml`):
+
+- `prek run --all-files` formats the tree with `treefmt`.
+- `make nilaway` runs [NilAway](https://github.com/uber-go/nilaway) over the non-test
+  packages to catch potential nil panics. When a report is a false positive, silence it
+  with a `//nolint:nilaway // <reason>` comment on the offending line.
+
 ## Module Overview
 
 At a high level Grog execution can be split into three phases, `loading`, `analysis`, and `execution`.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,12 @@ check-coverage: test
 
 
 ## LINT
+# Runs every check that CI gates on. Set TREEFMT_CI=true to bypass the formatter cache.
+lint: prek nilaway
+
+prek:
+	@prek run --all-files
+
 # Nil-panic analysis (https://github.com/uber-go/nilaway).
 # Suppress a false positive with a `//nolint:nilaway` comment on the offending line.
 nilaway:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,13 @@ check-coverage: test
 	@go tool cover -html=profile.txt
 
 
+## LINT
+# Nil-panic analysis (https://github.com/uber-go/nilaway).
+# Suppress a false positive with a `//nolint:nilaway` comment on the offending line.
+nilaway:
+	@nilaway -exclude-test-files ./...
+
+
 ## BUILD
 # Version and build metadata
 VERSION   ?= $(shell git describe --tags --always 2>/dev/null)

--- a/internal/caching/backends/gcs.go
+++ b/internal/caching/backends/gcs.go
@@ -246,7 +246,7 @@ func (gcs *GCSCache) Size(ctx context.Context, path, key string) (int64, error) 
 	if err != nil {
 		return 0, fmt.Errorf("failed to get object attrs: %w", err)
 	}
-	return attrs.Size, nil
+	return attrs.Size, nil //nolint:nilaway // Attrs only returns nil alongside a non-nil error.
 }
 
 // Exists checks if a file exists in GCS.

--- a/internal/dag/graph.go
+++ b/internal/dag/graph.go
@@ -83,11 +83,13 @@ func (g *DirectedTargetGraph) GetSelectedSubgraph() *DirectedTargetGraph {
 
 	// Add edges between selected nodes
 	for fromLabel, toList := range g.outEdges {
-		if g.nodes[fromLabel].GetIsSelected() {
-			for _, to := range toList {
-				if to.GetIsSelected() {
-					subgraph.AddEdge(g.nodes[fromLabel], to)
-				}
+		from, exists := g.nodes[fromLabel]
+		if !exists || !from.GetIsSelected() {
+			continue
+		}
+		for _, to := range toList {
+			if to.GetIsSelected() {
+				subgraph.AddEdge(from, to)
 			}
 		}
 	}

--- a/internal/dag/graph_walker.go
+++ b/internal/dag/graph_walker.go
@@ -119,15 +119,16 @@ func (w *Walker) Walk(
 		readyCh := make(chan any, 1)
 		cancelCh := make(chan any, 1)
 
-		w.nodeInfoMap[node.GetLabel()] = &nodeInfo{
+		info := &nodeInfo{
 			done:   doneCh,
 			ready:  readyCh,
 			cancel: cancelCh,
 		}
+		w.nodeInfoMap[node.GetLabel()] = info
 
 		w.wait.Add(1)
 		// start all routines
-		go w.nodeRoutine(ctx, node, w.nodeInfoMap[node.GetLabel()])
+		go w.nodeRoutine(ctx, node, info)
 	}
 
 	// Map is fully populated; now start the no-dependency nodes.

--- a/internal/loading/annotations.go
+++ b/internal/loading/annotations.go
@@ -12,6 +12,15 @@ type scriptAnnotation struct {
 	Platforms            []string          `yaml:"platforms"`
 }
 
+// annotationLineRange returns the first and last source line of an annotation
+// block, or (0, 0) when the block carries no comment lines at all.
+func annotationLineRange(annotationLineNumbers []int) (int, int) {
+	if len(annotationLineNumbers) == 0 {
+		return 0, 0
+	}
+	return annotationLineNumbers[0], annotationLineNumbers[len(annotationLineNumbers)-1]
+}
+
 // grogAnnotation represents the annotation block in a Makefile.
 type grogAnnotation struct {
 	scriptAnnotation `yaml:",inline"`

--- a/internal/loading/makefile_loader.go
+++ b/internal/loading/makefile_loader.go
@@ -107,12 +107,12 @@ func (p *makefileParser) handleTarget(
 ) error {
 	// Combine annotation lines into a YAML snippet.
 	annotationContent := strings.Join(annotationLines, "\n")
-	lastLineNum := annotationLineNumbers[len(annotationLineNumbers)-1]
+	firstLineNum, lastLineNum := annotationLineRange(annotationLineNumbers)
 
 	var annotation grogAnnotation
 	if len(annotationContent) > 0 {
 		if err := yaml.Unmarshal([]byte(annotationContent), &annotation); err != nil {
-			return fmt.Errorf("failed to parse annotation block L%d-%d: %w", annotationLineNumbers[0], lastLineNum, err)
+			return fmt.Errorf("failed to parse annotation block L%d-%d: %w", firstLineNum, lastLineNum, err)
 		}
 	}
 

--- a/internal/loading/makefile_loader.go
+++ b/internal/loading/makefile_loader.go
@@ -86,7 +86,7 @@ func (p *makefileParser) parse() (PackageDTO, bool, error) {
 					annotationLineNumbers = append(annotationLineNumbers, lineCount)
 				} else {
 					// End of annotation: this should be the target definition.
-					if err := p.handleTarget(annotationLines, annotationLineNumbers, nextLine); err != nil {
+					if err := p.handleTarget(annotationLines, annotationLineNumbers, nextLine, lineCount); err != nil {
 						return p.pkg, targetsFound, err
 					}
 					// Break out of the loop.
@@ -104,6 +104,7 @@ func (p *makefileParser) handleTarget(
 	annotationLines []string,
 	annotationLineNumbers []int,
 	targetLine string,
+	targetLineNumber int,
 ) error {
 	// Combine annotation lines into a YAML snippet.
 	annotationContent := strings.Join(annotationLines, "\n")
@@ -119,7 +120,7 @@ func (p *makefileParser) handleTarget(
 	// Process the target definition.
 	trimmedTarget := strings.TrimSpace(targetLine)
 	if !strings.Contains(trimmedTarget, ":") {
-		return fmt.Errorf("expected a make target definition in L%d ending with ':', got: %s", lastLineNum+1, trimmedTarget)
+		return fmt.Errorf("expected a make target definition in L%d ending with ':', got: %s", targetLineNumber, trimmedTarget)
 	}
 	// Extract the target name (remove the trailing colon).
 	targetName := strings.Split(trimmedTarget, ":")[0]

--- a/internal/loading/makefile_loader_test.go
+++ b/internal/loading/makefile_loader_test.go
@@ -116,6 +116,19 @@ build_error:
 			shouldError:       false,
 		},
 		{
+			name: "Bare annotation block with non matching target definition",
+			input: `setup:
+	echo "setup"
+
+# @grog
+build_bug
+	npm run build`,
+			expectedTargets:   nil,
+			expectedFoundFlag: true,
+			shouldError:       true,
+			errorContains:     "expected a make target definition in L5",
+		},
+		{
 			name: "Annotation block without any comment lines",
 			input: `# @grog
 build_bare:

--- a/internal/loading/makefile_loader_test.go
+++ b/internal/loading/makefile_loader_test.go
@@ -116,6 +116,20 @@ build_error:
 			shouldError:       false,
 		},
 		{
+			name: "Annotation block without any comment lines",
+			input: `# @grog
+build_bare:
+	echo "bare"`,
+			expectedTargets: []TargetDTO{
+				{
+					Name:    "build_bare",
+					Command: "make build_bare",
+				},
+			},
+			expectedFoundFlag: true,
+			shouldError:       false,
+		},
+		{
 			name: "Multiple valid annotations in one file",
 			input: `# @grog
 # name: target_one

--- a/internal/loading/script_loader.go
+++ b/internal/loading/script_loader.go
@@ -132,12 +132,12 @@ func (p *scriptParser) handleTarget(
 ) (scriptAnnotation, error) {
 	// Combine annotation lines into a YAML snippet.
 	annotationContent := strings.Join(annotationLines, "\n")
-	lastLineNum := annotationLineNumbers[len(annotationLineNumbers)-1]
+	firstLineNum, lastLineNum := annotationLineRange(annotationLineNumbers)
 
 	var annotation scriptAnnotation
 	if len(annotationContent) > 0 {
 		if err := yaml.Unmarshal([]byte(annotationContent), &annotation); err != nil {
-			return scriptAnnotation{}, fmt.Errorf("failed to parse annotation block L%d-%d: %w", annotationLineNumbers[0], lastLineNum, err)
+			return scriptAnnotation{}, fmt.Errorf("failed to parse annotation block L%d-%d: %w", firstLineNum, lastLineNum, err)
 		}
 	}
 

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -451,7 +451,7 @@ func starlarkListToStringSlice(list *starlark.List) ([]string, error) {
 	for iter.Next(&val) {
 		str, ok := val.(starlark.String)
 		if !ok {
-			return nil, fmt.Errorf("expected string, got %s", val.Type())
+			return nil, fmt.Errorf("expected string, got %s", val.Type()) //nolint:nilaway // Iterate assigns val before Next reports true.
 		}
 		result = append(result, string(str))
 	}
@@ -549,7 +549,7 @@ func starlarkListToOutputChecks(list *starlark.List) ([]model.OutputCheck, error
 				}
 			}
 		} else {
-			return nil, fmt.Errorf("output_check must be dict or struct, got %s", val.Type())
+			return nil, fmt.Errorf("output_check must be dict or struct, got %s", val.Type()) //nolint:nilaway // Iterate assigns val before Next reports true.
 		}
 
 		result = append(result, model.OutputCheck{

--- a/internal/locking/workspace_locker.go
+++ b/internal/locking/workspace_locker.go
@@ -196,14 +196,14 @@ func parseLockFileContents(lockFileContents string) (int, string, error) {
 		return 0, "", errors.New("lockfile is empty")
 	}
 
-	parts := strings.SplitN(trimmedContents, lockFileFieldSeparator, 2)
-	processID, conversionError := strconv.Atoi(parts[0])
+	processIDField, commandField, hasCommand := strings.Cut(trimmedContents, lockFileFieldSeparator)
+	processID, conversionError := strconv.Atoi(processIDField)
 	if conversionError != nil {
 		return 0, "", conversionError
 	}
-	if len(parts) < 2 {
+	if !hasCommand {
 		return processID, "", nil
 	}
 
-	return processID, strings.TrimSpace(parts[1]), nil
+	return processID, strings.TrimSpace(commandField), nil
 }

--- a/internal/model/target.go
+++ b/internal/model/target.go
@@ -109,11 +109,11 @@ func (t *Target) IsTestOnly() bool {
 }
 
 func (t *Target) CommandEllipsis() string {
-	lines := strings.SplitN(t.Command, "\n", 2)
-	firstLine := strings.TrimLeft(lines[0], " ")
+	firstLine, _, hasMoreLines := strings.Cut(t.Command, "\n")
+	firstLine = strings.TrimLeft(firstLine, " ")
 	if len(firstLine) > 70 {
 		return firstLine[:67] + "..."
-	} else if len(lines) > 1 {
+	} else if hasMoreLines {
 		return firstLine + "..."
 	}
 	return firstLine

--- a/internal/output/handlers/dir_output_handler.go
+++ b/internal/output/handlers/dir_output_handler.go
@@ -446,7 +446,7 @@ func (d *DirectoryOutputHandler) Load(
 	logger.Debugf("loading directory from cache for target %s → %s", target.Label, dirPath)
 
 	// Fetch the tree from CAS
-	treeDigest := directoryOutput.GetTreeDigest().Hash
+	treeDigest := directoryOutput.GetTreeDigest().GetHash()
 
 	// Check the current directory hash against the cached tree
 	// so that we can avoid downloading the directory if it hasn't changed

--- a/internal/output/handlers/docker_registry_output_handler.go
+++ b/internal/output/handlers/docker_registry_output_handler.go
@@ -199,8 +199,7 @@ func (d *DockerRegistryOutputHandler) Write(
 
 func makeRegistryAuth(ref string) (string, error) {
 	// Extract registry hostname (e.g. "gcr.io" or "myregistry.example.com")
-	parts := strings.SplitN(ref, "/", 2)
-	registry := parts[0]
+	registry, _, _ := strings.Cut(ref, "/")
 
 	// Load CLI config (respects DOCKER_CONFIG / XDG_CONFIG_HOME / ~/.docker)
 	cfg, err := dockerconfig.Load("")

--- a/internal/output/registry.go
+++ b/internal/output/registry.go
@@ -422,15 +422,13 @@ func validateTargetResultOutputs(target *model.Target, targetResult *gen.TargetR
 	slices.Sort(sortedExpectedOutputDefinitions)
 	slices.Sort(sortedLoadedOutputDefinitions)
 
-	for index := range sortedExpectedOutputDefinitions {
-		if sortedExpectedOutputDefinitions[index] != sortedLoadedOutputDefinitions[index] {
-			return fmt.Errorf(
-				"%s: cached outputs mismatch: expected outputs %v, got outputs %v",
-				target.Label,
-				expectedOutputDefinitions,
-				loadedOutputDefinitions,
-			)
-		}
+	if !slices.Equal(sortedExpectedOutputDefinitions, sortedLoadedOutputDefinitions) {
+		return fmt.Errorf(
+			"%s: cached outputs mismatch: expected outputs %v, got outputs %v",
+			target.Label,
+			expectedOutputDefinitions,
+			loadedOutputDefinitions,
+		)
 	}
 
 	return nil

--- a/mise.lock
+++ b/mise.lock
@@ -168,6 +168,10 @@ url = "https://dl.google.com/go/go1.26.3.darwin-amd64.tar.gz"
 checksum = "sha256:20d2ceafb4ed41b96b879010927b28bc92a5be57a7c1801ce365a9ca51d3224a"
 url = "https://dl.google.com/go/go1.26.3.windows-amd64.zip"
 
+[[tools."go:go.uber.org/nilaway/cmd/nilaway"]]
+version = "0.0.0-20260808063849-8649a03c818a"
+backend = "go:go.uber.org/nilaway/cmd/nilaway"
+
 [[tools."go:golang.org/x/tools/cmd/goimports"]]
 version = "0.48.0"
 backend = "go:golang.org/x/tools/cmd/goimports"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 "aqua:numtide/treefmt" = "latest"
 "aqua:protocolbuffers/protobuf/protoc" = "34.1" # protoc
+"go:go.uber.org/nilaway/cmd/nilaway" = "latest"
 "go:google.golang.org/protobuf/cmd/protoc-gen-go" = "latest"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:gotest.tools/gotestsum" = "latest"


### PR DESCRIPTION
## What

- Adds [NilAway](https://github.com/uber-go/nilaway) as a mise tool and introduces `make lint` as the single lint entrypoint (prek hooks + NilAway), which is exactly what the lint workflow now runs as one step.
- Clearing the 21 initial reports found a real crash: a Makefile with a bare `# @grog` line directly above a target indexed `annotationLineNumbers` at `-1` and panicked. Fixed in both the Makefile and script loaders, with regression tests.
- Everything else is guards for unchecked map lookups / protobuf getters, `SplitN` → `Cut` rewrites, and three `//nolint:nilaway` suppressions for library contracts NilAway cannot see.

## Notes

- Test-file diagnostics are excluded — they were almost entirely `http.Get(...).Body` noise in `ociproxy` tests, which would have needed ~50 suppressions for no safety gain.
- `make lint` takes ~1 min locally (NilAway dominates); the CI job caches `~/.cache/go-build` and the module cache.
- `golangci-lint` stays outside this entrypoint: it is configured but has never been wired into CI, and currently reports 10 pre-existing findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)