### PR TITLE
chore(deps): update pkl-go past the upstream dispatcher-deadlock fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/TyphonHill/go-mermaid v1.0.0
 	github.com/alitto/pond/v2 v2.6.0
-	github.com/apple/pkl-go v0.12.1
+	github.com/apple/pkl-go v0.14.1-0.20260826164911-a15d198922e0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.18
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.22

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/apache/arrow-go/v18 v18.5.1 h1:yaQ6zxMGgf9YCYw4/oaeOU3AULySDlAYDOcnr4
 github.com/apache/arrow-go/v18 v18.5.1/go.mod h1:OCCJsmdq8AsRm8FkBSSmYTwL/s4zHW9CqxeBxEytkNE=
 github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
-github.com/apple/pkl-go v0.12.1 h1:4G8vAAx7eMVOdUuzyCesbHcYBMbzDyRfS00+wA/LOM0=
-github.com/apple/pkl-go v0.12.1/go.mod h1:EDQmYVtFBok/eLI+9rT0EoBBXNtMM1THwR+rwBcAH3I=
+github.com/apple/pkl-go v0.14.1-0.20260826164911-a15d198922e0 h1:z8LT+Ci0e6UUeWUlgQ9I5WhtENCvhbbEbWkjsZ3vaAo=
+github.com/apple/pkl-go v0.14.1-0.20260826164911-a15d198922e0/go.mod h1:Ko3AgXOKd/vVYtsRZgoCZhymymz9RxqCIcfdZhOX85I=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=


### PR DESCRIPTION
## Summary

- Bump pkl-go v0.12.1 → v0.14.1-0.20260826164911 (pseudo-version pinning the merge commit of apple/pkl-go#265, which fixes the evaluator dispatcher deadlock we hit during concurrent BUILD.pkl loading).
- The fix is not in a tagged release yet (v0.14.0 predates it); swap for a real tag once upstream cuts one.
- Supersedes #187 — with the upstream fix we no longer need to bound evaluation time downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xn1BAzcCYePpRsJaQ3Z7T8