### PR TITLE
fix(loading): fail fast on stalled Pkl evaluation

### DIFF
--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -17,6 +17,7 @@ fail_fast = true # Exit immediately when encountering an issue
 num_workers = 4
 load_outputs = "minimal"
 hash_algorithm = "xxh3" # default
+pkl_evaluation_timeout = "30s" # maximum evaluation time per BUILD.pkl module
 # Disable injecting "set -eu" before running target commands
 # disable_default_shell_flags = true
 
@@ -89,6 +90,7 @@ For instance, to set or override the `fail_fast` option set `GROG_FAIL_FAST=fals
   an error.
 - **fail_fast**: When true, Grog will stop execution after encountering the first error, cancelling all running tasks. Defaults to `false`.
 - **num_workers**: Number of concurrent workers for parallel task execution. Defaults to the number of CPUs.
+- **pkl_evaluation_timeout**: Maximum time allowed to evaluate one `BUILD.pkl` module. Defaults to `30s`. It accepts Go duration syntax (for example, `10s` or `1m`) and can be overridden with `GROG_PKL_EVALUATION_TIMEOUT`.
 - **log_level**: Determines verbosity of logging (e.g., "debug", "info"). Defaults to `info`.
 - **stream_logs**: When `true`, Grog will stream build and test logs to stdout. Defaults to `false`.
 - **disable_default_shell_flags**: When `false` (default), Grog prepends `set -eu` to target commands before execution to fail fast on unset variables and errors. Set to `true` to opt out.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -224,6 +224,7 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetDefault("include_hidden", false)
 	viper.SetDefault("environment_variables", make(map[string]string))
 	viper.SetDefault("traces.enabled", false)
+	viper.SetDefault("pkl_evaluation_timeout", config.DefaultPklEvaluationTimeout)
 
 	names := []string{"grog"}
 	if os.Getenv("CI") == "1" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	semver "github.com/blang/semver/v4"
 )
@@ -13,6 +14,9 @@ import (
 const (
 	HashAlgorithmXXH3   = "xxh3"
 	HashAlgorithmSHA256 = "sha256"
+
+	// DefaultPklEvaluationTimeout bounds the evaluation of one BUILD.pkl module.
+	DefaultPklEvaluationTimeout = 30 * time.Second
 )
 
 type WorkspaceConfig struct {
@@ -60,6 +64,8 @@ type WorkspaceConfig struct {
 	// this knob only affects queueing — not the backend bound. Defaults
 	// to 3 * num_workers.
 	NumAsyncWriters int `mapstructure:"num_async_writers"`
+	// PklEvaluationTimeout bounds the evaluation of one BUILD.pkl module.
+	PklEvaluationTimeout time.Duration `mapstructure:"pkl_evaluation_timeout"`
 
 	// IncludeHidden controls whether the package loader descends into hidden
 	// files and directories (names starting with a dot, e.g. ".github"). By
@@ -258,6 +264,14 @@ func (w WorkspaceConfig) GetOutputMode() OutputMode {
 		return OutputModeTerse
 	}
 	return mode
+}
+
+// GetPklEvaluationTimeout returns the configured BUILD.pkl evaluation timeout.
+func (w WorkspaceConfig) GetPklEvaluationTimeout() time.Duration {
+	if w.PklEvaluationTimeout > 0 {
+		return w.PklEvaluationTimeout
+	}
+	return DefaultPklEvaluationTimeout
 }
 
 type CacheBackend string

--- a/internal/loading/pkl_loader.go
+++ b/internal/loading/pkl_loader.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"grog/internal/config"
-	"grog/internal/console"
 	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
+
+	"grog/internal/config"
+	"grog/internal/console"
 
 	"github.com/apple/pkl-go/pkl"
 )
+
+const pklEvaluatorCreationTimeout = 2 * time.Minute
 
 // PklLoader implements the Loader interface for pkl files.
 type PklLoader struct {
@@ -29,22 +33,33 @@ func (pl *PklLoader) Matches(fileName string) bool {
 // getEvaluator lazily loads and caches the evaluator.
 func (pl *PklLoader) getEvaluator(ctx context.Context) (pkl.Evaluator, error) {
 	pl.evaluatorOnce.Do(func() {
+		creationContext, cancel := newPklEvaluatorCreationContext(ctx)
+		defer cancel()
+
 		if hasPklProjectFile() {
-			pl.evaluator, pl.evaluatorErr = pkl.NewProjectEvaluator(ctx,
+			pl.evaluator, pl.evaluatorErr = pkl.NewProjectEvaluator(creationContext,
 				&url.URL{Scheme: "file", Path: config.Global.WorkspaceRoot},
 				pkl.PreconfiguredOptions,
 				withEnv(LoaderEnv()),
 				withEnv(config.Global.EnvironmentVariables),
 			)
 		} else {
-			pl.evaluator, pl.evaluatorErr = pkl.NewEvaluator(ctx,
+			pl.evaluator, pl.evaluatorErr = pkl.NewEvaluator(creationContext,
 				pkl.PreconfiguredOptions,
 				withEnv(LoaderEnv()),
 				withEnv(config.Global.EnvironmentVariables),
 			)
 		}
+
+		if contextErr := creationContext.Err(); contextErr != nil && pl.evaluatorErr == nil {
+			pl.evaluatorErr = fmt.Errorf("pkl evaluator creation did not complete within %s: %w", pklEvaluatorCreationTimeout, contextErr)
+		}
 	})
 	return pl.evaluator, pl.evaluatorErr
+}
+
+func newPklEvaluatorCreationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), pklEvaluatorCreationTimeout)
 }
 
 func hasPklProjectFile() bool {
@@ -70,9 +85,19 @@ func (pl *PklLoader) Load(ctx context.Context, filePath string) (PackageDTO, boo
 	evaluator, err := pl.getEvaluator(ctx)
 	if err != nil {
 		console.GetLogger(ctx).Debugf("failed to get evaluator: %v", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			return pkg, false, err
+		}
 		return pkg, false, fmt.Errorf("found a BUILD.pkl file but the `pkl` cli is not available. " +
 			"Please install it to use pkl files: https://pkl-lang.org/main/current/pkl-cli/index.html#installation")
 	}
+	if evaluator == nil {
+		return pkg, false, errors.New("pkl evaluator creation returned no evaluator and no error")
+	}
+
+	evaluationTimeout := config.Global.GetPklEvaluationTimeout()
+	evaluationContext, cancel := context.WithTimeout(ctx, evaluationTimeout)
+	defer cancel()
 
 	var evalErr error
 	// pkl evaluator can panic so we need to be able to recover
@@ -82,9 +107,14 @@ func (pl *PklLoader) Load(ctx context.Context, filePath string) (PackageDTO, boo
 				evalErr = fmt.Errorf("panic occurred while evaluating module: %v", r)
 			}
 		}()
-		evalErr = evaluator.EvaluateModule(ctx, pkl.FileSource(filePath), &pkg)
+		evalErr = evaluator.EvaluateModule(evaluationContext, pkl.FileSource(filePath), &pkg)
 	}()
 
+	// pkl-go v0.12.1 returns nil when its context is canceled, so checking only
+	// evalErr could turn a timed-out module into a successful empty package.
+	if contextErr := evaluationContext.Err(); contextErr != nil {
+		return pkg, false, fmt.Errorf("pkl module evaluation for %q did not complete within %s: %w", filePath, evaluationTimeout, contextErr)
+	}
 	if evalErr != nil {
 		return pkg, false, evalErr
 	}

--- a/internal/loading/pkl_loader_test.go
+++ b/internal/loading/pkl_loader_test.go
@@ -1,0 +1,88 @@
+package loading
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"grog/internal/config"
+
+	"github.com/apple/pkl-go/pkl"
+)
+
+type pklEvaluatorStub struct {
+	pkl.Evaluator
+	evaluateModule func(context.Context, *pkl.ModuleSource, any) error
+}
+
+func (e *pklEvaluatorStub) EvaluateModule(ctx context.Context, source *pkl.ModuleSource, output any) error {
+	return e.evaluateModule(ctx, source, output)
+}
+
+func TestPklLoaderTimeoutReturnsError(t *testing.T) {
+	previousConfig := config.Global
+	config.Global.PklEvaluationTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		config.Global = previousConfig
+	})
+
+	loader := &PklLoader{
+		evaluator: &pklEvaluatorStub{
+			evaluateModule: func(ctx context.Context, _ *pkl.ModuleSource, _ any) error {
+				<-ctx.Done()
+				// This matches pkl-go v0.12.1, which returns nil on cancellation.
+				return nil
+			},
+		},
+	}
+	loader.evaluatorOnce.Do(func() {})
+
+	packageDTO, matched, err := loader.Load(context.Background(), "BUILD.pkl")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded error, got %v", err)
+	}
+	if matched {
+		t.Fatal("expected a timed-out BUILD.pkl not to be reported as successfully loaded")
+	}
+	if len(packageDTO.Targets) != 0 {
+		t.Fatalf("expected no targets from timed-out BUILD.pkl, got %d", len(packageDTO.Targets))
+	}
+}
+
+func TestPklEvaluatorCreationContextIgnoresCallerCancellation(t *testing.T) {
+	type contextKey string
+	const key contextKey = "key"
+	callerContext, cancelCaller := context.WithCancel(context.WithValue(context.Background(), key, "value"))
+	cancelCaller()
+
+	creationContext, cancelCreation := newPklEvaluatorCreationContext(callerContext)
+	t.Cleanup(cancelCreation)
+
+	if err := creationContext.Err(); err != nil {
+		t.Fatalf("expected evaluator creation to ignore caller cancellation, got %v", err)
+	}
+	if _, hasDeadline := creationContext.Deadline(); !hasDeadline {
+		t.Fatal("expected evaluator creation context to have its own deadline")
+	}
+	if value := creationContext.Value(key); value != "value" {
+		t.Fatalf("expected evaluator creation context to retain caller values, got %v", value)
+	}
+}
+
+func TestPklLoaderRejectsNilEvaluator(t *testing.T) {
+	loader := &PklLoader{}
+	loader.evaluatorOnce.Do(func() {})
+
+	_, matched, err := loader.Load(context.Background(), "BUILD.pkl")
+	if err == nil {
+		t.Fatal("expected nil evaluator to return an error")
+	}
+	if !strings.Contains(err.Error(), "no evaluator and no error") {
+		t.Fatalf("expected explicit nil evaluator error, got %v", err)
+	}
+	if matched {
+		t.Fatal("expected BUILD.pkl not to be reported as loaded with a nil evaluator")
+	}
+}


### PR DESCRIPTION
## Summary

- bound each `BUILD.pkl` evaluation to 30 seconds by default, configurable with `pkl_evaluation_timeout` or `GROG_PKL_EVALUATION_TIMEOUT`
- explicitly check the evaluation context after `EvaluateModule` returns so the pkl-go cancellation bug cannot turn a timeout into a successful empty package
- create the shared evaluator with a cancellation-detached context and its own two-minute deadline
- return an explicit error if pkl-go returns a nil evaluator with no error
- document the new timeout and add regression coverage for timeout, creation-context, and nil-evaluator behavior

## Context

pkl-go v0.12.1 can return `(nil, nil)` when evaluation is canceled. Without the explicit context check, a deadlocked evaluation could time out and silently load an empty `PackageDTO`, producing a false-green build that runs no targets.

The detached evaluator-creation context is hardening for a plausible trigger: the evaluator is initialized once but package loads are concurrent, so cancellation of the first caller should not abort the shared creation handshake. No goroutine dump was captured from a hung process, so this PR does not claim that trigger is proven; the per-module deadline is the fail-fast fix.

## Testing

- `go test ./internal/...`
- `go test -timeout 360s ./integration/... -run TestCliScenarios/pkl_builds$`
- `make lint`
- `npm install && npm run build` in `docs/`

A full local `make test` completed all 423 unit tests, but unrelated executable integration fixtures cannot pass on this Nix host because it has no `/bin/bash`; those fixtures generate scripts with that absolute shebang. The focused Pkl integration suite passes.