### PR TITLE
feat: add built-in language server

### DIFF
--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -20,6 +20,7 @@ Reference for the `grog` CLI.
 - [`grog info`](#grog-info)
 - [`grog list`](#grog-list)
 - [`grog logs`](#grog-logs)
+- [`grog lsp`](#grog-lsp)
 - [`grog owners`](#grog-owners)
 - [`grog rdeps`](#grog-rdeps)
 - [`grog run`](#grog-run)
@@ -76,6 +77,7 @@ Reference for the `grog` CLI.
 - [`grog info`](#grog-info) - Prints information about the grog cli and workspace.
 - [`grog list`](#grog-list) - Lists targets by pattern.
 - [`grog logs`](#grog-logs) - Print the latest log file for the given target.
+- [`grog lsp`](#grog-lsp) - Start the grog language server.
 - [`grog owners`](#grog-owners) - Lists targets that own the specified files as inputs.
 - [`grog rdeps`](#grog-rdeps) - Lists (transitive) dependants (reverse dependencies) of a target.
 - [`grog run`](#grog-run) - Builds and runs one or more targets' binary outputs.
@@ -723,6 +725,56 @@ grog logs [flags]
 ```text
   -h, --help        help for logs
   -p, --path-only   Only print out the path of the target logs
+```
+
+### Options inherited from parent commands
+
+```text
+  -a, --all-platforms                 Select all platforms (bypasses platform selectors)
+      --async-cache-writes            Defer cache writes to background I/O workers during the build (default true)
+      --color string                  Set color output (yes, no, or auto) (default "auto")
+      --debug                         Enable debug logging
+      --disable-default-shell-flags   Do not prepend "set -eu" to target commands
+      --disable-progress-tracker      Disable progress tracking updates
+      --disable-tea                   Disable interactive TUI (Bubble Tea)
+      --enable-cache                  Enable cache (default true)
+      --exclude-tag strings           Exclude targets by tag. Can be used multiple times. Example: --exclude-tag=foo --exclude-tag=bar
+      --fail-fast                     Fail fast on first error
+      --load-outputs string           Level of output loading for cached targets. One of: all, minimal. (default "all")
+      --log-level string              Set log level (trace, debug, info, warn, error)
+      --output-mode string            Build output style: terse (one line per target) or detailed (stream each target's lifecycle) (default "terse")
+      --platform string               Force a specific platform in the form os/arch
+      --platform-tag strings          Enable a custom platform tag for matching targets' platform selectors. Can be used multiple times.
+      --profile string                Select a configuration profile to use
+      --push                          Push oci:: outputs declared in target.oci_push to their remote destinations after a successful build
+      --skip-workspace-lock           Skip the workspace level lock (DANGEROUS: may corrupt the cache)
+      --stream-logs                   Forward all target build/test logs to stdout/-err
+      --tag strings                   Filter targets by tag. Can be used multiple times. Example: --tag=foo --tag=bar
+  -v, --verbose count                 Set verbosity level (-v, -vv)
+```
+
+### See also
+
+- [`grog`](#grog)
+
+---
+
+## grog lsp
+
+Start the grog language server.
+
+### Synopsis
+
+Start the grog language server over standard input and output for Starlark and YAML build files.
+
+```text
+grog lsp [flags]
+```
+
+### Options
+
+```text
+  -h, --help   help for lsp
 ```
 
 ### Options inherited from parent commands

--- a/docs/src/content/docs/topics/editor-support.mdx
+++ b/docs/src/content/docs/topics/editor-support.mdx
@@ -1,0 +1,16 @@
+---
+title: Editor Support
+description: Configure an editor to use grog's built-in language server.
+---
+
+Grog includes a language server for `BUILD.star`, `BUILD.bzl`, other Starlark modules, and `BUILD.yaml` or `BUILD.yml` files. It provides diagnostics, completion, hover documentation, signature help, document symbols, and go-to-definition.
+
+Configure your editor's language server client to start this command using standard input and output:
+
+```shell
+grog lsp
+```
+
+Start the process with the workspace root as its working directory. No additional flags or network port are required.
+
+The server completes target labels and package-relative paths by scanning from the nearest `grog.toml`. Starlark diagnostics also read declared environment variable names from that file and its `environment_variables_file`, so build files can use the same predeclared names as grog itself.

--- a/integration/fixtures/no_arguments_message.txt
+++ b/integration/fixtures/no_arguments_message.txt
@@ -15,6 +15,7 @@ Available Commands:
   info            Prints information about the grog cli and workspace.
   list            Lists targets by pattern.
   logs            Print the latest log file for the given target.
+  lsp             Start the grog language server.
   owners          Lists targets that own the specified files as inputs.
   rdeps           Lists (transitive) dependants (reverse dependencies) of a target.
   run             Builds and runs one or more targets' binary outputs.

--- a/internal/cmd/cmds/lsp.go
+++ b/internal/cmd/cmds/lsp.go
@@ -1,0 +1,20 @@
+package cmds
+
+import (
+	"os"
+
+	"grog/internal/lsp"
+
+	"github.com/spf13/cobra"
+)
+
+// LSPCmd starts the grog language server.
+var LSPCmd = &cobra.Command{
+	Use:   "lsp",
+	Short: "Start the grog language server.",
+	Long:  "Start the grog language server over standard input and output for Starlark and YAML build files.",
+	Args:  cobra.NoArgs,
+	RunE: func(command *cobra.Command, arguments []string) error {
+		return lsp.Serve(command.Context(), os.Stdin, os.Stdout)
+	},
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,7 +27,7 @@ var RootCmd = &cobra.Command{
 	// PersistentPreRunE runs before any subcommand's Run, after flags are parsed.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("help") || cmd.Flags().Changed("version") ||
-			cmd.Name() == "help" || cmd.Name() == "lsp" || isCompletionCmd(cmd) {
+			cmd.Name() == "help" || isCompletionCmd(cmd) {
 			return nil
 		}
 
@@ -42,6 +42,9 @@ var RootCmd = &cobra.Command{
 
 		if err := config.Global.Validate(); err != nil {
 			return err
+		}
+		if cmd.Name() == "lsp" {
+			return nil
 		}
 
 		if !console.UseTea() {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"grog/internal/cmd/cmds"
 	"grog/internal/cmd/cmds/traces"
@@ -226,33 +225,11 @@ func initConfig(cmd *cobra.Command) error {
 	viper.SetDefault("environment_variables", make(map[string]string))
 	viper.SetDefault("traces.enabled", false)
 
-	names := []string{"grog"}
-	if os.Getenv("CI") == "1" {
-		names = append([]string{"grog.ci"}, names...)
-	}
-	if viper.GetString("profile") != "" {
-		names = append([]string{"grog." + viper.GetString("profile")}, names...)
-	}
-
 	logger := console.InitLogger()
-
-	var found bool
-	for _, name := range names {
-		viper.SetConfigName(name)
-		if err := viper.ReadInConfig(); err != nil {
-			var configFileNotFoundError viper.ConfigFileNotFoundError
-			if errors.As(err, &configFileNotFoundError) {
-				continue
-			}
-			return err
-		}
-		found = true
-		logger.Debugf("Loaded config file: %s", viper.ConfigFileUsed())
-		break
+	if operationError := config.ReadSelectedConfigFromViper(); operationError != nil {
+		return operationError
 	}
-	if !found {
-		return fmt.Errorf("no grog config file found (tried: %v)", names)
-	}
+	logger.Debugf("Loaded config file: %s", viper.ConfigFileUsed())
 
 	// Determine effective log level precedence before unmarshalling into Global:
 	// 1) --log-level flag (if set)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,16 +8,13 @@ import (
 	"grog/internal/cmd/flagtypes"
 	"grog/internal/config"
 	"grog/internal/console"
-	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
-	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/subosito/gotenv"
 )
 
 var Version string
@@ -279,84 +276,12 @@ func initConfig(cmd *cobra.Command) error {
 		}
 	}
 
-	// Merge all config sources into the global
-	if err := viper.Unmarshal(&config.Global); err != nil {
-		return fmt.Errorf("failed to parse config: %w", err)
+	if err := config.LoadGlobalFromViper(); err != nil {
+		return err
 	}
-
-	config.Global.HashAlgorithm = strings.ToLower(config.Global.HashAlgorithm)
 
 	logger.Debugf("Using config file: %s", viper.ConfigFileUsed())
 	logger.Debugf("Running on %s", config.Global.GetPlatform())
 
-	platform := viper.GetString("platform")
-	if config.Global.AllPlatforms && platform != "" {
-		return fmt.Errorf("--platform cannot be used with --all-platforms")
-	}
-	if platform != "" {
-		parts := strings.SplitN(platform, "/", 2)
-		if len(parts) != 2 {
-			return fmt.Errorf("invalid platform %s, expected os/arch", platform)
-		}
-		config.Global.OS = parts[0]
-		config.Global.Arch = parts[1]
-	}
-
-	if err := readInEnvironmentVariablesConfig(); err != nil {
-		return err
-	}
-
 	return nil
-}
-
-// Viper always normalizes all configuration keys to be lower-case
-// but users should be able to specify upper case environment_variables
-// So as a workaround we load the section here a second time _if_ there are env vars.
-//
-// When environment_variables_file is set, variables are loaded from the file
-// first, then inline environment_variables from grog.toml are merged on top
-// (inline values take precedence over file values).
-func readInEnvironmentVariablesConfig() error {
-	merged := make(map[string]string)
-
-	// Phase 1: Load variables from file if configured.
-	if config.Global.EnvironmentVariablesFile != "" {
-		envFilePath := config.Global.EnvironmentVariablesFile
-		if !filepath.IsAbs(envFilePath) {
-			envFilePath = filepath.Join(config.Global.WorkspaceRoot, envFilePath)
-		}
-
-		f, err := os.Open(envFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to open environment_variables_file %q: %w", envFilePath, err)
-		}
-		defer f.Close()
-
-		fileEnv := gotenv.Parse(f)
-		maps.Copy(merged, fileEnv)
-	}
-
-	// Phase 2: Load inline environment_variables from grog.toml (preserving case).
-	if len(config.Global.EnvironmentVariables) > 0 {
-		raw, err := os.ReadFile(viper.ConfigFileUsed())
-		if err != nil {
-			return err
-		}
-
-		var helper EnvVarsHelper
-		err = toml.Unmarshal(raw, &helper)
-		if err != nil {
-			return err
-		}
-
-		// Inline values override file-loaded values.
-		maps.Copy(merged, helper.EnvironmentVariables)
-	}
-
-	config.Global.EnvironmentVariables = merged
-	return nil
-}
-
-type EnvVarsHelper struct {
-	EnvironmentVariables map[string]string `toml:"environment_variables"`
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,7 +27,7 @@ var RootCmd = &cobra.Command{
 	// PersistentPreRunE runs before any subcommand's Run, after flags are parsed.
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Flags().Changed("help") || cmd.Flags().Changed("version") ||
-			cmd.Name() == "help" || isCompletionCmd(cmd) {
+			cmd.Name() == "help" || cmd.Name() == "lsp" || isCompletionCmd(cmd) {
 			return nil
 		}
 
@@ -194,6 +194,7 @@ func configureRoot() bool {
 	RootCmd.AddCommand(cmds.InfoCmd)
 	RootCmd.AddCommand(cmds.CheckCmd)
 	RootCmd.AddCommand(cmds.TaintCmd)
+	RootCmd.AddCommand(cmds.LSPCmd)
 	cmds.AddRunCmd(RootCmd)
 	cmds.AddGraphCmd(RootCmd)
 	cmds.AddCleanCmd(RootCmd)

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -11,6 +12,32 @@ import (
 	"github.com/spf13/viper"
 	"github.com/subosito/gotenv"
 )
+
+// ReadSelectedConfigFromViper applies profile and CI precedence to Viper's config search.
+func ReadSelectedConfigFromViper() error {
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		viper.AddConfigPath(filepath.Dir(configFile))
+	}
+	names := []string{"grog"}
+	if os.Getenv("CI") == "1" {
+		names = append([]string{"grog.ci"}, names...)
+	}
+	if profile := viper.GetString("profile"); profile != "" {
+		names = append([]string{"grog." + profile}, names...)
+	}
+	for _, name := range names {
+		viper.SetConfigName(name)
+		if operationError := viper.ReadInConfig(); operationError != nil {
+			var configFileNotFoundError viper.ConfigFileNotFoundError
+			if errors.As(operationError, &configFileNotFoundError) {
+				continue
+			}
+			return operationError
+		}
+		return nil
+	}
+	return fmt.Errorf("no grog config file found (tried: %v)", names)
+}
 
 // LoadGlobalFromViper refreshes Global from Viper's current settings.
 func LoadGlobalFromViper() error {
@@ -63,12 +90,12 @@ func LoadGlobalFromViper() error {
 	return nil
 }
 
-// ReloadGlobalFromViper rereads the active configuration file and refreshes Global.
+// ReloadGlobalFromViper reselects the active configuration file and refreshes Global.
 func ReloadGlobalFromViper() error {
 	if viper.ConfigFileUsed() == "" {
 		return nil
 	}
-	if operationError := viper.ReadInConfig(); operationError != nil {
+	if operationError := ReadSelectedConfigFromViper(); operationError != nil {
 		return operationError
 	}
 	return LoadGlobalFromViper()

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/spf13/viper"
+	"github.com/subosito/gotenv"
+)
+
+// LoadGlobalFromViper refreshes Global from Viper's current settings.
+func LoadGlobalFromViper() error {
+	var workspaceConfig WorkspaceConfig
+	if operationError := viper.Unmarshal(&workspaceConfig); operationError != nil {
+		return fmt.Errorf("failed to parse config: %w", operationError)
+	}
+	workspaceConfig.HashAlgorithm = strings.ToLower(workspaceConfig.HashAlgorithm)
+	platform := viper.GetString("platform")
+	if workspaceConfig.AllPlatforms && platform != "" {
+		return fmt.Errorf("--platform cannot be used with --all-platforms")
+	}
+	if platform != "" {
+		parts := strings.SplitN(platform, "/", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid platform %s, expected os/arch", platform)
+		}
+		workspaceConfig.OS = parts[0]
+		workspaceConfig.Arch = parts[1]
+	}
+
+	environmentVariables := make(map[string]string)
+	if workspaceConfig.EnvironmentVariablesFile != "" {
+		environmentFilePath := workspaceConfig.EnvironmentVariablesFile
+		if !filepath.IsAbs(environmentFilePath) {
+			environmentFilePath = filepath.Join(workspaceConfig.WorkspaceRoot, environmentFilePath)
+		}
+		file, operationError := os.Open(environmentFilePath)
+		if operationError != nil {
+			return fmt.Errorf("failed to open environment_variables_file %q: %w", environmentFilePath, operationError)
+		}
+		maps.Copy(environmentVariables, gotenv.Parse(file))
+		_ = file.Close()
+	}
+	if len(workspaceConfig.EnvironmentVariables) > 0 {
+		configurationBytes, operationError := os.ReadFile(viper.ConfigFileUsed())
+		if operationError != nil {
+			return operationError
+		}
+		var configuration struct {
+			EnvironmentVariables map[string]string `toml:"environment_variables"`
+		}
+		if operationError := toml.Unmarshal(configurationBytes, &configuration); operationError != nil {
+			return operationError
+		}
+		maps.Copy(environmentVariables, configuration.EnvironmentVariables)
+	}
+	workspaceConfig.EnvironmentVariables = environmentVariables
+	Global = workspaceConfig
+	return nil
+}
+
+// ReloadGlobalFromViper rereads the active configuration file and refreshes Global.
+func ReloadGlobalFromViper() error {
+	if viper.ConfigFileUsed() == "" {
+		return nil
+	}
+	if operationError := viper.ReadInConfig(); operationError != nil {
+		return operationError
+	}
+	return LoadGlobalFromViper()
+}

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -13,11 +13,8 @@ import (
 	"github.com/subosito/gotenv"
 )
 
-// ReadSelectedConfigFromViper applies profile and CI precedence to Viper's config search.
-func ReadSelectedConfigFromViper() error {
-	if configFile := viper.ConfigFileUsed(); configFile != "" {
-		viper.AddConfigPath(filepath.Dir(configFile))
-	}
+// SelectedConfigNames returns configuration basenames in precedence order.
+func SelectedConfigNames() []string {
 	names := []string{"grog"}
 	if os.Getenv("CI") == "1" {
 		names = append([]string{"grog.ci"}, names...)
@@ -25,6 +22,28 @@ func ReadSelectedConfigFromViper() error {
 	if profile := viper.GetString("profile"); profile != "" {
 		names = append([]string{"grog." + profile}, names...)
 	}
+	return names
+}
+
+// SelectedWorkspaceConfigPath returns the selected configuration path within a workspace.
+func SelectedWorkspaceConfigPath(workspaceRoot string) (string, error) {
+	for _, name := range SelectedConfigNames() {
+		path := filepath.Join(workspaceRoot, name+".toml")
+		if _, operationError := os.Stat(path); operationError == nil {
+			return path, nil
+		} else if !errors.Is(operationError, os.ErrNotExist) {
+			return "", operationError
+		}
+	}
+	return "", nil
+}
+
+// ReadSelectedConfigFromViper applies profile and CI precedence to Viper's config search.
+func ReadSelectedConfigFromViper() error {
+	if configFile := viper.ConfigFileUsed(); configFile != "" {
+		viper.AddConfigPath(filepath.Dir(configFile))
+	}
+	names := SelectedConfigNames()
 	for _, name := range names {
 		viper.SetConfigName(name)
 		if operationError := viper.ReadInConfig(); operationError != nil {

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -16,7 +16,7 @@ func TestReloadGlobalFromViper(t *testing.T) {
 	})
 	viper.Reset()
 	workspaceRoot := t.TempDir()
-	configurationPath := filepath.Join(workspaceRoot, "grog.dev.toml")
+	configurationPath := filepath.Join(workspaceRoot, "grog.toml")
 	environmentPath := filepath.Join(workspaceRoot, "environment.env")
 	if operationError := os.WriteFile(environmentPath, []byte("FILE_VALUE=one\n"), 0o644); operationError != nil {
 		t.Fatal(operationError)
@@ -44,5 +44,37 @@ func TestReloadGlobalFromViper(t *testing.T) {
 	}
 	if len(Global.PlatformTags) != 1 || Global.PlatformTags[0] != "second" || Global.EnvironmentVariables["BUILD_VALUE"] != "two" || Global.EnvironmentVariables["FILE_VALUE"] != "two" {
 		t.Fatalf("unexpected reloaded config: %#v", Global)
+	}
+}
+
+func TestReloadGlobalFromViperReselectsProfile(t *testing.T) {
+	previousGlobal := Global
+	t.Cleanup(func() {
+		Global = previousGlobal
+		viper.Reset()
+	})
+	viper.Reset()
+	workspaceRoot := t.TempDir()
+	viper.SetConfigType("toml")
+	viper.AddConfigPath(workspaceRoot)
+	viper.Set("workspace_root", workspaceRoot)
+	viper.Set("profile", "dev")
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("platform_tag = [\"base\"]\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := ReadSelectedConfigFromViper(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := LoadGlobalFromViper(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.dev.toml"), []byte("platform_tag = [\"profile\"]\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := ReloadGlobalFromViper(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if filepath.Base(viper.ConfigFileUsed()) != "grog.dev.toml" || len(Global.PlatformTags) != 1 || Global.PlatformTags[0] != "profile" {
+		t.Fatalf("unexpected reloaded config: %s %#v", viper.ConfigFileUsed(), Global)
 	}
 }

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestReloadGlobalFromViper(t *testing.T) {
+	previousGlobal := Global
+	t.Cleanup(func() {
+		Global = previousGlobal
+		viper.Reset()
+	})
+	viper.Reset()
+	workspaceRoot := t.TempDir()
+	configurationPath := filepath.Join(workspaceRoot, "grog.dev.toml")
+	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"first\"]\n[environment_variables]\nBUILD_VALUE = \"one\"\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	viper.SetConfigFile(configurationPath)
+	viper.Set("workspace_root", workspaceRoot)
+	if operationError := viper.ReadInConfig(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := LoadGlobalFromViper(); operationError != nil {
+		t.Fatal(operationError)
+	}
+
+	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"second\"]\n[environment_variables]\nBUILD_VALUE = \"two\"\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := ReloadGlobalFromViper(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if len(Global.PlatformTags) != 1 || Global.PlatformTags[0] != "second" || Global.EnvironmentVariables["BUILD_VALUE"] != "two" {
+		t.Fatalf("unexpected reloaded config: %#v", Global)
+	}
+}

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -17,7 +17,11 @@ func TestReloadGlobalFromViper(t *testing.T) {
 	viper.Reset()
 	workspaceRoot := t.TempDir()
 	configurationPath := filepath.Join(workspaceRoot, "grog.dev.toml")
-	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"first\"]\n[environment_variables]\nBUILD_VALUE = \"one\"\n"), 0o644); operationError != nil {
+	environmentPath := filepath.Join(workspaceRoot, "environment.env")
+	if operationError := os.WriteFile(environmentPath, []byte("FILE_VALUE=one\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"first\"]\nenvironment_variables_file = \"environment.env\"\n[environment_variables]\nBUILD_VALUE = \"one\"\n"), 0o644); operationError != nil {
 		t.Fatal(operationError)
 	}
 	viper.SetConfigFile(configurationPath)
@@ -29,13 +33,16 @@ func TestReloadGlobalFromViper(t *testing.T) {
 		t.Fatal(operationError)
 	}
 
-	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"second\"]\n[environment_variables]\nBUILD_VALUE = \"two\"\n"), 0o644); operationError != nil {
+	if operationError := os.WriteFile(configurationPath, []byte("os = \"linux\"\narch = \"amd64\"\nplatform_tag = [\"second\"]\nenvironment_variables_file = \"environment.env\"\n[environment_variables]\nBUILD_VALUE = \"two\"\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(environmentPath, []byte("FILE_VALUE=two\n"), 0o644); operationError != nil {
 		t.Fatal(operationError)
 	}
 	if operationError := ReloadGlobalFromViper(); operationError != nil {
 		t.Fatal(operationError)
 	}
-	if len(Global.PlatformTags) != 1 || Global.PlatformTags[0] != "second" || Global.EnvironmentVariables["BUILD_VALUE"] != "two" {
+	if len(Global.PlatformTags) != 1 || Global.PlatformTags[0] != "second" || Global.EnvironmentVariables["BUILD_VALUE"] != "two" || Global.EnvironmentVariables["FILE_VALUE"] != "two" {
 		t.Fatalf("unexpected reloaded config: %#v", Global)
 	}
 }

--- a/internal/loading/enrich_package.go
+++ b/internal/loading/enrich_package.go
@@ -20,6 +20,9 @@ import (
 // - applies any defaults
 // - parses the deps into target labels.
 func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageDTO) (*model.Package, error) {
+	if operationError := ValidatePackageRequiredFields(pkg); operationError != nil {
+		return nil, operationError
+	}
 	targets := make(map[label.TargetLabel]*model.Target)
 	aliases := make(map[label.TargetLabel]*model.Alias)
 	absolutePackagePath := config.GetPathAbsoluteToWorkspaceRoot(packagePath)

--- a/internal/loading/enrich_package.go
+++ b/internal/loading/enrich_package.go
@@ -10,7 +10,6 @@ import (
 	"grog/internal/console"
 	"grog/internal/label"
 	"grog/internal/model"
-	"grog/internal/output"
 
 	"github.com/bmatcuk/doublestar/v4"
 )
@@ -50,21 +49,9 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 			return nil, fmt.Errorf("failed to resolve inputs for target %s: %w", targetLabel, err)
 		}
 
-		parsedOutputs, err := output.ParseOutputs(target.Outputs)
+		parsedOutputs, parsedBinOutput, err := parseTargetOutputs(target, targetLabel.String())
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse outputs for target %s: %w", targetLabel, err)
-		}
-
-		parsedBinOutput := model.Output{}
-		if target.BinOutput != "" {
-			parsedBinOutput, err = output.ParseOutput(target.BinOutput)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse bin output for target %s: %w", targetLabel, err)
-			}
-			if !parsedBinOutput.IsFile() {
-				return nil, fmt.Errorf("bin output %s for target %s must be of type file",
-					target.BinOutput, targetLabel)
-			}
+			return nil, err
 		}
 
 		if _, ok := targets[targetLabel]; ok {

--- a/internal/loading/enrich_package.go
+++ b/internal/loading/enrich_package.go
@@ -73,10 +73,11 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 
 		var timeout time.Duration
 		if target.Timeout != "" {
-			timeout, err = time.ParseDuration(target.Timeout)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse timeout for target %s: %w", targetLabel, err)
+			parsedTimeout, operationError := parseBuildTimeout(targetDeclarationKind, targetLabel.String(), target.Timeout)
+			if operationError != nil {
+				return nil, operationError
 			}
+			timeout = parsedTimeout
 		}
 
 		// Determine the platforms to use
@@ -145,11 +146,11 @@ func getEnrichedPackage(logger *console.Logger, packagePath string, pkg PackageD
 
 		var resourceTimeout time.Duration
 		if resource.Timeout != "" {
-			var err error
-			resourceTimeout, err = time.ParseDuration(resource.Timeout)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse timeout for resource %s: %w", resourceLabel, err)
+			parsedTimeout, operationError := parseBuildTimeout(resourceDeclarationKind, resourceLabel.String(), resource.Timeout)
+			if operationError != nil {
+				return nil, operationError
 			}
+			resourceTimeout = parsedTimeout
 		}
 
 		resources[resourceLabel] = &model.Resource{

--- a/internal/loading/json_loader.go
+++ b/internal/loading/json_loader.go
@@ -10,8 +10,8 @@ import (
 // JsonLoader implements the Loader interface for JSON files.
 type JsonLoader struct{}
 
-func (j JsonLoader) Matches(fileName string) bool {
-	return fileName == "BUILD.json"
+func (JsonLoader) Matches(fileName string) bool {
+	return isPackageFileFormat(fileName, jsonPackageFile)
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.

--- a/internal/loading/json_loader.go
+++ b/internal/loading/json_loader.go
@@ -1,6 +1,7 @@
 package loading
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,25 +16,18 @@ func (JsonLoader) Matches(fileName string) bool {
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.
-func (j JsonLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
-	var pkg PackageDTO
-
-	// Open the file.
-	file, err := os.Open(filePath)
-	if err != nil {
-		return pkg, false, err
+func (loader JsonLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
+	source, operationError := os.ReadFile(filePath)
+	if operationError != nil {
+		return PackageDTO{}, false, operationError
 	}
-	defer file.Close()
+	return loader.loadSource(ctx, filePath, source)
+}
 
-	// Decode JSON content.
-	decoder := json.NewDecoder(file)
-	err = decoder.Decode(&pkg)
-	if err != nil {
-		return pkg, true, fmt.Errorf(
-			"failed to decode JSON file %s: %w",
-			filePath,
-			err)
+func (JsonLoader) loadSource(_ context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
+	var packageDTO PackageDTO
+	if operationError := json.NewDecoder(bytes.NewReader(source)).Decode(&packageDTO); operationError != nil {
+		return packageDTO, true, fmt.Errorf("failed to decode JSON file %s: %w", filePath, operationError)
 	}
-
-	return pkg, true, nil
+	return packageDTO, true, nil
 }

--- a/internal/loading/loader_env.go
+++ b/internal/loading/loader_env.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 
 	"grog/internal/config"
-
-	"go.starlark.net/starlark"
 )
 
 // LoaderEnv returns the GROG_* values exposed to both the pkl and starlark
@@ -16,14 +14,25 @@ import (
 // Per-target values (GROG_TARGET, GROG_PACKAGE) are intentionally excluded;
 // the loader does not know which target a value would belong to.
 func LoaderEnv() map[string]string {
+	return loaderEnvironment(
+		config.Global.WorkspaceRoot,
+		config.Global.OS,
+		config.Global.Arch,
+		strings.Join(config.Global.PlatformTags, ","),
+		resolvedEnvironmentVariablesFilePath(),
+		loaderGitHash(),
+	)
+}
+
+func loaderEnvironment(workspaceRoot string, operatingSystem string, architecture string, platformTags string, environmentFile string, gitHash string) map[string]string {
 	return map[string]string{
-		"GROG_OS":             config.Global.OS,
-		"GROG_ARCH":           config.Global.Arch,
-		"GROG_PLATFORM":       config.Global.GetPlatform(),
-		"GROG_PLATFORM_TAGS":  strings.Join(config.Global.PlatformTags, ","),
-		"GROG_ENV_FILE":       resolvedEnvironmentVariablesFilePath(),
-		"GROG_WORKSPACE_ROOT": config.Global.WorkspaceRoot,
-		"GROG_GIT_HASH":       loaderGitHash(),
+		"GROG_OS":             operatingSystem,
+		"GROG_ARCH":           architecture,
+		"GROG_PLATFORM":       operatingSystem + "/" + architecture,
+		"GROG_PLATFORM_TAGS":  platformTags,
+		"GROG_ENV_FILE":       environmentFile,
+		"GROG_WORKSPACE_ROOT": workspaceRoot,
+		"GROG_GIT_HASH":       gitHash,
 	}
 }
 
@@ -32,17 +41,4 @@ func LoaderEnv() map[string]string {
 func loaderGitHash() string {
 	hash, _ := config.GetGitHash()
 	return hash
-}
-
-// addLoaderEnvToStarlark mirrors LoaderEnv into a starlark predeclared dict.
-// GROG_PLATFORM_TAGS becomes a starlark list rather than the comma-joined
-// string used by pkl, matching the existing per-language convention.
-func addLoaderEnvToStarlark(dict starlark.StringDict) {
-	dict["GROG_OS"] = starlark.String(config.Global.OS)
-	dict["GROG_ARCH"] = starlark.String(config.Global.Arch)
-	dict["GROG_PLATFORM"] = starlark.String(config.Global.GetPlatform())
-	dict["GROG_PLATFORM_TAGS"] = platformTagsStarlarkList()
-	dict["GROG_ENV_FILE"] = starlark.String(resolvedEnvironmentVariablesFilePath())
-	dict["GROG_WORKSPACE_ROOT"] = starlark.String(config.Global.WorkspaceRoot)
-	dict["GROG_GIT_HASH"] = starlark.String(loaderGitHash())
 }

--- a/internal/loading/loader_env.go
+++ b/internal/loading/loader_env.go
@@ -15,13 +15,14 @@ import (
 // Per-target values (GROG_TARGET, GROG_PACKAGE) are intentionally excluded;
 // the loader does not know which target a value would belong to.
 func LoaderEnv() map[string]string {
+	gitHash, _ := config.GetGitHash()
 	return loaderEnvironment(
 		config.Global.WorkspaceRoot,
 		config.Global.OS,
 		config.Global.Arch,
 		strings.Join(config.Global.PlatformTags, ","),
 		resolvedEnvironmentVariablesFilePath(),
-		loaderGitHash(config.Global.WorkspaceRoot),
+		gitHash,
 	)
 }
 
@@ -37,8 +38,6 @@ func loaderEnvironment(workspaceRoot string, operatingSystem string, architectur
 	}
 }
 
-// loaderGitHash mirrors execution.GetExtendedTargetEnv: outside a git repo,
-// the variable resolves to the empty string instead of failing the load.
 func loaderGitHash(workspaceRoot string) string {
 	command := exec.Command("git", "-C", workspaceRoot, "rev-parse", "HEAD")
 	output, _ := command.Output()

--- a/internal/loading/loader_env.go
+++ b/internal/loading/loader_env.go
@@ -1,6 +1,7 @@
 package loading
 
 import (
+	"os/exec"
 	"strings"
 
 	"grog/internal/config"
@@ -20,7 +21,7 @@ func LoaderEnv() map[string]string {
 		config.Global.Arch,
 		strings.Join(config.Global.PlatformTags, ","),
 		resolvedEnvironmentVariablesFilePath(),
-		loaderGitHash(),
+		loaderGitHash(config.Global.WorkspaceRoot),
 	)
 }
 
@@ -38,7 +39,8 @@ func loaderEnvironment(workspaceRoot string, operatingSystem string, architectur
 
 // loaderGitHash mirrors execution.GetExtendedTargetEnv: outside a git repo,
 // the variable resolves to the empty string instead of failing the load.
-func loaderGitHash() string {
-	hash, _ := config.GetGitHash()
-	return hash
+func loaderGitHash(workspaceRoot string) string {
+	command := exec.Command("git", "-C", workspaceRoot, "rev-parse", "HEAD")
+	output, _ := command.Output()
+	return strings.TrimSpace(string(output))
 }

--- a/internal/loading/makefile_loader.go
+++ b/internal/loading/makefile_loader.go
@@ -13,8 +13,8 @@ import (
 // MakefileLoader implements the Loader interface for Makefiles.
 type MakefileLoader struct{}
 
-func (m MakefileLoader) Matches(fileName string) bool {
-	return fileName == "Makefile"
+func (MakefileLoader) Matches(fileName string) bool {
+	return isPackageFileFormat(fileName, makePackageFile)
 }
 
 // Load reads the Makefile at filePath parses it to PackageDTO.

--- a/internal/loading/makefile_loader.go
+++ b/internal/loading/makefile_loader.go
@@ -2,6 +2,7 @@ package loading
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -18,24 +19,26 @@ func (MakefileLoader) Matches(fileName string) bool {
 }
 
 // Load reads the Makefile at filePath parses it to PackageDTO.
-func (m MakefileLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return PackageDTO{}, false, err
+func (loader MakefileLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
+	source, operationError := os.ReadFile(filePath)
+	if operationError != nil {
+		return PackageDTO{}, false, operationError
 	}
-	defer file.Close()
+	return loader.loadSource(ctx, filePath, source)
+}
 
-	scanner := bufio.NewScanner(file)
+func (MakefileLoader) loadSource(_ context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(source))
 	parser := newMakefileParser(scanner)
-	packageDto, targetsFound, err := parser.parse()
-	if err != nil {
-		return packageDto, targetsFound, fmt.Errorf(
+	packageDTO, targetsFound, operationError := parser.parse()
+	if operationError != nil {
+		return packageDTO, targetsFound, fmt.Errorf(
 			"failed to parse Makefile %s: %w",
 			filePath,
-			err)
+			operationError)
 	}
 
-	return packageDto, targetsFound, nil
+	return packageDTO, targetsFound, nil
 }
 
 // makefileParser encapsulates the scanning logic and state.

--- a/internal/loading/package_loader.go
+++ b/internal/loading/package_loader.go
@@ -105,24 +105,13 @@ func IsStarlarkPackageFile(fileName string) bool {
 	return isPackageFileFormat(fileName, starlarkPackageFile)
 }
 
-// LoadPackageFile loads a file through the production loader registry.
-func LoadPackageFile(loadContext context.Context, filePath string) (PackageDTO, bool, error) {
-	fileName := filepath.Base(filePath)
-	for _, registration := range loaderRegistrations() {
-		if registration.matches(fileName) {
-			packageDTO, matched, operationError := registration.loader.Load(loadContext, filePath)
-			packageDTO.SourceFilePath = filePath
-			return packageDTO, matched, operationError
-		}
-	}
-	return PackageDTO{}, false, nil
-}
-
 // LoadIfMatched loads the package from the specified file name if it matches any of the supported file names.
 func (p *PackageLoader) LoadIfMatched(ctx context.Context, filePath string, fileName string) (PackageDTO, bool, error) {
 	for _, registration := range p.registrations {
 		if registration.matches(fileName) {
-			p.logger.Debugf("Loading package from %s using loader %s", filePath, registration.loader)
+			if p.logger != nil {
+				p.logger.Debugf("Loading package from %s using loader %s", filePath, registration.loader)
+			}
 			packageDTO, matched, err := registration.loader.Load(ctx, filePath)
 			packageDTO.SourceFilePath = filePath
 			return packageDTO, matched, err

--- a/internal/loading/package_loader.go
+++ b/internal/loading/package_loader.go
@@ -17,6 +17,11 @@ type Loader interface {
 	Load(ctx context.Context, filePath string) (PackageDTO, bool, error)
 }
 
+type registeredLoader interface {
+	Loader
+	loadSource(ctx context.Context, filePath string, source []byte) (PackageDTO, bool, error)
+}
+
 // PackageLoader facade that delegates to the correct loader based on the pattern.
 type PackageLoader struct {
 	registrations []loaderRegistration
@@ -25,7 +30,7 @@ type PackageLoader struct {
 
 type loaderRegistration struct {
 	format   packageFileFormat
-	loader   Loader
+	loader   registeredLoader
 	patterns []string
 }
 
@@ -118,5 +123,18 @@ func (p *PackageLoader) LoadIfMatched(ctx context.Context, filePath string, file
 		}
 	}
 
+	return PackageDTO{}, false, nil
+}
+
+// LoadSourceIfMatched loads in-memory source through the registered production loader.
+func (p *PackageLoader) LoadSourceIfMatched(ctx context.Context, filePath string, fileName string, source []byte) (PackageDTO, bool, error) {
+	for _, registration := range p.registrations {
+		if !registration.matches(fileName) {
+			continue
+		}
+		packageDTO, matched, operationError := registration.loader.loadSource(ctx, filePath, source)
+		packageDTO.SourceFilePath = filePath
+		return packageDTO, matched, operationError
+	}
 	return PackageDTO{}, false, nil
 }

--- a/internal/loading/package_loader.go
+++ b/internal/loading/package_loader.go
@@ -2,6 +2,7 @@ package loading
 
 import (
 	"context"
+	"path/filepath"
 
 	"grog/internal/console"
 )
@@ -18,32 +19,111 @@ type Loader interface {
 
 // PackageLoader facade that delegates to the correct loader based on the pattern.
 type PackageLoader struct {
-	loaders   []Loader
-	fileNames []string
-	logger    *console.Logger
+	registrations []loaderRegistration
+	logger        *console.Logger
+}
+
+type loaderRegistration struct {
+	format   packageFileFormat
+	loader   Loader
+	patterns []string
+}
+
+type packageFileFormat string
+
+const (
+	jsonPackageFile     packageFileFormat = "json"
+	yamlPackageFile     packageFileFormat = "yaml"
+	makePackageFile     packageFileFormat = "makefile"
+	pklPackageFile      packageFileFormat = "pkl"
+	starlarkPackageFile packageFileFormat = "starlark"
+	scriptPackageFile   packageFileFormat = "script"
+)
+
+func loaderRegistrations() []loaderRegistration {
+	return []loaderRegistration{
+		{format: jsonPackageFile, loader: JsonLoader{}, patterns: []string{"BUILD.json"}},
+		{format: yamlPackageFile, loader: YamlLoader{}, patterns: []string{"BUILD.yaml", "BUILD.yml"}},
+		{format: makePackageFile, loader: MakefileLoader{}, patterns: []string{"Makefile"}},
+		{format: pklPackageFile, loader: &PklLoader{}, patterns: []string{"BUILD.pkl"}},
+		{format: starlarkPackageFile, loader: StarlarkLoader{}, patterns: []string{"BUILD.star", "BUILD.bzl"}},
+		{format: scriptPackageFile, loader: ScriptLoader{}, patterns: []string{"*.grog.sh", "*.grog.py"}},
+	}
+}
+
+func (registration loaderRegistration) matches(fileName string) bool {
+	for _, pattern := range registration.patterns {
+		if matched, _ := filepath.Match(pattern, fileName); matched {
+			return true
+		}
+	}
+	return false
 }
 
 func NewPackageLoader(logger *console.Logger) *PackageLoader {
 	return &PackageLoader{
-		logger: logger,
-		// register loaders here
-		loaders: []Loader{
-			JsonLoader{},
-			YamlLoader{},
-			MakefileLoader{},
-			&PklLoader{},
-			StarlarkLoader{},
-			ScriptLoader{},
-		},
+		logger:        logger,
+		registrations: loaderRegistrations(),
 	}
+}
+
+// PackageFilePatterns returns the file patterns handled by production loaders.
+func PackageFilePatterns() []string {
+	patterns := []string{}
+	for _, registration := range loaderRegistrations() {
+		patterns = append(patterns, registration.patterns...)
+	}
+	return patterns
+}
+
+// IsPackageFile reports whether a production loader accepts a file name.
+func IsPackageFile(fileName string) bool {
+	for _, registration := range loaderRegistrations() {
+		if registration.matches(fileName) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPackageFileFormat(fileName string, format packageFileFormat) bool {
+	for _, registration := range loaderRegistrations() {
+		if registration.format == format && registration.matches(fileName) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsYAMLPackageFile reports whether the YAML loader accepts a file name.
+func IsYAMLPackageFile(fileName string) bool {
+	return isPackageFileFormat(fileName, yamlPackageFile)
+}
+
+// IsStarlarkPackageFile reports whether the Starlark loader accepts a file name.
+func IsStarlarkPackageFile(fileName string) bool {
+	return isPackageFileFormat(fileName, starlarkPackageFile)
+}
+
+// LoadPackageFile loads a file through the production loader registry.
+func LoadPackageFile(loadContext context.Context, filePath string) (PackageDTO, bool, error) {
+	fileName := filepath.Base(filePath)
+	for _, registration := range loaderRegistrations() {
+		if registration.matches(fileName) {
+			packageDTO, matched, operationError := registration.loader.Load(loadContext, filePath)
+			packageDTO.SourceFilePath = filePath
+			return packageDTO, matched, operationError
+		}
+	}
+	return PackageDTO{}, false, nil
 }
 
 // LoadIfMatched loads the package from the specified file name if it matches any of the supported file names.
 func (p *PackageLoader) LoadIfMatched(ctx context.Context, filePath string, fileName string) (PackageDTO, bool, error) {
-	for _, loader := range p.loaders {
-		if loader.Matches(fileName) {
-			p.logger.Debugf("Loading package from %s using loader %s", filePath, loader)
-			packageDTO, matched, err := loader.Load(ctx, filePath)
+	for _, registration := range p.registrations {
+		if registration.matches(fileName) {
+			p.logger.Debugf("Loading package from %s using loader %s", filePath, registration.loader)
+			packageDTO, matched, err := registration.loader.Load(ctx, filePath)
 			packageDTO.SourceFilePath = filePath
 			return packageDTO, matched, err
 		}

--- a/internal/loading/pkl_loader.go
+++ b/internal/loading/pkl_loader.go
@@ -65,6 +65,16 @@ func withEnv(envVars map[string]string) func(*pkl.EvaluatorOptions) {
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.
 func (pl *PklLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
+	return pl.evaluateSource(ctx, filePath, pkl.FileSource(filePath))
+}
+
+func (pl *PklLoader) loadSource(ctx context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
+	moduleSource := pkl.FileSource(filePath)
+	moduleSource.Contents = string(source)
+	return pl.evaluateSource(ctx, filePath, moduleSource)
+}
+
+func (pl *PklLoader) evaluateSource(ctx context.Context, filePath string, moduleSource *pkl.ModuleSource) (PackageDTO, bool, error) {
 	var pkg PackageDTO
 
 	evaluator, err := pl.getEvaluator(ctx)
@@ -82,7 +92,7 @@ func (pl *PklLoader) Load(ctx context.Context, filePath string) (PackageDTO, boo
 				evalErr = fmt.Errorf("panic occurred while evaluating module: %v", r)
 			}
 		}()
-		evalErr = evaluator.EvaluateModule(ctx, pkl.FileSource(filePath), &pkg)
+		evalErr = evaluator.EvaluateModule(ctx, moduleSource, &pkg)
 	}()
 
 	if evalErr != nil {

--- a/internal/loading/pkl_loader.go
+++ b/internal/loading/pkl_loader.go
@@ -22,8 +22,8 @@ type PklLoader struct {
 	evaluatorOnce sync.Once
 }
 
-func (pl *PklLoader) Matches(fileName string) bool {
-	return fileName == "BUILD.pkl"
+func (*PklLoader) Matches(fileName string) bool {
+	return isPackageFileFormat(fileName, pklPackageFile)
 }
 
 // getEvaluator lazily loads and caches the evaluator.

--- a/internal/loading/schema.go
+++ b/internal/loading/schema.go
@@ -1,0 +1,151 @@
+package loading
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// BuildDeclarationSchema identifies a declaration and its package collection.
+type BuildDeclarationSchema struct {
+	Kind       string
+	Collection string
+}
+
+// StarlarkParameter describes an argument accepted by a declaration builtin.
+type StarlarkParameter struct {
+	Name     string
+	Required bool
+}
+
+type buildDeclarationType struct {
+	kind         string
+	packageField string
+	dataType     reflect.Type
+}
+
+const (
+	targetDeclarationKind      = "target"
+	aliasDeclarationKind       = "alias"
+	resourceDeclarationKind    = "resource"
+	environmentDeclarationKind = "environment"
+)
+
+var buildDeclarationTypes = []buildDeclarationType{
+	{kind: targetDeclarationKind, packageField: "Targets", dataType: reflect.TypeFor[TargetDTO]()},
+	{kind: aliasDeclarationKind, packageField: "Aliases", dataType: reflect.TypeFor[AliasDTO]()},
+	{kind: resourceDeclarationKind, packageField: "Resources", dataType: reflect.TypeFor[ResourceDTO]()},
+	{kind: environmentDeclarationKind, packageField: "Environments", dataType: reflect.TypeFor[EnvironmentDTO]()},
+}
+
+var starlarkParameters = map[string][]StarlarkParameter{
+	targetDeclarationKind: {
+		{Name: "name", Required: true},
+		{Name: "command"},
+		{Name: "dependencies"},
+		{Name: "inputs"},
+		{Name: "exclude_inputs"},
+		{Name: "outputs"},
+		{Name: "bin_output"},
+		{Name: "binary_requires_push"},
+		{Name: "output_checks"},
+		{Name: "tags"},
+		{Name: "fingerprint"},
+		{Name: "platforms"},
+		{Name: "environment_variables"},
+		{Name: "timeout"},
+		{Name: "concurrency_group"},
+		{Name: "oci_push"},
+	},
+	aliasDeclarationKind: {
+		{Name: "name", Required: true},
+		{Name: "actual", Required: true},
+	},
+	resourceDeclarationKind: {
+		{Name: "name", Required: true},
+		{Name: "up", Required: true},
+		{Name: "down"},
+		{Name: "ready"},
+		{Name: "timeout"},
+		{Name: "exports"},
+		{Name: "dependencies"},
+	},
+	environmentDeclarationKind: {
+		{Name: "name", Required: true},
+		{Name: "type", Required: true},
+		{Name: "dependencies"},
+		{Name: "oci_image"},
+	},
+}
+
+// BuildDeclarationSchemas returns declaration names and package collections.
+func BuildDeclarationSchemas(format string) []BuildDeclarationSchema {
+	packageType := reflect.TypeFor[PackageDTO]()
+	schemas := make([]BuildDeclarationSchema, 0, len(buildDeclarationTypes))
+	for _, declarationType := range buildDeclarationTypes {
+		packageField, found := packageType.FieldByName(declarationType.packageField)
+		if !found {
+			continue
+		}
+		collection := serializedFieldName(packageField, format)
+		if collection != "" {
+			schemas = append(schemas, BuildDeclarationSchema{Kind: declarationType.kind, Collection: collection})
+		}
+	}
+	return schemas
+}
+
+// BuildFieldNames returns serialized package or declaration field names.
+func BuildFieldNames(format string, declarationKind string) []string {
+	dataType := reflect.TypeFor[PackageDTO]()
+	if declarationKind != "" {
+		dataType = nil
+		for _, declarationType := range buildDeclarationTypes {
+			if declarationType.kind == declarationKind {
+				dataType = declarationType.dataType
+				break
+			}
+		}
+		if dataType == nil {
+			return nil
+		}
+	}
+	fields := make([]string, 0, dataType.NumField())
+	for index := range dataType.NumField() {
+		if name := serializedFieldName(dataType.Field(index), format); name != "" {
+			fields = append(fields, name)
+		}
+	}
+	return fields
+}
+
+// StarlarkParameters returns the arguments accepted by a declaration builtin.
+func StarlarkParameters(declarationKind string) []StarlarkParameter {
+	return append([]StarlarkParameter(nil), starlarkParameters[declarationKind]...)
+}
+
+func serializedFieldName(field reflect.StructField, format string) string {
+	name := strings.Split(field.Tag.Get(format), ",")[0]
+	if name == "-" {
+		return ""
+	}
+	return name
+}
+
+func unpackStarlarkArgs(declarationKind string, arguments starlark.Tuple, keywordArguments []starlark.Tuple, destinations ...any) error {
+	parameters := starlarkParameters[declarationKind]
+	if len(parameters) != len(destinations) {
+		return fmt.Errorf("internal %s schema has %d parameters for %d destinations", declarationKind, len(parameters), len(destinations))
+	}
+	unpackArguments := make([]any, 0, len(parameters)*2)
+	for index, parameter := range parameters {
+		name := parameter.Name
+		if !parameter.Required {
+			name += "?"
+		}
+		unpackArguments = append(unpackArguments, name, destinations[index])
+	}
+	return starlark.UnpackArgs(declarationKind, arguments, keywordArguments, unpackArguments...)
+}

--- a/internal/loading/schema.go
+++ b/internal/loading/schema.go
@@ -162,6 +162,33 @@ func StarlarkParameters(declarationKind string) []StarlarkParameter {
 	return append([]StarlarkParameter(nil), starlarkParameters[declarationKind]...)
 }
 
+// ValidatePackageRequiredFields validates non-empty values from the declaration schema.
+func ValidatePackageRequiredFields(packageDTO PackageDTO) error {
+	packageValue := reflect.ValueOf(packageDTO)
+	for _, declarationType := range buildDeclarationTypes {
+		declarations := packageValue.FieldByName(declarationType.packageField)
+		for index := range declarations.Len() {
+			declaration := declarations.Index(index)
+			if declaration.IsNil() {
+				continue
+			}
+			declaration = declaration.Elem()
+			for _, parameter := range starlarkParameters[declarationType.kind] {
+				if !parameter.Required {
+					continue
+				}
+				for fieldIndex := range declaration.NumField() {
+					fieldType := declaration.Type().Field(fieldIndex)
+					if serializedFieldName(fieldType, "starlark") == parameter.Name && declaration.Field(fieldIndex).Kind() == reflect.String && declaration.Field(fieldIndex).String() == "" {
+						return fmt.Errorf("%s requires %s", declarationType.kind, parameter.Name)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
 func serializedFieldName(field reflect.StructField, format string) string {
 	name := strings.Split(field.Tag.Get(format), ",")[0]
 	if name == "-" {

--- a/internal/loading/schema.go
+++ b/internal/loading/schema.go
@@ -10,8 +10,9 @@ import (
 
 // BuildDeclarationSchema identifies a declaration and its package collection.
 type BuildDeclarationSchema struct {
-	Kind       string
-	Collection string
+	Kind        string
+	Collection  string
+	Addressable bool
 }
 
 // StarlarkParameter describes an argument accepted by a declaration builtin.
@@ -24,6 +25,7 @@ type buildDeclarationType struct {
 	kind         string
 	packageField string
 	dataType     reflect.Type
+	addressable  bool
 }
 
 const (
@@ -34,9 +36,9 @@ const (
 )
 
 var buildDeclarationTypes = []buildDeclarationType{
-	{kind: targetDeclarationKind, packageField: "Targets", dataType: reflect.TypeFor[TargetDTO]()},
-	{kind: aliasDeclarationKind, packageField: "Aliases", dataType: reflect.TypeFor[AliasDTO]()},
-	{kind: resourceDeclarationKind, packageField: "Resources", dataType: reflect.TypeFor[ResourceDTO]()},
+	{kind: targetDeclarationKind, packageField: "Targets", dataType: reflect.TypeFor[TargetDTO](), addressable: true},
+	{kind: aliasDeclarationKind, packageField: "Aliases", dataType: reflect.TypeFor[AliasDTO](), addressable: true},
+	{kind: resourceDeclarationKind, packageField: "Resources", dataType: reflect.TypeFor[ResourceDTO](), addressable: true},
 	{kind: environmentDeclarationKind, packageField: "Environments", dataType: reflect.TypeFor[EnvironmentDTO]()},
 }
 
@@ -91,10 +93,36 @@ func BuildDeclarationSchemas(format string) []BuildDeclarationSchema {
 		}
 		collection := serializedFieldName(packageField, format)
 		if collection != "" {
-			schemas = append(schemas, BuildDeclarationSchema{Kind: declarationType.kind, Collection: collection})
+			schemas = append(schemas, BuildDeclarationSchema{Kind: declarationType.kind, Collection: collection, Addressable: declarationType.addressable})
 		}
 	}
 	return schemas
+}
+
+// BuildFieldIsCollection reports whether a serialized declaration field is a slice.
+func BuildFieldIsCollection(format string, declarationKind string, fieldName string) bool {
+	for _, declarationType := range buildDeclarationTypes {
+		if declarationType.kind != declarationKind {
+			continue
+		}
+		for index := range declarationType.dataType.NumField() {
+			field := declarationType.dataType.Field(index)
+			if serializedFieldName(field, format) == fieldName {
+				return field.Type.Kind() == reflect.Slice
+			}
+		}
+	}
+	return false
+}
+
+// IsBuildLabelKind reports whether a declaration becomes an addressable build node.
+func IsBuildLabelKind(declarationKind string) bool {
+	for _, declarationType := range buildDeclarationTypes {
+		if declarationType.kind == declarationKind {
+			return declarationType.addressable
+		}
+	}
+	return false
 }
 
 // BuildFieldNames returns serialized package or declaration field names.

--- a/internal/loading/schema.go
+++ b/internal/loading/schema.go
@@ -84,10 +84,33 @@ var starlarkParameters = map[string][]StarlarkParameter{
 
 // BuildFileNames returns every file name accepted by a package loader.
 func BuildFileNames() []string {
-	fileNames := make([]string, 0, len(starlarkBuildFileNames)+len(yamlBuildFileNames))
-	fileNames = append(fileNames, starlarkBuildFileNames...)
-	fileNames = append(fileNames, yamlBuildFileNames...)
+	fileNames := []string{}
+	for _, pattern := range PackageFilePatterns() {
+		if !strings.Contains(pattern, "*") {
+			fileNames = append(fileNames, pattern)
+		}
+	}
 	return fileNames
+}
+
+// PackageDeclarations returns declaration names using the production schema.
+func PackageDeclarations(packageDTO PackageDTO) []StarlarkDeclaration {
+	packageValue := reflect.ValueOf(packageDTO)
+	declarations := []StarlarkDeclaration{}
+	for _, declarationType := range buildDeclarationTypes {
+		values := packageValue.FieldByName(declarationType.packageField)
+		for index := range values.Len() {
+			value := values.Index(index)
+			if value.IsNil() {
+				continue
+			}
+			name := value.Elem().FieldByName("Name")
+			if name.IsValid() && name.Kind() == reflect.String {
+				declarations = append(declarations, StarlarkDeclaration{Kind: declarationType.kind, Name: name.String()})
+			}
+		}
+	}
+	return declarations
 }
 
 // BuildDeclarationSchemas returns declaration names and package collections.

--- a/internal/loading/schema.go
+++ b/internal/loading/schema.go
@@ -82,6 +82,14 @@ var starlarkParameters = map[string][]StarlarkParameter{
 	},
 }
 
+// BuildFileNames returns every file name accepted by a package loader.
+func BuildFileNames() []string {
+	fileNames := make([]string, 0, len(starlarkBuildFileNames)+len(yamlBuildFileNames))
+	fileNames = append(fileNames, starlarkBuildFileNames...)
+	fileNames = append(fileNames, yamlBuildFileNames...)
+	return fileNames
+}
+
 // BuildDeclarationSchemas returns declaration names and package collections.
 func BuildDeclarationSchemas(format string) []BuildDeclarationSchema {
 	packageType := reflect.TypeFor[PackageDTO]()

--- a/internal/loading/schema_test.go
+++ b/internal/loading/schema_test.go
@@ -2,6 +2,7 @@ package loading
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -24,6 +25,15 @@ func TestStarlarkSchemaMatchesLoaderDeclarations(t *testing.T) {
 	slices.Sort(declarationKinds)
 	if builtins := StarlarkBuiltinNames(); !slices.Equal(declarationKinds, builtins) {
 		t.Fatalf("declaration schemas = %v, builtins = %v", declarationKinds, builtins)
+	}
+}
+
+func TestPackageFilePatternsMatchLoaderRegistry(t *testing.T) {
+	for _, pattern := range PackageFilePatterns() {
+		fileName := strings.Replace(pattern, "*", "sample", 1)
+		if !IsPackageFile(fileName) {
+			t.Errorf("pattern %q does not match %q", pattern, fileName)
+		}
 	}
 }
 

--- a/internal/loading/schema_test.go
+++ b/internal/loading/schema_test.go
@@ -29,12 +29,18 @@ func TestStarlarkSchemaMatchesLoaderDeclarations(t *testing.T) {
 
 func TestBuildDeclarationSchemasUsePackageTags(t *testing.T) {
 	want := []BuildDeclarationSchema{
-		{Kind: "target", Collection: "targets"},
-		{Kind: "alias", Collection: "aliases"},
-		{Kind: "resource", Collection: "resources"},
+		{Kind: "target", Collection: "targets", Addressable: true},
+		{Kind: "alias", Collection: "aliases", Addressable: true},
+		{Kind: "resource", Collection: "resources", Addressable: true},
 		{Kind: "environment", Collection: "environments"},
 	}
 	if schemas := BuildDeclarationSchemas("yaml"); !slices.Equal(schemas, want) {
 		t.Fatalf("schemas = %#v, want %#v", schemas, want)
+	}
+	if !BuildFieldIsCollection("starlark", targetDeclarationKind, "dependencies") || BuildFieldIsCollection("starlark", aliasDeclarationKind, "actual") {
+		t.Fatal("unexpected collection metadata")
+	}
+	if !IsBuildLabelKind(resourceDeclarationKind) || IsBuildLabelKind(environmentDeclarationKind) {
+		t.Fatal("unexpected addressable declaration metadata")
 	}
 }

--- a/internal/loading/schema_test.go
+++ b/internal/loading/schema_test.go
@@ -43,4 +43,7 @@ func TestBuildDeclarationSchemasUsePackageTags(t *testing.T) {
 	if !IsBuildLabelKind(resourceDeclarationKind) || IsBuildLabelKind(environmentDeclarationKind) {
 		t.Fatal("unexpected addressable declaration metadata")
 	}
+	if !slices.Contains(BuildFileNames(), "BUILD.star") || !slices.Contains(BuildFileNames(), "BUILD.yaml") {
+		t.Fatalf("unexpected build file names: %v", BuildFileNames())
+	}
 }

--- a/internal/loading/schema_test.go
+++ b/internal/loading/schema_test.go
@@ -1,0 +1,40 @@
+package loading
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestStarlarkSchemaMatchesLoaderDeclarations(t *testing.T) {
+	declarationKinds := make([]string, 0, len(buildDeclarationTypes))
+	for _, schema := range BuildDeclarationSchemas("starlark") {
+		declarationKinds = append(declarationKinds, schema.Kind)
+		fields := BuildFieldNames("starlark", schema.Kind)
+		parameters := StarlarkParameters(schema.Kind)
+		parameterNames := make([]string, 0, len(parameters))
+		for _, parameter := range parameters {
+			parameterNames = append(parameterNames, parameter.Name)
+		}
+		slices.Sort(fields)
+		slices.Sort(parameterNames)
+		if !slices.Equal(fields, parameterNames) {
+			t.Errorf("%s fields = %v, parameters = %v", schema.Kind, fields, parameterNames)
+		}
+	}
+	slices.Sort(declarationKinds)
+	if builtins := StarlarkBuiltinNames(); !slices.Equal(declarationKinds, builtins) {
+		t.Fatalf("declaration schemas = %v, builtins = %v", declarationKinds, builtins)
+	}
+}
+
+func TestBuildDeclarationSchemasUsePackageTags(t *testing.T) {
+	want := []BuildDeclarationSchema{
+		{Kind: "target", Collection: "targets"},
+		{Kind: "alias", Collection: "aliases"},
+		{Kind: "resource", Collection: "resources"},
+		{Kind: "environment", Collection: "environments"},
+	}
+	if schemas := BuildDeclarationSchemas("yaml"); !slices.Equal(schemas, want) {
+		t.Fatalf("schemas = %#v, want %#v", schemas, want)
+	}
+}

--- a/internal/loading/script_loader.go
+++ b/internal/loading/script_loader.go
@@ -19,7 +19,7 @@ import (
 type ScriptLoader struct{}
 
 func (ScriptLoader) Matches(fileName string) bool {
-	return strings.HasSuffix(fileName, ".grog.sh") || strings.HasSuffix(fileName, ".grog.py")
+	return isPackageFileFormat(fileName, scriptPackageFile)
 }
 
 func (ScriptLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {

--- a/internal/loading/script_loader.go
+++ b/internal/loading/script_loader.go
@@ -2,6 +2,7 @@ package loading
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -22,14 +23,16 @@ func (ScriptLoader) Matches(fileName string) bool {
 	return isPackageFileFormat(fileName, scriptPackageFile)
 }
 
-func (ScriptLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return PackageDTO{}, false, err
+func (loader ScriptLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
+	source, operationError := os.ReadFile(filePath)
+	if operationError != nil {
+		return PackageDTO{}, false, operationError
 	}
-	defer file.Close()
+	return loader.loadSource(ctx, filePath, source)
+}
 
-	scanner := bufio.NewScanner(file)
+func (ScriptLoader) loadSource(_ context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(source))
 	parser := newScriptParser(scanner, filePath)
 	return parser.parse()
 }

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -21,16 +21,15 @@ import (
 // StarlarkLoader implements the Loader interface for Starlark files.
 type StarlarkLoader struct{}
 
-var starlarkBuildFileNames = []string{"BUILD.star", "BUILD.bzl"}
 var starlarkSourceExtensions = []string{".star", ".bzl"}
 
 func (StarlarkLoader) Matches(fileName string) bool {
-	return slices.Contains(starlarkBuildFileNames, fileName)
+	return IsStarlarkPackageFile(fileName)
 }
 
 // IsStarlarkSourceFile reports whether tooling should treat a file as Starlark.
 func IsStarlarkSourceFile(fileName string) bool {
-	if (StarlarkLoader{}).Matches(fileName) {
+	if IsStarlarkPackageFile(fileName) {
 		return true
 	}
 	for _, extension := range starlarkSourceExtensions {

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -7,6 +7,7 @@ import (
 	"grog/internal/model"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"go.starlark.net/lib/json"
@@ -20,13 +21,29 @@ import (
 // StarlarkLoader implements the Loader interface for Starlark files.
 type StarlarkLoader struct{}
 
+var starlarkBuildFileNames = []string{"BUILD.star", "BUILD.bzl"}
+var starlarkSourceExtensions = []string{".star", ".bzl"}
+
 func (StarlarkLoader) Matches(fileName string) bool {
-	return fileName == "BUILD.star" || fileName == "BUILD.bzl"
+	return slices.Contains(starlarkBuildFileNames, fileName)
 }
 
 // IsStarlarkSourceFile reports whether tooling should treat a file as Starlark.
 func IsStarlarkSourceFile(fileName string) bool {
-	return (StarlarkLoader{}).Matches(fileName) || strings.HasSuffix(fileName, ".star") || strings.HasSuffix(fileName, ".bzl")
+	if (StarlarkLoader{}).Matches(fileName) {
+		return true
+	}
+	for _, extension := range starlarkSourceExtensions {
+		if strings.HasSuffix(fileName, extension) {
+			return true
+		}
+	}
+	return false
+}
+
+// StarlarkSourceExtensions returns file extensions supported by Starlark tooling.
+func StarlarkSourceExtensions() []string {
+	return slices.Clone(starlarkSourceExtensions)
 }
 
 // ResolveStarlarkModulePath resolves a load path using loader semantics.

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -7,6 +7,7 @@ import (
 	"grog/internal/model"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"go.starlark.net/lib/json"
 	"go.starlark.net/lib/math"
@@ -19,8 +20,42 @@ import (
 // StarlarkLoader implements the Loader interface for Starlark files.
 type StarlarkLoader struct{}
 
-func (sl StarlarkLoader) Matches(fileName string) bool {
+func (StarlarkLoader) Matches(fileName string) bool {
 	return fileName == "BUILD.star" || fileName == "BUILD.bzl"
+}
+
+// IsStarlarkSourceFile reports whether tooling should treat a file as Starlark.
+func IsStarlarkSourceFile(fileName string) bool {
+	return (StarlarkLoader{}).Matches(fileName) || strings.HasSuffix(fileName, ".star") || strings.HasSuffix(fileName, ".bzl")
+}
+
+// ResolveStarlarkModulePath resolves a load path using loader semantics.
+func ResolveStarlarkModulePath(workspaceRoot string, currentPath string, module string) string {
+	if strings.HasPrefix(module, "//") {
+		return filepath.Clean(filepath.Join(workspaceRoot, strings.TrimPrefix(module, "//")))
+	}
+	if filepath.IsAbs(module) {
+		return filepath.Clean(module)
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(currentPath), module))
+}
+
+// StarlarkDeclaration identifies a declaration produced during evaluation.
+type StarlarkDeclaration struct {
+	Kind   string
+	Name   string
+	Path   string
+	Line   int
+	Column int
+}
+
+// StarlarkEvaluationOptions configures source and environment resolution.
+type StarlarkEvaluationOptions struct {
+	WorkspaceRoot       string
+	Environment         map[string]string
+	PlatformTags        []string
+	ReadFile            func(path string) ([]byte, error)
+	DeclarationCallback func(StarlarkDeclaration)
 }
 
 // starlarkPackageCollector holds the collected targets, aliases, resources, and environments.
@@ -30,6 +65,7 @@ type starlarkPackageCollector struct {
 	resources        []*ResourceDTO
 	environments     []*EnvironmentDTO
 	defaultPlatforms []string
+	declaration      func(StarlarkDeclaration)
 }
 
 // moduleLoadContext tracks loaded modules and in-progress loads for cycle detection.
@@ -41,131 +77,114 @@ type moduleLoadContext struct {
 }
 
 // Load reads the file at the specified filePath and evaluates it as Starlark code.
-func (sl StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
+func (StarlarkLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
+	source, operationError := os.ReadFile(filePath)
+	if operationError != nil {
+		return PackageDTO{}, false, operationError
+	}
+	environment := LoaderEnv()
+	for key, value := range config.Global.EnvironmentVariables {
+		environment[key] = value
+	}
+	packageDTO, operationError := EvaluateStarlark(filePath, source, StarlarkEvaluationOptions{WorkspaceRoot: config.Global.WorkspaceRoot, Environment: environment, PlatformTags: config.Global.PlatformTags})
+	if operationError != nil {
+		return PackageDTO{}, false, fmt.Errorf("failed to evaluate Starlark file %s: %w", filePath, operationError)
+	}
+	return packageDTO, true, nil
+}
+
+// EvaluateStarlark evaluates source with the same builtins as StarlarkLoader.
+func EvaluateStarlark(filePath string, source []byte, options StarlarkEvaluationOptions) (PackageDTO, error) {
+	if options.ReadFile == nil {
+		options.ReadFile = os.ReadFile
+	}
 	collector := &starlarkPackageCollector{
 		targets:      make([]*TargetDTO, 0),
 		aliases:      make([]*AliasDTO, 0),
 		resources:    make([]*ResourceDTO, 0),
 		environments: make([]*EnvironmentDTO, 0),
+		declaration:  options.DeclarationCallback,
 	}
-
-	// Create module load context for caching and cycle detection
-	loadContext := &moduleLoadContext{
-		cache:   make(map[string]starlark.StringDict),
-		loading: make(map[string]bool),
+	evaluator := &starlarkEvaluator{
+		collector: collector,
+		options:   options,
+		modules:   moduleLoadContext{cache: make(map[string]starlark.StringDict), loading: make(map[string]bool)},
 	}
-
-	// Create predeclared functions and values
-	predeclared := starlark.StringDict{
-		"target":      starlark.NewBuiltin("target", collector.targetBuiltin),
-		"alias":       starlark.NewBuiltin("alias", collector.aliasBuiltin),
-		"resource":    starlark.NewBuiltin("resource", collector.resourceBuiltin),
-		"environment": starlark.NewBuiltin("environment", collector.environmentBuiltin),
-		"json":        json.Module,
-		"math":        math.Module,
-		"time":        time.Module,
+	thread := &starlark.Thread{Name: filePath, Load: evaluator.loadModule}
+	_, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, filePath, source, evaluator.predeclared())
+	if operationError != nil {
+		return PackageDTO{}, operationError
 	}
-	addLoaderEnvToStarlark(predeclared)
-	for key, value := range config.Global.EnvironmentVariables {
-		predeclared[key] = starlark.String(value)
-	}
-
-	thread := &starlark.Thread{
-		Name: filePath,
-		Load: func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
-			return sl.loadModule(thread, module, filePath, collector, loadContext)
-		},
-	}
-
-	// Execute the Starlark file
-	_, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, filePath, nil, predeclared)
-	if err != nil {
-		return PackageDTO{}, false, fmt.Errorf("failed to evaluate Starlark file %s: %w", filePath, err)
-	}
-
-	packageDTO := PackageDTO{
+	return PackageDTO{
 		Targets:          collector.targets,
 		Aliases:          collector.aliases,
 		Resources:        collector.resources,
 		Environments:     collector.environments,
 		DefaultPlatforms: collector.defaultPlatforms,
-	}
+	}, nil
+}
 
-	return packageDTO, true, nil
+type starlarkEvaluator struct {
+	collector *starlarkPackageCollector
+	options   StarlarkEvaluationOptions
+	modules   moduleLoadContext
+}
+
+func (evaluator *starlarkEvaluator) predeclared() starlark.StringDict {
+	predeclared := starlark.StringDict{
+		targetDeclarationKind:      starlark.NewBuiltin(targetDeclarationKind, evaluator.collector.targetBuiltin),
+		aliasDeclarationKind:       starlark.NewBuiltin(aliasDeclarationKind, evaluator.collector.aliasBuiltin),
+		resourceDeclarationKind:    starlark.NewBuiltin(resourceDeclarationKind, evaluator.collector.resourceBuiltin),
+		environmentDeclarationKind: starlark.NewBuiltin(environmentDeclarationKind, evaluator.collector.environmentBuiltin),
+		"json":                     json.Module,
+		"math":                     math.Module,
+		"time":                     time.Module,
+	}
+	for name, value := range evaluator.options.Environment {
+		predeclared[name] = starlark.String(value)
+	}
+	values := make([]starlark.Value, 0, len(evaluator.options.PlatformTags))
+	for _, tag := range evaluator.options.PlatformTags {
+		values = append(values, starlark.String(tag))
+	}
+	platformTags := starlark.NewList(values)
+	platformTags.Freeze()
+	predeclared["GROG_PLATFORM_TAGS"] = platformTags
+	return predeclared
 }
 
 // loadModule implements the load() function for importing other Starlark files
 // with caching and cycle detection.
-func (sl StarlarkLoader) loadModule(thread *starlark.Thread, module string, currentFile string, collector *starlarkPackageCollector, loadContext *moduleLoadContext) (starlark.StringDict, error) {
-	// Resolve module path relative to workspace root or current file
-	var modulePath string
-
-	if len(module) > 2 && module[:2] == "//" {
-		// Absolute path from workspace root
-		relativePath := module[2:]
-		modulePath = filepath.Join(config.Global.WorkspaceRoot, relativePath)
-	} else {
-		// Relative path from current file
-		currentDirectory := filepath.Dir(currentFile)
-		modulePath = filepath.Join(currentDirectory, module)
-	}
-
-	// Clean the path to normalize it for cache lookups
-	modulePath = filepath.Clean(modulePath)
+func (evaluator *starlarkEvaluator) loadModule(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	modulePath := ResolveStarlarkModulePath(evaluator.options.WorkspaceRoot, thread.Name, module)
 
 	// Check cache first - if already loaded, return cached result
-	if cached, ok := loadContext.cache[modulePath]; ok {
+	if cached, isLoaded := evaluator.modules.cache[modulePath]; isLoaded {
 		return cached, nil
 	}
 
 	// Check if currently being loaded - this indicates a cycle
-	if loadContext.loading[modulePath] {
+	if evaluator.modules.loading[modulePath] {
 		return nil, fmt.Errorf("cycle detected: module %s is already being loaded", module)
 	}
 
 	// Check if file exists
-	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("module not found: %s (resolved to %s)", module, modulePath)
+	source, operationError := evaluator.options.ReadFile(modulePath)
+	if operationError != nil {
+		return nil, fmt.Errorf("module not found: %s (resolved to %s): %w", module, modulePath, operationError)
 	}
-
-	// Mark as currently loading to detect cycles
-	loadContext.loading[modulePath] = true
+	evaluator.modules.loading[modulePath] = true
 	defer func() {
-		// Remove from loading set when done
-		delete(loadContext.loading, modulePath)
+		delete(evaluator.modules.loading, modulePath)
 	}()
-
-	// Create predeclared functions for the loaded module
-	predeclared := starlark.StringDict{
-		"target":      starlark.NewBuiltin("target", collector.targetBuiltin),
-		"alias":       starlark.NewBuiltin("alias", collector.aliasBuiltin),
-		"resource":    starlark.NewBuiltin("resource", collector.resourceBuiltin),
-		"environment": starlark.NewBuiltin("environment", collector.environmentBuiltin),
-		"json":        json.Module,
-		"math":        math.Module,
-		"time":        time.Module,
-	}
-	addLoaderEnvToStarlark(predeclared)
-	for key, value := range config.Global.EnvironmentVariables {
-		predeclared[key] = starlark.String(value)
-	}
-
-	// Create a new thread for the module with the same load function
-	moduleThread := &starlark.Thread{
-		Name: modulePath,
-		Load: func(threadInner *starlark.Thread, moduleInner string) (starlark.StringDict, error) {
-			return sl.loadModule(threadInner, moduleInner, modulePath, collector, loadContext)
-		},
-	}
-
-	// Execute the module
-	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, moduleThread, modulePath, nil, predeclared)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load module %s: %w", module, err)
+	moduleThread := &starlark.Thread{Name: modulePath, Load: evaluator.loadModule}
+	globals, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, moduleThread, modulePath, source, evaluator.predeclared())
+	if operationError != nil {
+		return nil, fmt.Errorf("failed to load module %s: %w", module, operationError)
 	}
 
 	// Cache the result before returning
-	loadContext.cache[modulePath] = globals
+	evaluator.modules.cache[modulePath] = globals
 
 	return globals, nil
 }
@@ -189,26 +208,25 @@ func (c *starlarkPackageCollector) targetBuiltin(thread *starlark.Thread, fn *st
 	var concurrencyGroup string
 	var ociPush *starlark.Dict
 
-	// Parse keyword arguments
-	if err := starlark.UnpackArgs("target", args, kwargs,
-		"name", &name,
-		"command?", &command,
-		"dependencies?", &dependencies,
-		"inputs?", &inputs,
-		"exclude_inputs?", &excludeInputs,
-		"outputs?", &outputs,
-		"bin_output?", &binOutput,
-		"binary_requires_push?", &binaryRequiresPush,
-		"output_checks?", &outputChecks,
-		"tags?", &tags,
-		"fingerprint?", &fingerprint,
-		"platforms?", &platforms,
-		"environment_variables?", &envVars,
-		"timeout?", &timeout,
-		"concurrency_group?", &concurrencyGroup,
-		"oci_push?", &ociPush,
-	); err != nil {
-		return nil, err
+	if operationError := unpackStarlarkArgs(targetDeclarationKind, args, kwargs,
+		&name,
+		&command,
+		&dependencies,
+		&inputs,
+		&excludeInputs,
+		&outputs,
+		&binOutput,
+		&binaryRequiresPush,
+		&outputChecks,
+		&tags,
+		&fingerprint,
+		&platforms,
+		&envVars,
+		&timeout,
+		&concurrencyGroup,
+		&ociPush,
+	); operationError != nil {
+		return nil, operationError
 	}
 
 	target := &TargetDTO{
@@ -322,6 +340,7 @@ func (c *starlarkPackageCollector) targetBuiltin(thread *starlark.Thread, fn *st
 	}
 
 	c.targets = append(c.targets, target)
+	c.recordDeclaration(thread, targetDeclarationKind, name)
 	return starlark.None, nil
 }
 
@@ -330,11 +349,11 @@ func (c *starlarkPackageCollector) aliasBuiltin(thread *starlark.Thread, fn *sta
 	var name string
 	var actual string
 
-	if err := starlark.UnpackArgs("alias", args, kwargs,
-		"name", &name,
-		"actual", &actual,
-	); err != nil {
-		return nil, err
+	if operationError := unpackStarlarkArgs(aliasDeclarationKind, args, kwargs,
+		&name,
+		&actual,
+	); operationError != nil {
+		return nil, operationError
 	}
 
 	alias := &AliasDTO{
@@ -343,6 +362,7 @@ func (c *starlarkPackageCollector) aliasBuiltin(thread *starlark.Thread, fn *sta
 	}
 
 	c.aliases = append(c.aliases, alias)
+	c.recordDeclaration(thread, aliasDeclarationKind, name)
 	return starlark.None, nil
 }
 
@@ -356,16 +376,16 @@ func (c *starlarkPackageCollector) resourceBuiltin(thread *starlark.Thread, fn *
 	var exports *starlark.Dict
 	var dependencies *starlark.List
 
-	if err := starlark.UnpackArgs("resource", args, kwargs,
-		"name", &name,
-		"up", &up,
-		"down?", &down,
-		"ready?", &ready,
-		"timeout?", &timeout,
-		"exports?", &exports,
-		"dependencies?", &dependencies,
-	); err != nil {
-		return nil, err
+	if operationError := unpackStarlarkArgs(resourceDeclarationKind, args, kwargs,
+		&name,
+		&up,
+		&down,
+		&ready,
+		&timeout,
+		&exports,
+		&dependencies,
+	); operationError != nil {
+		return nil, operationError
 	}
 
 	resource := &ResourceDTO{
@@ -393,6 +413,7 @@ func (c *starlarkPackageCollector) resourceBuiltin(thread *starlark.Thread, fn *
 	}
 
 	c.resources = append(c.resources, resource)
+	c.recordDeclaration(thread, resourceDeclarationKind, name)
 	return starlark.None, nil
 }
 
@@ -403,13 +424,13 @@ func (c *starlarkPackageCollector) environmentBuiltin(thread *starlark.Thread, f
 	var dependencies *starlark.List
 	var ociImage string
 
-	if err := starlark.UnpackArgs("environment", args, kwargs,
-		"name", &name,
-		"type", &envType,
-		"dependencies?", &dependencies,
-		"oci_image?", &ociImage,
-	); err != nil {
-		return nil, err
+	if operationError := unpackStarlarkArgs(environmentDeclarationKind, args, kwargs,
+		&name,
+		&envType,
+		&dependencies,
+		&ociImage,
+	); operationError != nil {
+		return nil, operationError
 	}
 
 	env := &EnvironmentDTO{
@@ -428,19 +449,16 @@ func (c *starlarkPackageCollector) environmentBuiltin(thread *starlark.Thread, f
 	}
 
 	c.environments = append(c.environments, env)
+	c.recordDeclaration(thread, environmentDeclarationKind, name)
 	return starlark.None, nil
 }
 
-// Helper functions to convert Starlark types to Go types
-
-func platformTagsStarlarkList() *starlark.List {
-	values := make([]starlark.Value, 0, len(config.Global.PlatformTags))
-	for _, tag := range config.Global.PlatformTags {
-		values = append(values, starlark.String(tag))
+func (collector *starlarkPackageCollector) recordDeclaration(thread *starlark.Thread, kind string, name string) {
+	if collector.declaration == nil {
+		return
 	}
-	list := starlark.NewList(values)
-	list.Freeze()
-	return list
+	position := thread.CallFrame(1).Pos
+	collector.declaration(StarlarkDeclaration{Kind: kind, Name: name, Path: position.Filename(), Line: int(position.Line), Column: int(position.Col)})
 }
 
 func starlarkListToStringSlice(list *starlark.List) ([]string, error) {

--- a/internal/loading/starlark_loader.go
+++ b/internal/loading/starlark_loader.go
@@ -93,11 +93,15 @@ type moduleLoadContext struct {
 }
 
 // Load reads the file at the specified filePath and evaluates it as Starlark code.
-func (StarlarkLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
+func (loader StarlarkLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
 	source, operationError := os.ReadFile(filePath)
 	if operationError != nil {
 		return PackageDTO{}, false, operationError
 	}
+	return loader.loadSource(ctx, filePath, source)
+}
+
+func (StarlarkLoader) loadSource(_ context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
 	environment := LoaderEnv()
 	for key, value := range config.Global.EnvironmentVariables {
 		environment[key] = value

--- a/internal/loading/starlark_options.go
+++ b/internal/loading/starlark_options.go
@@ -28,8 +28,8 @@ func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions
 	}
 	operatingSystem := runtime.GOOS
 	architecture := runtime.GOARCH
-	environment := standardStarlarkEnvironment(workspaceRoot, operatingSystem, architecture)
-	environment["GROG_GIT_HASH"] = loaderGitHash(workspaceRoot)
+	gitHash := loaderGitHash(workspaceRoot)
+	environment := loaderEnvironment(workspaceRoot, operatingSystem, architecture, "", "", gitHash)
 	options := StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment}
 	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
 	if operationError != nil {
@@ -51,7 +51,7 @@ func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions
 	if configuration.Architecture != "" {
 		architecture = configuration.Architecture
 	}
-	options.Environment = standardStarlarkEnvironment(workspaceRoot, operatingSystem, architecture)
+	options.Environment = loaderEnvironment(workspaceRoot, operatingSystem, architecture, strings.Join(configuration.PlatformTags, ","), "", gitHash)
 	options.PlatformTags = configuration.PlatformTags
 	if configuration.EnvironmentVariablesFile != "" {
 		environmentFilePath := configuration.EnvironmentVariablesFile

--- a/internal/loading/starlark_options.go
+++ b/internal/loading/starlark_options.go
@@ -1,10 +1,14 @@
 package loading
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
+
+	"grog/internal/config"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/subosito/gotenv"
@@ -13,9 +17,19 @@ import (
 
 // StarlarkOptionsForWorkspace returns tooling evaluation defaults for a workspace.
 func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions {
+	if filepath.Clean(config.Global.WorkspaceRoot) == filepath.Clean(workspaceRoot) && config.Global.OS != "" && config.Global.Arch != "" {
+		environmentFilePath := config.Global.EnvironmentVariablesFile
+		if environmentFilePath != "" && !filepath.IsAbs(environmentFilePath) {
+			environmentFilePath = filepath.Join(workspaceRoot, environmentFilePath)
+		}
+		environment := loaderEnvironment(workspaceRoot, config.Global.OS, config.Global.Arch, strings.Join(config.Global.PlatformTags, ","), environmentFilePath, loaderGitHash(workspaceRoot))
+		maps.Copy(environment, config.Global.EnvironmentVariables)
+		return StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment, PlatformTags: config.Global.PlatformTags}
+	}
 	operatingSystem := runtime.GOOS
 	architecture := runtime.GOARCH
 	environment := standardStarlarkEnvironment(workspaceRoot, operatingSystem, architecture)
+	environment["GROG_GIT_HASH"] = loaderGitHash(workspaceRoot)
 	options := StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment}
 	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
 	if operationError != nil {

--- a/internal/loading/starlark_options.go
+++ b/internal/loading/starlark_options.go
@@ -1,6 +1,7 @@
 package loading
 
 import (
+	"fmt"
 	"maps"
 	"os"
 	"path/filepath"
@@ -16,7 +17,7 @@ import (
 )
 
 // StarlarkOptionsForWorkspace returns tooling evaluation defaults for a workspace.
-func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions {
+func StarlarkOptionsForWorkspace(workspaceRoot string) (StarlarkEvaluationOptions, error) {
 	if filepath.Clean(config.Global.WorkspaceRoot) == filepath.Clean(workspaceRoot) && config.Global.OS != "" && config.Global.Arch != "" {
 		environmentFilePath := config.Global.EnvironmentVariablesFile
 		if environmentFilePath != "" && !filepath.IsAbs(environmentFilePath) {
@@ -24,16 +25,23 @@ func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions
 		}
 		environment := loaderEnvironment(workspaceRoot, config.Global.OS, config.Global.Arch, strings.Join(config.Global.PlatformTags, ","), environmentFilePath, loaderGitHash(workspaceRoot))
 		maps.Copy(environment, config.Global.EnvironmentVariables)
-		return StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment, PlatformTags: config.Global.PlatformTags}
+		return StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment, PlatformTags: config.Global.PlatformTags}, nil
 	}
 	operatingSystem := runtime.GOOS
 	architecture := runtime.GOARCH
 	gitHash := loaderGitHash(workspaceRoot)
 	environment := loaderEnvironment(workspaceRoot, operatingSystem, architecture, "", "", gitHash)
 	options := StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment}
-	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
+	configurationPath, operationError := config.SelectedWorkspaceConfigPath(workspaceRoot)
 	if operationError != nil {
-		return options
+		return options, fmt.Errorf("select workspace configuration: %w", operationError)
+	}
+	if configurationPath == "" {
+		return options, nil
+	}
+	configurationBytes, operationError := os.ReadFile(configurationPath)
+	if operationError != nil {
+		return options, fmt.Errorf("read workspace configuration: %w", operationError)
 	}
 	var configuration struct {
 		EnvironmentVariables     map[string]string `toml:"environment_variables"`
@@ -42,8 +50,8 @@ func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions
 		Architecture             string            `toml:"arch"`
 		PlatformTags             []string          `toml:"platform_tag"`
 	}
-	if toml.Unmarshal(configurationBytes, &configuration) != nil {
-		return options
+	if operationError := toml.Unmarshal(configurationBytes, &configuration); operationError != nil {
+		return options, fmt.Errorf("parse workspace configuration %s: %w", configurationPath, operationError)
 	}
 	if configuration.OperatingSystem != "" {
 		operatingSystem = configuration.OperatingSystem
@@ -59,16 +67,18 @@ func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions
 			environmentFilePath = filepath.Join(workspaceRoot, environmentFilePath)
 		}
 		options.Environment["GROG_ENV_FILE"] = environmentFilePath
-		if environmentVariables, readError := gotenv.Read(environmentFilePath); readError == nil {
-			for name, value := range environmentVariables {
-				options.Environment[name] = value
-			}
+		environmentVariables, readError := gotenv.Read(environmentFilePath)
+		if readError != nil {
+			return options, fmt.Errorf("read environment variables file %s: %w", environmentFilePath, readError)
+		}
+		for name, value := range environmentVariables {
+			options.Environment[name] = value
 		}
 	}
 	for name, value := range configuration.EnvironmentVariables {
 		options.Environment[name] = value
 	}
-	return options
+	return options, nil
 }
 
 func standardStarlarkEnvironment(workspaceRoot string, operatingSystem string, architecture string) map[string]string {

--- a/internal/loading/starlark_options.go
+++ b/internal/loading/starlark_options.go
@@ -1,0 +1,88 @@
+package loading
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/subosito/gotenv"
+	"go.starlark.net/starlark"
+)
+
+// StarlarkOptionsForWorkspace returns tooling evaluation defaults for a workspace.
+func StarlarkOptionsForWorkspace(workspaceRoot string) StarlarkEvaluationOptions {
+	operatingSystem := runtime.GOOS
+	architecture := runtime.GOARCH
+	environment := standardStarlarkEnvironment(workspaceRoot, operatingSystem, architecture)
+	options := StarlarkEvaluationOptions{WorkspaceRoot: workspaceRoot, Environment: environment}
+	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
+	if operationError != nil {
+		return options
+	}
+	var configuration struct {
+		EnvironmentVariables     map[string]string `toml:"environment_variables"`
+		EnvironmentVariablesFile string            `toml:"environment_variables_file"`
+		OperatingSystem          string            `toml:"os"`
+		Architecture             string            `toml:"arch"`
+		PlatformTags             []string          `toml:"platform_tag"`
+	}
+	if toml.Unmarshal(configurationBytes, &configuration) != nil {
+		return options
+	}
+	if configuration.OperatingSystem != "" {
+		operatingSystem = configuration.OperatingSystem
+	}
+	if configuration.Architecture != "" {
+		architecture = configuration.Architecture
+	}
+	options.Environment = standardStarlarkEnvironment(workspaceRoot, operatingSystem, architecture)
+	options.PlatformTags = configuration.PlatformTags
+	if configuration.EnvironmentVariablesFile != "" {
+		environmentFilePath := configuration.EnvironmentVariablesFile
+		if !filepath.IsAbs(environmentFilePath) {
+			environmentFilePath = filepath.Join(workspaceRoot, environmentFilePath)
+		}
+		options.Environment["GROG_ENV_FILE"] = environmentFilePath
+		if environmentVariables, readError := gotenv.Read(environmentFilePath); readError == nil {
+			for name, value := range environmentVariables {
+				options.Environment[name] = value
+			}
+		}
+	}
+	for name, value := range configuration.EnvironmentVariables {
+		options.Environment[name] = value
+	}
+	return options
+}
+
+func standardStarlarkEnvironment(workspaceRoot string, operatingSystem string, architecture string) map[string]string {
+	return loaderEnvironment(workspaceRoot, operatingSystem, architecture, "", "", "")
+}
+
+// StarlarkGlobalNames returns the standard modules and environment names.
+func StarlarkGlobalNames() []string {
+	return starlarkNames(false)
+}
+
+// StarlarkBuiltinNames returns the declaration builtins accepted by the loader.
+func StarlarkBuiltinNames() []string {
+	return starlarkNames(true)
+}
+
+func starlarkNames(wantBuiltin bool) []string {
+	options := StarlarkEvaluationOptions{Environment: standardStarlarkEnvironment("", "", "")}
+	evaluator := starlarkEvaluator{collector: &starlarkPackageCollector{}, options: options}
+	predeclared := evaluator.predeclared()
+	names := make([]string, 0, len(predeclared))
+	for name, value := range predeclared {
+		_, isBuiltin := value.(*starlark.Builtin)
+		if isBuiltin != wantBuiltin {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/loading/starlark_options_test.go
+++ b/internal/loading/starlark_options_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"grog/internal/config"
+
+	"github.com/spf13/viper"
 )
 
 func TestStarlarkOptionsForWorkspaceUsesEffectiveConfiguration(t *testing.T) {
@@ -22,7 +24,10 @@ func TestStarlarkOptionsForWorkspaceUsesEffectiveConfiguration(t *testing.T) {
 	}
 	t.Cleanup(func() { config.Global = previousConfiguration })
 
-	options := StarlarkOptionsForWorkspace(workspaceRoot)
+	options, operationError := StarlarkOptionsForWorkspace(workspaceRoot)
+	if operationError != nil {
+		t.Fatal(operationError)
+	}
 	if options.Environment["GROG_PLATFORM"] != "custom-os/custom-arch" || options.Environment["PROFILE_VALUE"] != "enabled" {
 		t.Fatalf("unexpected environment: %#v", options.Environment)
 	}
@@ -52,8 +57,50 @@ func TestStarlarkOptionsForWorkspaceUsesGitHash(t *testing.T) {
 			t.Fatalf("%v: %v: %s", arguments, operationError, output)
 		}
 	}
-	options := StarlarkOptionsForWorkspace(workspaceRoot)
+	options, operationError := StarlarkOptionsForWorkspace(workspaceRoot)
+	if operationError != nil {
+		t.Fatal(operationError)
+	}
 	if options.Environment["GROG_GIT_HASH"] == "" {
 		t.Fatal("expected GROG_GIT_HASH")
+	}
+}
+
+func TestStarlarkOptionsForWorkspaceUsesSelectedProfile(t *testing.T) {
+	previousConfiguration := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: t.TempDir()}
+	viper.Reset()
+	viper.Set("profile", "dev")
+	t.Setenv("CI", "")
+	t.Cleanup(func() {
+		config.Global = previousConfiguration
+		viper.Reset()
+	})
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("platform_tag = [\"base\"]\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.dev.toml"), []byte("platform_tag = [\"profile\"]\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	options, operationError := StarlarkOptionsForWorkspace(workspaceRoot)
+	if operationError != nil {
+		t.Fatal(operationError)
+	}
+	if len(options.PlatformTags) != 1 || options.PlatformTags[0] != "profile" {
+		t.Fatalf("platform tags = %v", options.PlatformTags)
+	}
+}
+
+func TestStarlarkOptionsForWorkspaceReportsMalformedConfiguration(t *testing.T) {
+	previousConfiguration := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: t.TempDir()}
+	t.Cleanup(func() { config.Global = previousConfiguration })
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("platform_tag = ["), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if _, operationError := StarlarkOptionsForWorkspace(workspaceRoot); operationError == nil {
+		t.Fatal("expected malformed configuration error")
 	}
 }

--- a/internal/loading/starlark_options_test.go
+++ b/internal/loading/starlark_options_test.go
@@ -1,0 +1,56 @@
+package loading
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"grog/internal/config"
+)
+
+func TestStarlarkOptionsForWorkspaceUsesEffectiveConfiguration(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	previousConfiguration := config.Global
+	config.Global = config.WorkspaceConfig{
+		WorkspaceRoot:            workspaceRoot,
+		OS:                       "custom-os",
+		Arch:                     "custom-arch",
+		PlatformTags:             []string{"accelerated"},
+		EnvironmentVariables:     map[string]string{"PROFILE_VALUE": "enabled"},
+		EnvironmentVariablesFile: "profile.env",
+	}
+	t.Cleanup(func() { config.Global = previousConfiguration })
+
+	options := StarlarkOptionsForWorkspace(workspaceRoot)
+	if options.Environment["GROG_PLATFORM"] != "custom-os/custom-arch" || options.Environment["PROFILE_VALUE"] != "enabled" {
+		t.Fatalf("unexpected environment: %#v", options.Environment)
+	}
+	if options.Environment["GROG_ENV_FILE"] != filepath.Join(workspaceRoot, "profile.env") {
+		t.Fatalf("GROG_ENV_FILE = %q", options.Environment["GROG_ENV_FILE"])
+	}
+	if len(options.PlatformTags) != 1 || options.PlatformTags[0] != "accelerated" {
+		t.Fatalf("platform tags = %v", options.PlatformTags)
+	}
+}
+
+func TestStarlarkOptionsForWorkspaceUsesGitHash(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "file"), []byte("content"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	commands := [][]string{
+		{"git", "init", "--quiet", workspaceRoot},
+		{"git", "-C", workspaceRoot, "add", "file"},
+		{"git", "-C", workspaceRoot, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--quiet", "-m", "initial"},
+	}
+	for _, arguments := range commands {
+		if output, operationError := exec.Command(arguments[0], arguments[1:]...).CombinedOutput(); operationError != nil {
+			t.Fatalf("%v: %v: %s", arguments, operationError, output)
+		}
+	}
+	options := StarlarkOptionsForWorkspace(workspaceRoot)
+	if options.Environment["GROG_GIT_HASH"] == "" {
+		t.Fatal("expected GROG_GIT_HASH")
+	}
+}

--- a/internal/loading/starlark_options_test.go
+++ b/internal/loading/starlark_options_test.go
@@ -36,6 +36,9 @@ func TestStarlarkOptionsForWorkspaceUsesEffectiveConfiguration(t *testing.T) {
 
 func TestStarlarkOptionsForWorkspaceUsesGitHash(t *testing.T) {
 	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("platform_tag = [\"configured\"]\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
 	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "file"), []byte("content"), 0o644); operationError != nil {
 		t.Fatal(operationError)
 	}

--- a/internal/loading/validation.go
+++ b/internal/loading/validation.go
@@ -1,0 +1,32 @@
+package loading
+
+import (
+	"fmt"
+	"time"
+)
+
+// ValidatePackageTimeouts validates duration fields accepted by package loaders.
+func ValidatePackageTimeouts(packageDTO PackageDTO) error {
+	for _, target := range packageDTO.Targets {
+		if _, operationError := parseBuildTimeout(targetDeclarationKind, target.Name, target.Timeout); operationError != nil {
+			return operationError
+		}
+	}
+	for _, resource := range packageDTO.Resources {
+		if _, operationError := parseBuildTimeout(resourceDeclarationKind, resource.Name, resource.Timeout); operationError != nil {
+			return operationError
+		}
+	}
+	return nil
+}
+
+func parseBuildTimeout(declarationKind string, declarationName string, value string) (time.Duration, error) {
+	if value == "" {
+		return 0, nil
+	}
+	duration, operationError := time.ParseDuration(value)
+	if operationError != nil {
+		return 0, fmt.Errorf("failed to parse timeout for %s %s: %w", declarationKind, declarationName, operationError)
+	}
+	return duration, nil
+}

--- a/internal/loading/validation.go
+++ b/internal/loading/validation.go
@@ -8,11 +8,17 @@ import (
 // ValidatePackageTimeouts validates duration fields accepted by package loaders.
 func ValidatePackageTimeouts(packageDTO PackageDTO) error {
 	for _, target := range packageDTO.Targets {
+		if target == nil {
+			continue
+		}
 		if _, operationError := parseBuildTimeout(targetDeclarationKind, target.Name, target.Timeout); operationError != nil {
 			return operationError
 		}
 	}
 	for _, resource := range packageDTO.Resources {
+		if resource == nil {
+			continue
+		}
 		if _, operationError := parseBuildTimeout(resourceDeclarationKind, resource.Name, resource.Timeout); operationError != nil {
 			return operationError
 		}

--- a/internal/loading/validation.go
+++ b/internal/loading/validation.go
@@ -3,6 +3,8 @@ package loading
 import (
 	"fmt"
 	"time"
+
+	"grog/internal/label"
 )
 
 // ValidatePackageTimeouts validates duration fields accepted by package loaders.
@@ -20,6 +22,44 @@ func ValidatePackageTimeouts(packageDTO PackageDTO) error {
 			continue
 		}
 		if _, operationError := parseBuildTimeout(resourceDeclarationKind, resource.Name, resource.Timeout); operationError != nil {
+			return operationError
+		}
+	}
+	return nil
+}
+
+// ValidatePackageLabels validates every target label accepted by package enrichment.
+func ValidatePackageLabels(packageDTO PackageDTO, packagePath string) error {
+	for _, target := range packageDTO.Targets {
+		if target == nil {
+			continue
+		}
+		if operationError := validateLabels(packagePath, target.Dependencies); operationError != nil {
+			return operationError
+		}
+	}
+	for _, resource := range packageDTO.Resources {
+		if resource == nil {
+			continue
+		}
+		if operationError := validateLabels(packagePath, resource.Dependencies); operationError != nil {
+			return operationError
+		}
+	}
+	for _, alias := range packageDTO.Aliases {
+		if alias == nil {
+			continue
+		}
+		if _, operationError := label.ParseTargetLabel(packagePath, alias.Actual); operationError != nil {
+			return operationError
+		}
+	}
+	return nil
+}
+
+func validateLabels(packagePath string, values []string) error {
+	for _, value := range values {
+		if _, operationError := label.ParseTargetLabel(packagePath, value); operationError != nil {
 			return operationError
 		}
 	}

--- a/internal/loading/validation.go
+++ b/internal/loading/validation.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"grog/internal/label"
+	"grog/internal/model"
+	"grog/internal/output"
 )
 
 // ValidatePackageTimeouts validates duration fields accepted by package loaders.
@@ -55,6 +57,38 @@ func ValidatePackageLabels(packageDTO PackageDTO, packagePath string) error {
 		}
 	}
 	return nil
+}
+
+// ValidatePackageOutputs validates output fields accepted by package enrichment.
+func ValidatePackageOutputs(packageDTO PackageDTO) error {
+	for _, target := range packageDTO.Targets {
+		if target == nil {
+			continue
+		}
+		if _, _, operationError := parseTargetOutputs(target, target.Name); operationError != nil {
+			return operationError
+		}
+	}
+	return nil
+}
+
+func parseTargetOutputs(target *TargetDTO, targetName string) ([]model.Output, model.Output, error) {
+	parsedOutputs, operationError := output.ParseOutputs(target.Outputs)
+	if operationError != nil {
+		return nil, model.Output{}, fmt.Errorf("failed to parse outputs for target %s: %w", targetName, operationError)
+	}
+	binaryOutput := model.Output{}
+	if target.BinOutput == "" {
+		return parsedOutputs, binaryOutput, nil
+	}
+	binaryOutput, operationError = output.ParseOutput(target.BinOutput)
+	if operationError != nil {
+		return nil, model.Output{}, fmt.Errorf("failed to parse bin output for target %s: %w", targetName, operationError)
+	}
+	if !binaryOutput.IsFile() {
+		return nil, model.Output{}, fmt.Errorf("bin output %s for target %s must be of type file", target.BinOutput, targetName)
+	}
+	return parsedOutputs, binaryOutput, nil
 }
 
 func validateLabels(packagePath string, values []string) error {

--- a/internal/loading/workspace_options.go
+++ b/internal/loading/workspace_options.go
@@ -14,7 +14,11 @@ func WorkspaceIncludesHidden(workspaceRoot string) bool {
 	if config.Global.WorkspaceRoot != "" && filepath.Clean(config.Global.WorkspaceRoot) == filepath.Clean(workspaceRoot) {
 		return config.Global.IncludeHidden
 	}
-	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
+	configurationPath, operationError := config.SelectedWorkspaceConfigPath(workspaceRoot)
+	if operationError != nil || configurationPath == "" {
+		return false
+	}
+	configurationBytes, operationError := os.ReadFile(configurationPath)
 	if operationError != nil {
 		return false
 	}

--- a/internal/loading/workspace_options.go
+++ b/internal/loading/workspace_options.go
@@ -1,0 +1,28 @@
+package loading
+
+import (
+	"os"
+	"path/filepath"
+
+	"grog/internal/config"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// WorkspaceIncludesHidden returns the effective package discovery setting.
+func WorkspaceIncludesHidden(workspaceRoot string) bool {
+	if config.Global.WorkspaceRoot != "" && filepath.Clean(config.Global.WorkspaceRoot) == filepath.Clean(workspaceRoot) {
+		return config.Global.IncludeHidden
+	}
+	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
+	if operationError != nil {
+		return false
+	}
+	var configuration struct {
+		IncludeHidden bool `toml:"include_hidden"`
+	}
+	if toml.Unmarshal(configurationBytes, &configuration) != nil {
+		return false
+	}
+	return configuration.IncludeHidden
+}

--- a/internal/loading/yaml_loader.go
+++ b/internal/loading/yaml_loader.go
@@ -17,11 +17,15 @@ func (YamlLoader) Matches(fileName string) bool {
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.
-func (YamlLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
+func (loader YamlLoader) Load(ctx context.Context, filePath string) (PackageDTO, bool, error) {
 	source, operationError := os.ReadFile(filePath)
 	if operationError != nil {
 		return PackageDTO{}, false, operationError
 	}
+	return loader.loadSource(ctx, filePath, source)
+}
+
+func (YamlLoader) loadSource(_ context.Context, filePath string, source []byte) (PackageDTO, bool, error) {
 	packageDTO, operationError := DecodeYAML(source)
 	if operationError != nil {
 		return PackageDTO{}, true, fmt.Errorf("failed to decode YAML file %s: %w", filePath, operationError)

--- a/internal/loading/yaml_loader.go
+++ b/internal/loading/yaml_loader.go
@@ -1,6 +1,7 @@
 package loading
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -8,33 +9,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// YamlLoader implements the Loader interface for JSON files.
+// YamlLoader implements the Loader interface for YAML files.
 type YamlLoader struct{}
 
-func (j YamlLoader) Matches(fileName string) bool {
+func (YamlLoader) Matches(fileName string) bool {
 	return fileName == "BUILD.yaml" || fileName == "BUILD.yml"
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.
-func (j YamlLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
-	var pkg PackageDTO
-
-	// Open the file.
-	file, err := os.Open(filePath)
-	if err != nil {
-		return pkg, false, err
+func (YamlLoader) Load(_ context.Context, filePath string) (PackageDTO, bool, error) {
+	source, operationError := os.ReadFile(filePath)
+	if operationError != nil {
+		return PackageDTO{}, false, operationError
 	}
-	defer file.Close()
-
-	// Decode JSON content.
-	decoder := yaml.NewDecoder(file)
-	err = decoder.Decode(&pkg)
-	if err != nil {
-		return pkg, true, fmt.Errorf(
-			"failed to decode JSON file %s: %w",
-			filePath,
-			err)
+	packageDTO, operationError := DecodeYAML(source)
+	if operationError != nil {
+		return PackageDTO{}, true, fmt.Errorf("failed to decode YAML file %s: %w", filePath, operationError)
 	}
+	return packageDTO, true, nil
+}
 
-	return pkg, true, nil
+// DecodeYAML decodes a package from YAML source.
+func DecodeYAML(source []byte) (PackageDTO, error) {
+	var packageDTO PackageDTO
+	if operationError := yaml.NewDecoder(bytes.NewReader(source)).Decode(&packageDTO); operationError != nil {
+		return PackageDTO{}, operationError
+	}
+	return packageDTO, nil
 }

--- a/internal/loading/yaml_loader.go
+++ b/internal/loading/yaml_loader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -12,8 +13,10 @@ import (
 // YamlLoader implements the Loader interface for YAML files.
 type YamlLoader struct{}
 
+var yamlBuildFileNames = []string{"BUILD.yaml", "BUILD.yml"}
+
 func (YamlLoader) Matches(fileName string) bool {
-	return fileName == "BUILD.yaml" || fileName == "BUILD.yml"
+	return slices.Contains(yamlBuildFileNames, fileName)
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.

--- a/internal/loading/yaml_loader.go
+++ b/internal/loading/yaml_loader.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -13,10 +12,8 @@ import (
 // YamlLoader implements the Loader interface for YAML files.
 type YamlLoader struct{}
 
-var yamlBuildFileNames = []string{"BUILD.yaml", "BUILD.yml"}
-
 func (YamlLoader) Matches(fileName string) bool {
-	return slices.Contains(yamlBuildFileNames, fileName)
+	return IsYAMLPackageFile(fileName)
 }
 
 // Load reads the file at the specified filePath and unmarshals its content into a model.Package.

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -26,7 +26,11 @@ func (server *server) completionItems(documentURI string, textPosition position)
 		}
 		return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
-		return pathCompletionItems(path, text, textPosition, yamlBuildFieldIsCollection(field))
+		alreadyListed := map[string]bool{}
+		if yamlBuildFieldIsCollection(field) {
+			alreadyListed = yamlListValuesAt(text, textPosition, field)
+		}
+		return pathCompletionItems(path, text, textPosition, alreadyListed)
 	} else if field == "outputs" {
 		return outputPathCompletionItems(path, text, textPosition)
 	}
@@ -57,7 +61,11 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 			return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 		}
 		if (field == "inputs" || field == "exclude_inputs" || field == "bin_output") && starlarkDeclarationHasField(callName, field) {
-			return pathCompletionItems(path, text, textPosition, loading.BuildFieldIsCollection("starlark", callName, field))
+			alreadyListed := map[string]bool{}
+			if loading.BuildFieldIsCollection("starlark", callName, field) {
+				alreadyListed = stringListValuesAt(text, textPosition)
+			}
+			return pathCompletionItems(path, text, textPosition, alreadyListed)
 		}
 		if field == "outputs" && starlarkDeclarationHasField(callName, field) {
 			return outputPathCompletionItems(path, text, textPosition)
@@ -203,12 +211,8 @@ func outputPathCompletionItems(currentPath string, text string, textPosition pos
 	return items
 }
 
-func pathCompletionItems(currentPath string, text string, textPosition position, excludeAlreadyListed bool) []map[string]any {
+func pathCompletionItems(currentPath string, text string, textPosition position, alreadyListed map[string]bool) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
-	alreadyListed := map[string]bool{}
-	if excludeAlreadyListed {
-		alreadyListed = stringListValuesAt(text, textPosition)
-	}
 	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, alreadyListed)
 	addCompletionTextEdits(items, textPosition, prefix)
 	return items
@@ -419,7 +423,7 @@ func inStringAt(text string, textPosition position) bool {
 	if offset < 0 || offset > len(text) {
 		return false
 	}
-	inString := byte(0)
+	stringDelimiter := ""
 	inComment := false
 	for index := 0; index < offset; index++ {
 		character := text[index]
@@ -429,19 +433,29 @@ func inStringAt(text string, textPosition position) bool {
 			}
 			continue
 		}
-		if inString != 0 {
-			if character == inString && !starlarkCharacterEscaped(text, index) {
-				inString = 0
+		if stringDelimiter != "" {
+			if strings.HasPrefix(text[index:], stringDelimiter) && !starlarkCharacterEscaped(text, index) {
+				index += len(stringDelimiter) - 1
+				stringDelimiter = ""
 			}
 			continue
 		}
 		if character == '\'' || character == '"' {
-			inString = character
+			stringDelimiter = starlarkStringDelimiter(text, index)
+			index += len(stringDelimiter) - 1
 		} else if character == '#' {
 			inComment = true
 		}
 	}
-	return inString != 0
+	return stringDelimiter != ""
+}
+
+func starlarkStringDelimiter(text string, index int) string {
+	delimiter := string(text[index])
+	if strings.HasPrefix(text[index:], delimiter+delimiter+delimiter) {
+		return delimiter + delimiter + delimiter
+	}
+	return delimiter
 }
 
 func starlarkCharacterEscaped(text string, index int) bool {
@@ -499,7 +513,7 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 		return ""
 	}
 	callNames := []string{}
-	inString := byte(0)
+	stringDelimiter := ""
 	inComment := false
 	for index := 0; index < offset; index++ {
 		character := text[index]
@@ -509,14 +523,16 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 			}
 			continue
 		}
-		if inString != 0 {
-			if character == inString && !starlarkCharacterEscaped(text, index) {
-				inString = 0
+		if stringDelimiter != "" {
+			if strings.HasPrefix(text[index:], stringDelimiter) && !starlarkCharacterEscaped(text, index) {
+				index += len(stringDelimiter) - 1
+				stringDelimiter = ""
 			}
 			continue
 		}
 		if character == '\'' || character == '"' {
-			inString = character
+			stringDelimiter = starlarkStringDelimiter(text, index)
+			index += len(stringDelimiter) - 1
 			continue
 		}
 		if character == '#' {
@@ -669,7 +685,7 @@ func starlarkActiveParameter(text string, textPosition position, declarationKind
 	segmentStart := 0
 	equalsOffset := -1
 	depth := 0
-	inString := byte(0)
+	stringDelimiter := ""
 	inComment := false
 	for index := 0; index < len(arguments); index++ {
 		character := arguments[index]
@@ -679,15 +695,17 @@ func starlarkActiveParameter(text string, textPosition position, declarationKind
 			}
 			continue
 		}
-		if inString != 0 {
-			if character == inString && !starlarkCharacterEscaped(arguments, index) {
-				inString = 0
+		if stringDelimiter != "" {
+			if strings.HasPrefix(arguments[index:], stringDelimiter) && !starlarkCharacterEscaped(arguments, index) {
+				index += len(stringDelimiter) - 1
+				stringDelimiter = ""
 			}
 			continue
 		}
 		switch character {
 		case '\'', '"':
-			inString = character
+			stringDelimiter = starlarkStringDelimiter(arguments, index)
+			index += len(stringDelimiter) - 1
 		case '#':
 			inComment = true
 		case '(', '[', '{':

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -536,9 +536,15 @@ func yamlFieldAt(text string, textPosition position) string {
 		if character != ':' {
 			continue
 		}
+		if index+1 < len(currentLine) && !unicodeSpace(currentLine[index+1]) && !strings.ContainsRune("[{\"'},]", rune(currentLine[index+1])) {
+			continue
+		}
 		start := index
 		for start > 0 && isWordCharacter(currentLine[start-1]) {
 			start--
+		}
+		if start > 0 && !unicodeSpace(currentLine[start-1]) && !strings.ContainsRune("[{,-", rune(currentLine[start-1])) {
+			continue
 		}
 		if yamlFieldName(currentLine[start:index]) {
 			activeField = currentLine[start:index]

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -20,7 +20,11 @@ func (server *server) completionItems(documentURI string, textPosition position)
 	}
 	field := yamlFieldAt(text, textPosition)
 	if field == "dependencies" || field == "actual" {
-		return server.labelCompletionItems(path, text, textPosition, yamlBuildFieldIsCollection(field))
+		alreadyListed := map[string]bool{}
+		if yamlBuildFieldIsCollection(field) {
+			alreadyListed = yamlListValuesAt(text, textPosition, field)
+		}
+		return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
 		return pathCompletionItems(path, text, textPosition)
 	} else if field == "outputs" {
@@ -46,7 +50,11 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	callName := enclosingStarlarkCall(text, textPosition)
 	if inStringAt(text, textPosition) {
 		if (field == "dependencies" || field == "actual") && starlarkDeclarationHasField(callName, field) {
-			return server.labelCompletionItems(path, text, textPosition, loading.BuildFieldIsCollection("starlark", callName, field))
+			alreadyListed := map[string]bool{}
+			if loading.BuildFieldIsCollection("starlark", callName, field) {
+				alreadyListed = stringListValuesAt(text, textPosition)
+			}
+			return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 		}
 		if (field == "inputs" || field == "exclude_inputs" || field == "bin_output") && starlarkDeclarationHasField(callName, field) {
 			return pathCompletionItems(path, text, textPosition)
@@ -107,14 +115,10 @@ func yamlBuildFieldIsCollection(field string) bool {
 	return false
 }
 
-func (server *server) labelCompletionItems(currentPath string, text string, textPosition position, excludeAlreadyListed bool) []map[string]any {
+func (server *server) labelCompletionItems(currentPath string, text string, textPosition position, alreadyListed map[string]bool) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
 	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
 	labels := server.collectWorkspaceLabels(workspaceRoot, filepath.Dir(currentPath))
-	alreadyListed := map[string]bool{}
-	if excludeAlreadyListed {
-		alreadyListed = stringListValuesAt(text, textPosition)
-	}
 	items := []map[string]any{}
 	for _, label := range preferredDependencyLabels(labels, prefix) {
 		if prefix != "" && !strings.HasPrefix(label, prefix) || alreadyListed[label] {
@@ -126,6 +130,43 @@ func (server *server) labelCompletionItems(currentPath string, text string, text
 		}
 	}
 	return items
+}
+
+func yamlListValuesAt(text string, textPosition position, field string) map[string]bool {
+	lines := strings.Split(text, "\n")
+	if textPosition.Line < 0 || textPosition.Line >= len(lines) {
+		return map[string]bool{}
+	}
+	fieldLine := -1
+	fieldIndent := 0
+	for lineNumber := textPosition.Line; lineNumber >= 0; lineNumber-- {
+		trimmedLine := strings.TrimSpace(lines[lineNumber])
+		if name, _, found := strings.Cut(trimmedLine, ":"); found && strings.TrimSpace(name) == field {
+			fieldLine = lineNumber
+			fieldIndent = len(lines[lineNumber]) - len(strings.TrimLeft(lines[lineNumber], " \t"))
+			break
+		}
+	}
+	if fieldLine < 0 {
+		return map[string]bool{}
+	}
+	if fieldLine == textPosition.Line && strings.Contains(lines[fieldLine], "[") {
+		return stringListValuesAt(text, textPosition)
+	}
+	values := map[string]bool{}
+	valuePattern := regexp.MustCompile(`^-\s*["']([^"']+)["']`)
+	for lineNumber := fieldLine + 1; lineNumber < textPosition.Line; lineNumber++ {
+		line := lines[lineNumber]
+		trimmedLine := strings.TrimSpace(line)
+		indent := len(line) - len(strings.TrimLeft(line, " \t"))
+		if trimmedLine != "" && indent <= fieldIndent {
+			break
+		}
+		if matches := valuePattern.FindStringSubmatch(trimmedLine); len(matches) == 2 {
+			values[matches[1]] = true
+		}
+	}
+	return values
 }
 
 func preferredDependencyLabels(labels []string, prefix string) []string {
@@ -602,5 +643,70 @@ func signatureHelp(text string, textPosition position) any {
 		names = append(names, name)
 	}
 	label := declarationKind + "(" + strings.Join(names, ", ") + ")"
-	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": 0}
+	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": starlarkActiveParameter(text, textPosition, declarationKind, parameters)}
+}
+
+func starlarkActiveParameter(text string, textPosition position, declarationKind string, parameters []loading.StarlarkParameter) int {
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return 0
+	}
+	prefix := text[:offset]
+	openingOffset := strings.LastIndex(prefix, declarationKind+"(")
+	if openingOffset < 0 {
+		return 0
+	}
+	arguments := prefix[openingOffset+len(declarationKind)+1:]
+	activeParameter := 0
+	segmentStart := 0
+	equalsOffset := -1
+	depth := 0
+	inString := byte(0)
+	inComment := false
+	for index := 0; index < len(arguments); index++ {
+		character := arguments[index]
+		if inComment {
+			if character == '\n' {
+				inComment = false
+			}
+			continue
+		}
+		if inString != 0 {
+			if character == inString && !starlarkCharacterEscaped(arguments, index) {
+				inString = 0
+			}
+			continue
+		}
+		switch character {
+		case '\'', '"':
+			inString = character
+		case '#':
+			inComment = true
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				activeParameter++
+				segmentStart = index + 1
+				equalsOffset = -1
+			}
+		case '=':
+			if depth == 0 {
+				equalsOffset = index
+			}
+		}
+	}
+	if equalsOffset >= segmentStart {
+		name := strings.TrimSpace(arguments[segmentStart:equalsOffset])
+		for index, parameter := range parameters {
+			if parameter.Name == name {
+				return index
+			}
+		}
+	}
+	return min(activeParameter, len(parameters)-1)
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -1,0 +1,499 @@
+package lsp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func (server *server) completionItems(documentURI string, textPosition position) []map[string]any {
+	path := uriPath(documentURI)
+	text := server.documentText(documentURI)
+	name := filepath.Base(path)
+	if isStarlarkFile(name) {
+		return server.starlarkCompletionItems(documentURI, text, textPosition)
+	}
+	if field := yamlFieldAt(text, textPosition); field == "dependencies" || field == "actual" {
+		return labelCompletionItems(path, text, textPosition)
+	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
+		return pathCompletionItems(path, text, textPosition)
+	} else if field == "outputs" {
+		return outputPathCompletionItems(path, text, textPosition)
+	}
+	return completionItemsFor([]string{"targets", "aliases", "resources", "environments", "default_platforms", "name", "command", "dependencies", "inputs", "exclude_inputs", "outputs", "bin_output", "binary_requires_push", "output_checks", "tags", "fingerprint", "platforms", "environment_variables", "timeout", "concurrency_group", "oci_push", "actual", "up", "down", "ready", "exports", "type", "oci_image"}, 5)
+}
+
+func (server *server) documentText(documentURI string) string {
+	if text, isOpen := server.documents[documentURI]; isOpen {
+		return text
+	}
+	text, operationError := os.ReadFile(uriPath(documentURI))
+	if operationError != nil {
+		return ""
+	}
+	return string(text)
+}
+
+func (server *server) starlarkCompletionItems(documentURI string, text string, textPosition position) []map[string]any {
+	path := uriPath(documentURI)
+	field := starlarkFieldAt(text, textPosition)
+	callName := enclosingStarlarkCall(text, textPosition)
+	if inStringAt(text, textPosition) {
+		if field == "dependencies" && (callName == "target" || callName == "resource" || callName == "environment") || field == "actual" && callName == "alias" {
+			return labelCompletionItems(path, text, textPosition)
+		}
+		if callName == "target" && (field == "inputs" || field == "exclude_inputs" || field == "bin_output") {
+			return pathCompletionItems(path, text, textPosition)
+		}
+		if callName == "target" && field == "outputs" {
+			return outputPathCompletionItems(path, text, textPosition)
+		}
+		return nil
+	}
+	if callName != "" && !shouldSuggestStarlarkCallParameters(text, textPosition) {
+		return nil
+	}
+	switch callName {
+	case "target":
+		return completionItemsFor([]string{"name", "command", "dependencies", "inputs", "exclude_inputs", "outputs", "bin_output", "binary_requires_push", "output_checks", "tags", "fingerprint", "platforms", "environment_variables", "timeout", "concurrency_group", "oci_push"}, 5)
+	case "alias":
+		return completionItemsFor([]string{"name", "actual"}, 5)
+	case "resource":
+		return completionItemsFor([]string{"name", "up", "down", "ready", "timeout", "exports", "dependencies"}, 5)
+	case "environment":
+		return completionItemsFor([]string{"name", "type", "dependencies", "oci_image"}, 5)
+	}
+	items := completionItemsFor([]string{"target", "alias", "resource", "environment", "load"}, 3)
+	items = append(items, completionItemsFor([]string{"GROG_OS", "GROG_ARCH", "GROG_PLATFORM", "GROG_PLATFORM_TAGS", "GROG_ENV_FILE", "GROG_WORKSPACE_ROOT", "GROG_GIT_HASH", "json", "math", "time"}, 6)...)
+	return items
+}
+
+func labelCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+	prefix := pathCompletionPrefix(text, textPosition)
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
+	labels := collectWorkspaceLabels(workspaceRoot, filepath.Dir(currentPath))
+	alreadyListed := stringListValuesAt(text, textPosition)
+	items := []map[string]any{}
+	for _, label := range preferredDependencyLabels(labels, prefix) {
+		if prefix != "" && !strings.HasPrefix(label, prefix) || alreadyListed[label] {
+			continue
+		}
+		items = append(items, map[string]any{"label": label, "kind": 12, "insertText": label, "sortText": fmt.Sprintf("%03d_%s", len(items), label), "documentation": "grog target label", "textEdit": completionTextEdit(textPosition, prefix, label)})
+		if len(items) >= 10 {
+			break
+		}
+	}
+	return items
+}
+
+func preferredDependencyLabels(labels []string, prefix string) []string {
+	if strings.HasPrefix(prefix, ":") {
+		return labels
+	}
+	preferred := make([]string, 0, len(labels))
+	deferred := make([]string, 0, len(labels))
+	for _, label := range labels {
+		if strings.HasPrefix(label, "//") {
+			preferred = append(preferred, label)
+		} else {
+			deferred = append(deferred, label)
+		}
+	}
+	return append(preferred, deferred...)
+}
+
+func outputPathCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+	prefix := pathCompletionPrefix(text, textPosition)
+	for _, outputTypePrefix := range []string{"dir::"} {
+		if strings.HasPrefix(prefix, outputTypePrefix) {
+			items := pathCompletionItemsWithPrefix(currentPath, strings.TrimPrefix(prefix, outputTypePrefix), outputTypePrefix, true, stringListValuesAt(text, textPosition))
+			addCompletionTextEdits(items, textPosition, prefix)
+			return items
+		}
+	}
+	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, stringListValuesAt(text, textPosition))
+	addCompletionTextEdits(items, textPosition, prefix)
+	return items
+}
+
+func pathCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+	prefix := pathCompletionPrefix(text, textPosition)
+	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, stringListValuesAt(text, textPosition))
+	addCompletionTextEdits(items, textPosition, prefix)
+	return items
+}
+
+func addCompletionTextEdits(items []map[string]any, textPosition position, prefix string) {
+	for _, item := range items {
+		label, isString := item["label"].(string)
+		if isString {
+			item["textEdit"] = completionTextEdit(textPosition, prefix, label)
+		}
+	}
+}
+
+func completionTextEdit(textPosition position, prefix string, newText string) map[string]any {
+	start := position{Line: textPosition.Line, Character: max(textPosition.Character-len(prefix), 0)}
+	return map[string]any{"range": rangeValue{Start: start, End: textPosition}, "newText": newText}
+}
+
+func pathCompletionItemsWithPrefix(currentPath string, prefix string, labelBasePrefix string, directoriesOnly bool, alreadyListed map[string]bool) []map[string]any {
+	directory := filepath.Dir(currentPath)
+	entryDirectory := directory
+	entryPrefix := prefix
+	labelPrefix := labelBasePrefix
+	if prefix == "./" {
+		entryPrefix = ""
+		labelPrefix += "./"
+	} else if slash := strings.LastIndex(prefix, "/"); slash >= 0 {
+		entryDirectory = filepath.Join(directory, prefix[:slash+1])
+		entryPrefix = prefix[slash+1:]
+		labelPrefix += prefix[:slash+1]
+	}
+	entries, operationError := os.ReadDir(entryDirectory)
+	if operationError != nil {
+		return nil
+	}
+	items := []map[string]any{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasPrefix(name, entryPrefix) || directoriesOnly && !entry.IsDir() {
+			continue
+		}
+		label := labelPrefix + name
+		if entry.IsDir() {
+			label += "/"
+		}
+		if alreadyListed[label] || alreadyListed[strings.TrimSuffix(label, "/")] {
+			continue
+		}
+		insertText := label
+		if prefix != "" && strings.HasPrefix(label, labelBasePrefix+prefix) {
+			insertText = strings.TrimPrefix(label, labelBasePrefix+prefix)
+		} else if strings.HasPrefix(name, entryPrefix) {
+			insertText = strings.TrimPrefix(name, entryPrefix)
+			if entry.IsDir() {
+				insertText += "/"
+			}
+		}
+		items = append(items, map[string]any{"label": label, "kind": 17, "insertText": insertText, "sortText": fmt.Sprintf("%03d_%s", len(items), label), "documentation": "file path"})
+		if len(items) >= 10 {
+			break
+		}
+	}
+	return items
+}
+
+func pathCompletionPrefix(text string, textPosition position) string {
+	lines := strings.Split(text, "\n")
+	if textPosition.Line < 0 || textPosition.Line >= len(lines) {
+		return ""
+	}
+	line := lines[textPosition.Line]
+	if textPosition.Character < 0 || textPosition.Character > len(line) {
+		return ""
+	}
+	prefix := line[:textPosition.Character]
+	quote := strings.LastIndexAny(prefix, "\"'")
+	if quote < 0 {
+		return ""
+	}
+	return prefix[quote+1:]
+}
+
+func stringListValuesAt(text string, textPosition position) map[string]bool {
+	values := map[string]bool{}
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return values
+	}
+	start := strings.LastIndex(text[:offset], "[")
+	if start < 0 {
+		return values
+	}
+	end := len(text)
+	if endRelative := strings.Index(text[offset:], "]"); endRelative >= 0 {
+		end = offset + endRelative
+	}
+	listText := text[start:end]
+	stringPattern := regexp.MustCompile(`["']([^"']+)["']`)
+	for _, match := range stringPattern.FindAllStringSubmatchIndex(listText, -1) {
+		absoluteStart := start + match[0]
+		absoluteEnd := start + match[1]
+		if absoluteStart <= offset && offset <= absoluteEnd {
+			continue
+		}
+		values[listText[match[2]:match[3]]] = true
+	}
+	return values
+}
+
+func completionItemsFor(names []string, kind int) []map[string]any {
+	items := []map[string]any{}
+	for index, itemName := range names {
+		insertText := itemName
+		if kind == 3 {
+			insertText = itemName + "("
+		}
+		items = append(items, map[string]any{"label": itemName, "kind": kind, "insertText": insertText, "sortText": fmt.Sprintf("%03d_%s", index, itemName), "documentation": docs[itemName]})
+	}
+	return items
+}
+
+var docs = map[string]string{
+	"target":                "Declare a grog build/test target.",
+	"alias":                 "Declare an alias to another grog target.",
+	"resource":              "Declare a long-running resource used by targets.",
+	"environment":           "Declare an execution environment.",
+	"load":                  "Load symbols from another Starlark file using grog's local load resolution. No Bazel repositories are fetched.",
+	"name":                  "The declaration name.",
+	"command":               "Shell command run by a target.",
+	"dependencies":          "Target labels this item depends on, such as :build or //pkg:test.",
+	"inputs":                "Input files or globs used to fingerprint a target.",
+	"exclude_inputs":        "Input globs to exclude from fingerprinting.",
+	"outputs":               "Output paths produced by a target.",
+	"bin_output":            "Executable output path produced by a target.",
+	"binary_requires_push":  "Require --push before running this target's binary output.",
+	"output_checks":         "Checks that validate produced outputs.",
+	"tags":                  "Tags used for filtering targets.",
+	"fingerprint":           "Additional key/value fingerprint material.",
+	"platforms":             "Platform selectors that constrain where this declaration applies.",
+	"environment_variables": "Environment variables for the target.",
+	"timeout":               "Target timeout duration.",
+	"concurrency_group":     "Concurrency group used to serialize related targets.",
+	"oci_push":              "OCI push destinations for declared OCI outputs.",
+	"actual":                "Target label referenced by an alias.",
+	"up":                    "Command that starts a resource.",
+	"down":                  "Command that stops a resource.",
+	"ready":                 "Command that reports when a resource is ready.",
+	"exports":               "Environment variables exported by a resource.",
+	"type":                  "Environment type.",
+	"oci_image":             "OCI image used by an environment.",
+	"targets":               "YAML list of grog targets.",
+	"aliases":               "YAML list of grog aliases.",
+	"resources":             "YAML list of grog resources.",
+	"environments":          "YAML list of grog environments.",
+	"default_platforms":     "Default platform selectors for this package.",
+	"GROG_OS":               "Target operating system selected by grog.",
+	"GROG_ARCH":             "Target architecture selected by grog.",
+	"GROG_PLATFORM":         "Selected operating system and architecture.",
+	"GROG_PLATFORM_TAGS":    "Active custom platform tags.",
+	"GROG_ENV_FILE":         "Resolved environment variables file path.",
+	"GROG_WORKSPACE_ROOT":   "Absolute path to the grog workspace.",
+	"GROG_GIT_HASH":         "Current Git commit hash.",
+	"json":                  "Starlark JSON module.",
+	"math":                  "Starlark math module.",
+	"time":                  "Starlark time module.",
+}
+
+func (server *server) hover(documentURI string, textPosition position) any {
+	word := wordAt(server.documentText(documentURI), textPosition)
+	if word == "" {
+		return nil
+	}
+	documentation, isDocumented := docs[word]
+	if !isDocumented {
+		return nil
+	}
+	return map[string]any{"contents": map[string]any{"kind": "markdown", "value": "**" + word + "**\n\n" + documentation}}
+}
+func starlarkFieldAt(text string, textPosition position) string {
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return ""
+	}
+	prefix := text[:offset]
+	equals := strings.LastIndex(prefix, "=")
+	if equals < 0 {
+		return ""
+	}
+	start := equals
+	for start > 0 && unicodeSpace(prefix[start-1]) {
+		start--
+	}
+	end := start
+	for start > 0 && isWordCharacter(prefix[start-1]) {
+		start--
+	}
+	return prefix[start:end]
+}
+
+func unicodeSpace(character byte) bool {
+	return character == ' ' || character == '\t' || character == '\n' || character == '\r'
+}
+
+func inStringAt(text string, textPosition position) bool {
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return false
+	}
+	inString := byte(0)
+	for index := 0; index < offset; index++ {
+		character := text[index]
+		if inString != 0 {
+			if character == inString && (index == 0 || text[index-1] != '\\') {
+				inString = 0
+			}
+			continue
+		}
+		if character == '\'' || character == '"' {
+			inString = character
+		}
+	}
+	return inString != 0
+}
+
+func yamlFieldAt(text string, textPosition position) string {
+	lines := strings.Split(text, "\n")
+	for lineNumber := textPosition.Line; lineNumber >= 0 && lineNumber < len(lines); lineNumber-- {
+		line := strings.TrimSpace(lines[lineNumber])
+		if strings.HasSuffix(line, ":") {
+			return strings.TrimSuffix(line, ":")
+		}
+		if field, _, found := strings.Cut(line, ":"); found && lineNumber == textPosition.Line {
+			return strings.TrimSpace(field)
+		}
+	}
+	return ""
+}
+
+func shouldSuggestStarlarkCallParameters(text string, textPosition position) bool {
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return false
+	}
+	prefix := text[:offset]
+	index := len(prefix) - 1
+	for index >= 0 && unicodeSpace(prefix[index]) {
+		index--
+	}
+	if index >= 0 && prefix[index] == ',' {
+		return true
+	}
+	return len(prefix) > 0 && isWordCharacter(prefix[len(prefix)-1])
+}
+
+func enclosingStarlarkCall(text string, textPosition position) string {
+	offset := byteOffset(text, textPosition)
+	if offset < 0 || offset > len(text) {
+		return ""
+	}
+	callNames := []string{}
+	inString := byte(0)
+	for index := 0; index < offset; index++ {
+		character := text[index]
+		if inString != 0 {
+			if character == inString && (index == 0 || text[index-1] != '\\') {
+				inString = 0
+			}
+			continue
+		}
+		if character == '\'' || character == '"' {
+			inString = character
+			continue
+		}
+		switch character {
+		case '(':
+			end := index
+			start := end
+			for start > 0 && isWordCharacter(text[start-1]) {
+				start--
+			}
+			callNames = append(callNames, text[start:end])
+		case ')':
+			if len(callNames) > 0 {
+				callNames = callNames[:len(callNames)-1]
+			}
+		}
+	}
+	for index := len(callNames) - 1; index >= 0; index-- {
+		name := callNames[index]
+		if name == "target" || name == "alias" || name == "resource" || name == "environment" {
+			return name
+		}
+	}
+	return ""
+}
+
+func positionForOffset(text string, targetOffset int) position {
+	line := 0
+	character := 0
+	if targetOffset < 0 {
+		return position{}
+	}
+	for offset := 0; offset < len(text) && offset < targetOffset; offset++ {
+		if text[offset] == '\n' {
+			line++
+			character = 0
+			continue
+		}
+		character++
+	}
+	return position{Line: line, Character: character}
+}
+
+func byteOffset(text string, textPosition position) int {
+	if textPosition.Line < 0 || textPosition.Character < 0 {
+		return -1
+	}
+	line := 0
+	character := 0
+	for offset := 0; offset < len(text); offset++ {
+		if line == textPosition.Line && character == textPosition.Character {
+			return offset
+		}
+		if text[offset] == '\n' {
+			line++
+			character = 0
+			continue
+		}
+		character++
+	}
+	if line == textPosition.Line && character == textPosition.Character {
+		return len(text)
+	}
+	return -1
+}
+
+func wordAt(text string, textPosition position) string {
+	lines := strings.Split(text, "\n")
+	if textPosition.Line < 0 || textPosition.Line >= len(lines) {
+		return ""
+	}
+	line := lines[textPosition.Line]
+	if textPosition.Character < 0 || textPosition.Character > len(line) {
+		return ""
+	}
+	start := textPosition.Character
+	for start > 0 && isWordCharacter(line[start-1]) {
+		start--
+	}
+	end := textPosition.Character
+	for end < len(line) && isWordCharacter(line[end]) {
+		end++
+	}
+	if start == end {
+		return ""
+	}
+	return line[start:end]
+}
+
+func isWordCharacter(character byte) bool {
+	return character == '_' || character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9'
+}
+
+func signatureHelp(text string, textPosition position) any {
+	labels := map[string]string{
+		"target":      "target(name, command?, dependencies?, inputs?, exclude_inputs?, outputs?, bin_output?, binary_requires_push?, output_checks?, tags?, fingerprint?, platforms?, environment_variables?, timeout?, concurrency_group?, oci_push?)",
+		"alias":       "alias(name, actual)",
+		"resource":    "resource(name, up, down?, ready?, timeout?, exports?, dependencies?)",
+		"environment": "environment(name, type, dependencies?, oci_image?)",
+	}
+	label, found := labels[enclosingStarlarkCall(text, textPosition)]
+	if !found {
+		return nil
+	}
+	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": 0}
+}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -520,11 +520,20 @@ func shouldSuggestStarlarkCallParameters(text string, textPosition position) boo
 }
 
 func enclosingStarlarkCall(text string, textPosition position) string {
+	name, _ := enclosingStarlarkCallAt(text, textPosition)
+	return name
+}
+
+func enclosingStarlarkCallAt(text string, textPosition position) (string, int) {
 	offset := byteOffset(text, textPosition)
 	if offset < 0 || offset > len(text) {
-		return ""
+		return "", -1
 	}
-	callNames := []string{}
+	type call struct {
+		name          string
+		openingOffset int
+	}
+	calls := []call{}
 	stringDelimiter := ""
 	inComment := false
 	for index := 0; index < offset; index++ {
@@ -554,24 +563,26 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 		switch character {
 		case '(':
 			end := index
+			for end > 0 && unicodeSpace(text[end-1]) {
+				end--
+			}
 			start := end
 			for start > 0 && isWordCharacter(text[start-1]) {
 				start--
 			}
-			callNames = append(callNames, text[start:end])
+			calls = append(calls, call{name: text[start:end], openingOffset: index})
 		case ')':
-			if len(callNames) > 0 {
-				callNames = callNames[:len(callNames)-1]
+			if len(calls) > 0 {
+				calls = calls[:len(calls)-1]
 			}
 		}
 	}
-	for index := len(callNames) - 1; index >= 0; index-- {
-		name := callNames[index]
-		if slices.Contains(loading.StarlarkBuiltinNames(), name) {
-			return name
+	for index := len(calls) - 1; index >= 0; index-- {
+		if slices.Contains(loading.StarlarkBuiltinNames(), calls[index].name) {
+			return calls[index].name, calls[index].openingOffset
 		}
 	}
-	return ""
+	return "", -1
 }
 
 func positionForOffset(text string, targetOffset int) position {
@@ -665,7 +676,7 @@ func isWordCharacter(character byte) bool {
 }
 
 func signatureHelp(text string, textPosition position) any {
-	declarationKind := enclosingStarlarkCall(text, textPosition)
+	declarationKind, openingOffset := enclosingStarlarkCallAt(text, textPosition)
 	parameters := loading.StarlarkParameters(declarationKind)
 	if len(parameters) == 0 {
 		return nil
@@ -679,20 +690,15 @@ func signatureHelp(text string, textPosition position) any {
 		names = append(names, name)
 	}
 	label := declarationKind + "(" + strings.Join(names, ", ") + ")"
-	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": starlarkActiveParameter(text, textPosition, declarationKind, parameters)}
+	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": starlarkActiveParameter(text, textPosition, openingOffset, parameters)}
 }
 
-func starlarkActiveParameter(text string, textPosition position, declarationKind string, parameters []loading.StarlarkParameter) int {
+func starlarkActiveParameter(text string, textPosition position, openingOffset int, parameters []loading.StarlarkParameter) int {
 	offset := byteOffset(text, textPosition)
-	if offset < 0 || offset > len(text) {
+	if offset < 0 || offset > len(text) || openingOffset < 0 || openingOffset >= offset {
 		return 0
 	}
-	prefix := text[:offset]
-	openingOffset := strings.LastIndex(prefix, declarationKind+"(")
-	if openingOffset < 0 {
-		return 0
-	}
-	arguments := prefix[openingOffset+len(declarationKind)+1:]
+	arguments := text[openingOffset+1 : offset]
 	activeParameter := 0
 	segmentStart := 0
 	equalsOffset := -1

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -16,7 +16,7 @@ func (server *server) completionItems(documentURI string, textPosition position)
 		return server.starlarkCompletionItems(documentURI, text, textPosition)
 	}
 	if field := yamlFieldAt(text, textPosition); field == "dependencies" || field == "actual" {
-		return labelCompletionItems(path, text, textPosition)
+		return server.labelCompletionItems(path, text, textPosition)
 	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
 		return pathCompletionItems(path, text, textPosition)
 	} else if field == "outputs" {
@@ -42,7 +42,7 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	callName := enclosingStarlarkCall(text, textPosition)
 	if inStringAt(text, textPosition) {
 		if field == "dependencies" && (callName == "target" || callName == "resource" || callName == "environment") || field == "actual" && callName == "alias" {
-			return labelCompletionItems(path, text, textPosition)
+			return server.labelCompletionItems(path, text, textPosition)
 		}
 		if callName == "target" && (field == "inputs" || field == "exclude_inputs" || field == "bin_output") {
 			return pathCompletionItems(path, text, textPosition)
@@ -70,10 +70,10 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	return items
 }
 
-func labelCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+func (server *server) labelCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
 	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
-	labels := collectWorkspaceLabels(workspaceRoot, filepath.Dir(currentPath))
+	labels := server.collectWorkspaceLabels(workspaceRoot, filepath.Dir(currentPath))
 	alreadyListed := stringListValuesAt(text, textPosition)
 	items := []map[string]any{}
 	for _, label := range preferredDependencyLabels(labels, prefix) {
@@ -331,8 +331,15 @@ func inStringAt(text string, textPosition position) bool {
 		return false
 	}
 	inString := byte(0)
+	inComment := false
 	for index := 0; index < offset; index++ {
 		character := text[index]
+		if inComment {
+			if character == '\n' {
+				inComment = false
+			}
+			continue
+		}
 		if inString != 0 {
 			if character == inString && (index == 0 || text[index-1] != '\\') {
 				inString = 0
@@ -341,6 +348,8 @@ func inStringAt(text string, textPosition position) bool {
 		}
 		if character == '\'' || character == '"' {
 			inString = character
+		} else if character == '#' {
+			inComment = true
 		}
 	}
 	return inString != 0
@@ -394,8 +403,15 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 	}
 	callNames := []string{}
 	inString := byte(0)
+	inComment := false
 	for index := 0; index < offset; index++ {
 		character := text[index]
+		if inComment {
+			if character == '\n' {
+				inComment = false
+			}
+			continue
+		}
 		if inString != 0 {
 			if character == inString && (index == 0 || text[index-1] != '\\') {
 				inString = 0
@@ -404,6 +420,10 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 		}
 		if character == '\'' || character == '"' {
 			inString = character
+			continue
+		}
+		if character == '#' {
+			inComment = true
 			continue
 		}
 		switch character {

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
+
+	"grog/internal/loading"
 )
 
 func (server *server) completionItems(documentURI string, textPosition position) []map[string]any {
@@ -22,7 +25,7 @@ func (server *server) completionItems(documentURI string, textPosition position)
 	} else if field == "outputs" {
 		return outputPathCompletionItems(path, text, textPosition)
 	}
-	return completionItemsFor([]string{"targets", "aliases", "resources", "environments", "default_platforms", "name", "command", "dependencies", "inputs", "exclude_inputs", "outputs", "bin_output", "binary_requires_push", "output_checks", "tags", "fingerprint", "platforms", "environment_variables", "timeout", "concurrency_group", "oci_push", "actual", "up", "down", "ready", "exports", "type", "oci_image"}, 5)
+	return completionItemsFor(allBuildFieldNames("yaml"), 5)
 }
 
 func (server *server) documentText(documentURI string) string {
@@ -41,13 +44,13 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	field := starlarkFieldAt(text, textPosition)
 	callName := enclosingStarlarkCall(text, textPosition)
 	if inStringAt(text, textPosition) {
-		if field == "dependencies" && (callName == "target" || callName == "resource" || callName == "environment") || field == "actual" && callName == "alias" {
+		if (field == "dependencies" || field == "actual") && starlarkDeclarationHasField(callName, field) {
 			return server.labelCompletionItems(path, text, textPosition)
 		}
-		if callName == "target" && (field == "inputs" || field == "exclude_inputs" || field == "bin_output") {
+		if (field == "inputs" || field == "exclude_inputs" || field == "bin_output") && starlarkDeclarationHasField(callName, field) {
 			return pathCompletionItems(path, text, textPosition)
 		}
-		if callName == "target" && field == "outputs" {
+		if field == "outputs" && starlarkDeclarationHasField(callName, field) {
 			return outputPathCompletionItems(path, text, textPosition)
 		}
 		return nil
@@ -55,19 +58,43 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	if callName != "" && !shouldSuggestStarlarkCallParameters(text, textPosition) {
 		return nil
 	}
-	switch callName {
-	case "target":
-		return completionItemsFor([]string{"name", "command", "dependencies", "inputs", "exclude_inputs", "outputs", "bin_output", "binary_requires_push", "output_checks", "tags", "fingerprint", "platforms", "environment_variables", "timeout", "concurrency_group", "oci_push"}, 5)
-	case "alias":
-		return completionItemsFor([]string{"name", "actual"}, 5)
-	case "resource":
-		return completionItemsFor([]string{"name", "up", "down", "ready", "timeout", "exports", "dependencies"}, 5)
-	case "environment":
-		return completionItemsFor([]string{"name", "type", "dependencies", "oci_image"}, 5)
+	if parameters := loading.StarlarkParameters(callName); callName != "" && len(parameters) > 0 {
+		names := make([]string, 0, len(parameters))
+		for _, parameter := range parameters {
+			names = append(names, parameter.Name)
+		}
+		return completionItemsFor(names, 5)
 	}
-	items := completionItemsFor([]string{"target", "alias", "resource", "environment", "load"}, 3)
-	items = append(items, completionItemsFor([]string{"GROG_OS", "GROG_ARCH", "GROG_PLATFORM", "GROG_PLATFORM_TAGS", "GROG_ENV_FILE", "GROG_WORKSPACE_ROOT", "GROG_GIT_HASH", "json", "math", "time"}, 6)...)
+	builtins := append(loading.StarlarkBuiltinNames(), "load")
+	items := completionItemsFor(builtins, 3)
+	items = append(items, completionItemsFor(loading.StarlarkGlobalNames(), 6)...)
 	return items
+}
+
+func allBuildFieldNames(format string) []string {
+	names := loading.BuildFieldNames(format, "")
+	seen := map[string]bool{}
+	for _, name := range names {
+		seen[name] = true
+	}
+	for _, schema := range loading.BuildDeclarationSchemas(format) {
+		for _, name := range loading.BuildFieldNames(format, schema.Kind) {
+			if !seen[name] {
+				names = append(names, name)
+				seen[name] = true
+			}
+		}
+	}
+	return names
+}
+
+func starlarkDeclarationHasField(declarationKind string, field string) bool {
+	for _, parameter := range loading.StarlarkParameters(declarationKind) {
+		if parameter.Name == field {
+			return true
+		}
+	}
+	return false
 }
 
 func (server *server) labelCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
@@ -442,7 +469,7 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 	}
 	for index := len(callNames) - 1; index >= 0; index-- {
 		name := callNames[index]
-		if name == "target" || name == "alias" || name == "resource" || name == "environment" {
+		if slices.Contains(loading.StarlarkBuiltinNames(), name) {
 			return name
 		}
 	}
@@ -540,15 +567,19 @@ func isWordCharacter(character byte) bool {
 }
 
 func signatureHelp(text string, textPosition position) any {
-	labels := map[string]string{
-		"target":      "target(name, command?, dependencies?, inputs?, exclude_inputs?, outputs?, bin_output?, binary_requires_push?, output_checks?, tags?, fingerprint?, platforms?, environment_variables?, timeout?, concurrency_group?, oci_push?)",
-		"alias":       "alias(name, actual)",
-		"resource":    "resource(name, up, down?, ready?, timeout?, exports?, dependencies?)",
-		"environment": "environment(name, type, dependencies?, oci_image?)",
-	}
-	label, found := labels[enclosingStarlarkCall(text, textPosition)]
-	if !found {
+	declarationKind := enclosingStarlarkCall(text, textPosition)
+	parameters := loading.StarlarkParameters(declarationKind)
+	if len(parameters) == 0 {
 		return nil
 	}
+	names := make([]string, 0, len(parameters))
+	for _, parameter := range parameters {
+		name := parameter.Name
+		if !parameter.Required {
+			name += "?"
+		}
+		names = append(names, name)
+	}
+	label := declarationKind + "(" + strings.Join(names, ", ") + ")"
 	return map[string]any{"signatures": []map[string]any{{"label": label}}, "activeSignature": 0, "activeParameter": 0}
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -32,7 +32,7 @@ func (server *server) completionItems(documentURI string, textPosition position)
 		}
 		return pathCompletionItems(path, text, textPosition, alreadyListed)
 	} else if field == "outputs" {
-		return outputPathCompletionItems(path, text, textPosition)
+		return outputPathCompletionItems(path, text, textPosition, yamlListValuesAt(text, textPosition, field))
 	}
 	return completionItemsFor(allBuildFieldNames("yaml"), 5)
 }
@@ -68,7 +68,7 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 			return pathCompletionItems(path, text, textPosition, alreadyListed)
 		}
 		if field == "outputs" && starlarkDeclarationHasField(callName, field) {
-			return outputPathCompletionItems(path, text, textPosition)
+			return outputPathCompletionItems(path, text, textPosition, stringListValuesAt(text, textPosition))
 		}
 		return nil
 	}
@@ -193,7 +193,7 @@ func preferredDependencyLabels(labels []string, prefix string) []string {
 	return append(preferred, deferred...)
 }
 
-func outputPathCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+func outputPathCompletionItems(currentPath string, text string, textPosition position, alreadyListed map[string]bool) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
 	outputTypes := []struct {
 		prefix          string
@@ -201,12 +201,12 @@ func outputPathCompletionItems(currentPath string, text string, textPosition pos
 	}{{prefix: "dir::", directoriesOnly: true}, {prefix: "file::"}}
 	for _, outputType := range outputTypes {
 		if strings.HasPrefix(prefix, outputType.prefix) {
-			items := pathCompletionItemsWithPrefix(currentPath, strings.TrimPrefix(prefix, outputType.prefix), outputType.prefix, outputType.directoriesOnly, stringListValuesAt(text, textPosition))
+			items := pathCompletionItemsWithPrefix(currentPath, strings.TrimPrefix(prefix, outputType.prefix), outputType.prefix, outputType.directoriesOnly, alreadyListed)
 			addCompletionTextEdits(items, textPosition, prefix)
 			return items
 		}
 	}
-	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, stringListValuesAt(text, textPosition))
+	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, alreadyListed)
 	addCompletionTextEdits(items, textPosition, prefix)
 	return items
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -290,24 +290,26 @@ func pathCompletionPrefix(text string, textPosition position) string {
 		return ""
 	}
 	prefix := line[:characterOffset]
-	stringDelimiter := byte(0)
+	stringDelimiter := ""
 	quoteStart := -1
 	for index := 0; index < len(prefix); index++ {
 		character := prefix[index]
-		if stringDelimiter != 0 {
-			if character == stringDelimiter && !starlarkCharacterEscaped(prefix, index) {
-				stringDelimiter = 0
+		if stringDelimiter != "" {
+			if strings.HasPrefix(prefix[index:], stringDelimiter) && !starlarkCharacterEscaped(prefix, index) {
+				index += len(stringDelimiter) - 1
+				stringDelimiter = ""
 				quoteStart = -1
 			}
 			continue
 		}
 		if character == '\'' || character == '"' {
-			stringDelimiter = character
+			stringDelimiter = starlarkStringDelimiter(prefix, index)
 			quoteStart = index
+			index += len(stringDelimiter) - 1
 		}
 	}
 	if quoteStart >= 0 {
-		return prefix[quoteStart+1:]
+		return prefix[quoteStart+len(stringDelimiter):]
 	}
 	start := strings.LastIndexAny(prefix, " \t,[](){}=") + 1
 	return prefix[start:]

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -26,7 +26,7 @@ func (server *server) completionItems(documentURI string, textPosition position)
 		}
 		return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
-		return pathCompletionItems(path, text, textPosition)
+		return pathCompletionItems(path, text, textPosition, yamlBuildFieldIsCollection(field))
 	} else if field == "outputs" {
 		return outputPathCompletionItems(path, text, textPosition)
 	}
@@ -57,7 +57,7 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 			return server.labelCompletionItems(path, text, textPosition, alreadyListed)
 		}
 		if (field == "inputs" || field == "exclude_inputs" || field == "bin_output") && starlarkDeclarationHasField(callName, field) {
-			return pathCompletionItems(path, text, textPosition)
+			return pathCompletionItems(path, text, textPosition, loading.BuildFieldIsCollection("starlark", callName, field))
 		}
 		if field == "outputs" && starlarkDeclarationHasField(callName, field) {
 			return outputPathCompletionItems(path, text, textPosition)
@@ -187,9 +187,13 @@ func preferredDependencyLabels(labels []string, prefix string) []string {
 
 func outputPathCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
-	for _, outputTypePrefix := range []string{"dir::"} {
-		if strings.HasPrefix(prefix, outputTypePrefix) {
-			items := pathCompletionItemsWithPrefix(currentPath, strings.TrimPrefix(prefix, outputTypePrefix), outputTypePrefix, true, stringListValuesAt(text, textPosition))
+	outputTypes := []struct {
+		prefix          string
+		directoriesOnly bool
+	}{{prefix: "dir::", directoriesOnly: true}, {prefix: "file::"}}
+	for _, outputType := range outputTypes {
+		if strings.HasPrefix(prefix, outputType.prefix) {
+			items := pathCompletionItemsWithPrefix(currentPath, strings.TrimPrefix(prefix, outputType.prefix), outputType.prefix, outputType.directoriesOnly, stringListValuesAt(text, textPosition))
 			addCompletionTextEdits(items, textPosition, prefix)
 			return items
 		}
@@ -199,9 +203,13 @@ func outputPathCompletionItems(currentPath string, text string, textPosition pos
 	return items
 }
 
-func pathCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+func pathCompletionItems(currentPath string, text string, textPosition position, excludeAlreadyListed bool) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
-	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, stringListValuesAt(text, textPosition))
+	alreadyListed := map[string]bool{}
+	if excludeAlreadyListed {
+		alreadyListed = stringListValuesAt(text, textPosition)
+	}
+	items := pathCompletionItemsWithPrefix(currentPath, prefix, "", false, alreadyListed)
 	addCompletionTextEdits(items, textPosition, prefix)
 	return items
 }

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -18,8 +18,9 @@ func (server *server) completionItems(documentURI string, textPosition position)
 	if isStarlarkFile(name) {
 		return server.starlarkCompletionItems(documentURI, text, textPosition)
 	}
-	if field := yamlFieldAt(text, textPosition); field == "dependencies" || field == "actual" {
-		return server.labelCompletionItems(path, text, textPosition)
+	field := yamlFieldAt(text, textPosition)
+	if field == "dependencies" || field == "actual" {
+		return server.labelCompletionItems(path, text, textPosition, yamlBuildFieldIsCollection(field))
 	} else if field == "inputs" || field == "exclude_inputs" || field == "bin_output" {
 		return pathCompletionItems(path, text, textPosition)
 	} else if field == "outputs" {
@@ -45,7 +46,7 @@ func (server *server) starlarkCompletionItems(documentURI string, text string, t
 	callName := enclosingStarlarkCall(text, textPosition)
 	if inStringAt(text, textPosition) {
 		if (field == "dependencies" || field == "actual") && starlarkDeclarationHasField(callName, field) {
-			return server.labelCompletionItems(path, text, textPosition)
+			return server.labelCompletionItems(path, text, textPosition, loading.BuildFieldIsCollection("starlark", callName, field))
 		}
 		if (field == "inputs" || field == "exclude_inputs" || field == "bin_output") && starlarkDeclarationHasField(callName, field) {
 			return pathCompletionItems(path, text, textPosition)
@@ -97,11 +98,23 @@ func starlarkDeclarationHasField(declarationKind string, field string) bool {
 	return false
 }
 
-func (server *server) labelCompletionItems(currentPath string, text string, textPosition position) []map[string]any {
+func yamlBuildFieldIsCollection(field string) bool {
+	for _, schema := range loading.BuildDeclarationSchemas("yaml") {
+		if loading.BuildFieldIsCollection("yaml", schema.Kind, field) {
+			return true
+		}
+	}
+	return false
+}
+
+func (server *server) labelCompletionItems(currentPath string, text string, textPosition position, excludeAlreadyListed bool) []map[string]any {
 	prefix := pathCompletionPrefix(text, textPosition)
 	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
 	labels := server.collectWorkspaceLabels(workspaceRoot, filepath.Dir(currentPath))
-	alreadyListed := stringListValuesAt(text, textPosition)
+	alreadyListed := map[string]bool{}
+	if excludeAlreadyListed {
+		alreadyListed = stringListValuesAt(text, textPosition)
+	}
 	items := []map[string]any{}
 	for _, label := range preferredDependencyLabels(labels, prefix) {
 		if prefix != "" && !strings.HasPrefix(label, prefix) || alreadyListed[label] {
@@ -368,7 +381,7 @@ func inStringAt(text string, textPosition position) bool {
 			continue
 		}
 		if inString != 0 {
-			if character == inString && (index == 0 || text[index-1] != '\\') {
+			if character == inString && !starlarkCharacterEscaped(text, index) {
 				inString = 0
 			}
 			continue
@@ -380,6 +393,14 @@ func inStringAt(text string, textPosition position) bool {
 		}
 	}
 	return inString != 0
+}
+
+func starlarkCharacterEscaped(text string, index int) bool {
+	backslashes := 0
+	for index > backslashes && text[index-backslashes-1] == '\\' {
+		backslashes++
+	}
+	return backslashes%2 == 1
 }
 
 func yamlFieldAt(text string, textPosition position) string {
@@ -440,7 +461,7 @@ func enclosingStarlarkCall(text string, textPosition position) string {
 			continue
 		}
 		if inString != 0 {
-			if character == inString && (index == 0 || text[index-1] != '\\') {
+			if character == inString && !starlarkCharacterEscaped(text, index) {
 				inString = 0
 			}
 			continue

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -473,6 +473,38 @@ func yamlFieldAt(text string, textPosition position) string {
 	}
 	currentLine := lines[textPosition.Line]
 	currentIndent := len(currentLine) - len(strings.TrimLeft(currentLine, " \t"))
+	characterOffset := characterByteOffset(currentLine, textPosition.Character)
+	if characterOffset < 0 {
+		return ""
+	}
+	activeField := ""
+	stringDelimiter := byte(0)
+	for index := 0; index < characterOffset; index++ {
+		character := currentLine[index]
+		if stringDelimiter != 0 {
+			if character == stringDelimiter && !starlarkCharacterEscaped(currentLine, index) {
+				stringDelimiter = 0
+			}
+			continue
+		}
+		if character == '\'' || character == '"' {
+			stringDelimiter = character
+			continue
+		}
+		if character != ':' {
+			continue
+		}
+		start := index
+		for start > 0 && isWordCharacter(currentLine[start-1]) {
+			start--
+		}
+		if yamlFieldName(currentLine[start:index]) {
+			activeField = currentLine[start:index]
+		}
+	}
+	if activeField != "" {
+		return activeField
+	}
 	for lineNumber := textPosition.Line; lineNumber >= 0 && lineNumber < len(lines); lineNumber-- {
 		rawLine := lines[lineNumber]
 		indent := len(rawLine) - len(strings.TrimLeft(rawLine, " \t"))

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -290,11 +290,27 @@ func pathCompletionPrefix(text string, textPosition position) string {
 		return ""
 	}
 	prefix := line[:characterOffset]
-	quote := strings.LastIndexAny(prefix, "\"'")
-	if quote < 0 {
-		return ""
+	stringDelimiter := byte(0)
+	quoteStart := -1
+	for index := 0; index < len(prefix); index++ {
+		character := prefix[index]
+		if stringDelimiter != 0 {
+			if character == stringDelimiter && !starlarkCharacterEscaped(prefix, index) {
+				stringDelimiter = 0
+				quoteStart = -1
+			}
+			continue
+		}
+		if character == '\'' || character == '"' {
+			stringDelimiter = character
+			quoteStart = index
+		}
 	}
-	return prefix[quote+1:]
+	if quoteStart >= 0 {
+		return prefix[quoteStart+1:]
+	}
+	start := strings.LastIndexAny(prefix, " \t,[](){}=") + 1
+	return prefix[start:]
 }
 
 func stringListValuesAt(text string, textPosition position) map[string]bool {
@@ -399,7 +415,33 @@ func starlarkFieldAt(text string, textPosition position) string {
 		return ""
 	}
 	prefix := text[:offset]
-	equals := strings.LastIndex(prefix, "=")
+	equals := -1
+	stringDelimiter := ""
+	inComment := false
+	for index := 0; index < len(prefix); index++ {
+		character := prefix[index]
+		if inComment {
+			if character == '\n' {
+				inComment = false
+			}
+			continue
+		}
+		if stringDelimiter != "" {
+			if strings.HasPrefix(prefix[index:], stringDelimiter) && !starlarkCharacterEscaped(prefix, index) {
+				index += len(stringDelimiter) - 1
+				stringDelimiter = ""
+			}
+			continue
+		}
+		if character == '\'' || character == '"' {
+			stringDelimiter = starlarkStringDelimiter(prefix, index)
+			index += len(stringDelimiter) - 1
+		} else if character == '#' {
+			inComment = true
+		} else if character == '=' {
+			equals = index
+		}
+	}
 	if equals < 0 {
 		return ""
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -135,7 +135,7 @@ func addCompletionTextEdits(items []map[string]any, textPosition position, prefi
 }
 
 func completionTextEdit(textPosition position, prefix string, newText string) map[string]any {
-	start := position{Line: textPosition.Line, Character: max(textPosition.Character-len(prefix), 0)}
+	start := position{Line: textPosition.Line, Character: max(textPosition.Character-utf16Length(prefix), 0)}
 	return map[string]any{"range": rangeValue{Start: start, End: textPosition}, "newText": newText}
 }
 
@@ -192,10 +192,11 @@ func pathCompletionPrefix(text string, textPosition position) string {
 		return ""
 	}
 	line := lines[textPosition.Line]
-	if textPosition.Character < 0 || textPosition.Character > len(line) {
+	characterOffset := characterByteOffset(line, textPosition.Character)
+	if characterOffset < 0 {
 		return ""
 	}
-	prefix := line[:textPosition.Character]
+	prefix := line[:characterOffset]
 	quote := strings.LastIndexAny(prefix, "\"'")
 	if quote < 0 {
 		return ""
@@ -349,14 +350,25 @@ func yamlFieldAt(text string, textPosition position) string {
 	lines := strings.Split(text, "\n")
 	for lineNumber := textPosition.Line; lineNumber >= 0 && lineNumber < len(lines); lineNumber-- {
 		line := strings.TrimSpace(lines[lineNumber])
-		if strings.HasSuffix(line, ":") {
-			return strings.TrimSuffix(line, ":")
-		}
-		if field, _, found := strings.Cut(line, ":"); found && lineNumber == textPosition.Line {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "-"))
+		if field, _, found := strings.Cut(line, ":"); found && yamlFieldName(field) {
 			return strings.TrimSpace(field)
 		}
 	}
 	return ""
+}
+
+func yamlFieldName(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	for index := range len(value) {
+		if !isWordCharacter(value[index]) {
+			return false
+		}
+	}
+	return true
 }
 
 func shouldSuggestStarlarkCallParameters(text string, textPosition position) bool {
@@ -423,13 +435,16 @@ func positionForOffset(text string, targetOffset int) position {
 	if targetOffset < 0 {
 		return position{}
 	}
-	for offset := 0; offset < len(text) && offset < targetOffset; offset++ {
-		if text[offset] == '\n' {
+	for offset, currentRune := range text {
+		if offset >= targetOffset {
+			break
+		}
+		if currentRune == '\n' {
 			line++
 			character = 0
 			continue
 		}
-		character++
+		character += utf16RuneLength(currentRune)
 	}
 	return position{Line: line, Character: character}
 }
@@ -440,21 +455,40 @@ func byteOffset(text string, textPosition position) int {
 	}
 	line := 0
 	character := 0
-	for offset := 0; offset < len(text); offset++ {
+	for offset, currentRune := range text {
 		if line == textPosition.Line && character == textPosition.Character {
 			return offset
 		}
-		if text[offset] == '\n' {
+		if currentRune == '\n' {
 			line++
 			character = 0
 			continue
 		}
-		character++
+		character += utf16RuneLength(currentRune)
 	}
 	if line == textPosition.Line && character == textPosition.Character {
 		return len(text)
 	}
 	return -1
+}
+
+func characterByteOffset(line string, character int) int {
+	return byteOffset(line, position{Character: character})
+}
+
+func utf16Length(value string) int {
+	length := 0
+	for _, currentRune := range value {
+		length += utf16RuneLength(currentRune)
+	}
+	return length
+}
+
+func utf16RuneLength(currentRune rune) int {
+	if currentRune > 0xffff {
+		return 2
+	}
+	return 1
 }
 
 func wordAt(text string, textPosition position) string {
@@ -463,14 +497,15 @@ func wordAt(text string, textPosition position) string {
 		return ""
 	}
 	line := lines[textPosition.Line]
-	if textPosition.Character < 0 || textPosition.Character > len(line) {
+	characterOffset := characterByteOffset(line, textPosition.Character)
+	if characterOffset < 0 {
 		return ""
 	}
-	start := textPosition.Character
+	start := characterOffset
 	for start > 0 && isWordCharacter(line[start-1]) {
 		start--
 	}
-	end := textPosition.Character
+	end := characterOffset
 	for end < len(line) && isWordCharacter(line[end]) {
 		end++
 	}

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -595,7 +595,7 @@ func shouldSuggestStarlarkCallParameters(text string, textPosition position) boo
 	for index >= 0 && unicodeSpace(prefix[index]) {
 		index--
 	}
-	if index >= 0 && prefix[index] == ',' {
+	if index >= 0 && (prefix[index] == ',' || prefix[index] == '(') {
 		return true
 	}
 	return len(prefix) > 0 && isWordCharacter(prefix[len(prefix)-1])

--- a/internal/lsp/completion.go
+++ b/internal/lsp/completion.go
@@ -468,11 +468,23 @@ func starlarkCharacterEscaped(text string, index int) bool {
 
 func yamlFieldAt(text string, textPosition position) string {
 	lines := strings.Split(text, "\n")
+	if textPosition.Line < 0 || textPosition.Line >= len(lines) {
+		return ""
+	}
+	currentLine := lines[textPosition.Line]
+	currentIndent := len(currentLine) - len(strings.TrimLeft(currentLine, " \t"))
 	for lineNumber := textPosition.Line; lineNumber >= 0 && lineNumber < len(lines); lineNumber-- {
-		line := strings.TrimSpace(lines[lineNumber])
+		rawLine := lines[lineNumber]
+		indent := len(rawLine) - len(strings.TrimLeft(rawLine, " \t"))
+		line := strings.TrimSpace(rawLine)
 		line = strings.TrimSpace(strings.TrimPrefix(line, "-"))
 		if field, _, found := strings.Cut(line, ":"); found && yamlFieldName(field) {
-			return strings.TrimSpace(field)
+			if lineNumber == textPosition.Line || indent < currentIndent {
+				return strings.TrimSpace(field)
+			}
+		}
+		if lineNumber < textPosition.Line && strings.HasPrefix(strings.TrimSpace(rawLine), "-") && indent <= currentIndent {
+			return ""
 		}
 	}
 	return ""

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -123,7 +123,10 @@ func evaluateStarlark(path string, text string, readText func(path string) (stri
 		}
 		declarations = append(declarations, namedDeclaration{kind: declaration.Kind, name: declaration.Name, path: declaration.Path, rangeValue: declarationRange})
 	}
-	_, operationError := loading.EvaluateStarlark(path, []byte(text), options)
+	packageDTO, operationError := loading.EvaluateStarlark(path, []byte(text), options)
+	if operationError == nil {
+		operationError = loading.ValidatePackageTimeouts(packageDTO)
+	}
 	return declarations, operationError
 }
 
@@ -324,7 +327,11 @@ func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 }
 
 func yamlDiagnostics(text string) []diagnostic {
-	if _, operationError := loading.DecodeYAML([]byte(text)); operationError != nil {
+	packageDTO, operationError := loading.DecodeYAML([]byte(text))
+	if operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	if operationError := loading.ValidatePackageTimeouts(packageDTO); operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	var root yaml.Node

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -12,21 +12,39 @@ import (
 
 	"grog/internal/loading"
 
+	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
 )
 
 func (server *server) publishDiagnostics(documentURI string) error {
 	text := server.documentText(documentURI)
-	diagnostics := diagnosticsFor(documentURI, text)
+	diagnostics := server.diagnosticsFor(documentURI, text)
 	return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": documentURI, "diagnostics": diagnostics})
 }
 
 func diagnosticsFor(documentURI string, text string) []diagnostic {
+	return diagnosticsForReader(documentURI, text, func(path string) (string, error) {
+		content, operationError := os.ReadFile(path)
+		return string(content), operationError
+	})
+}
+
+func (server *server) diagnosticsFor(documentURI string, text string) []diagnostic {
+	return diagnosticsForReader(documentURI, text, func(path string) (string, error) {
+		if content, isOpen := server.documents[pathToURI(path)]; isOpen {
+			return content, nil
+		}
+		content, operationError := os.ReadFile(path)
+		return string(content), operationError
+	})
+}
+
+func diagnosticsForReader(documentURI string, text string, readText func(path string) (string, error)) []diagnostic {
 	path := uriPath(documentURI)
 	name := filepath.Base(path)
 	if isStarlarkFile(name) {
-		return starlarkDiagnostics(path, text)
+		return starlarkDiagnostics(path, text, readText)
 	}
 	if (loading.YamlLoader{}).Matches(name) {
 		return yamlDiagnostics(text)
@@ -34,20 +52,60 @@ func diagnosticsFor(documentURI string, text string) []diagnostic {
 	return []diagnostic{}
 }
 
-func starlarkDiagnostics(path string, text string) []diagnostic {
+func starlarkDiagnostics(path string, text string, readText func(path string) (string, error)) []diagnostic {
 	if _, operationError := syntax.Parse(path, text, syntax.RetainComments); operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
-	declarations, operationError := evaluateStarlark(path, text, func(path string) (string, error) {
-		content, readError := os.ReadFile(path)
-		return string(content), readError
-	})
+	declarations, operationError := evaluateStarlark(path, text, readText)
 	diagnostics := duplicateNameDiagnostics(declarations)
 	diagnostics = append(diagnostics, duplicateKeywordArgumentDiagnostics(text)...)
 	if operationError != nil && !isRepeatedKeywordArgumentError(operationError) {
-		diagnostics = append([]diagnostic{diagnosticFromError(text, operationError)}, diagnostics...)
+		diagnostics = append([]diagnostic{starlarkDiagnosticFromError(path, text, operationError)}, diagnostics...)
 	}
 	return diagnostics
+}
+
+func starlarkDiagnosticFromError(path string, text string, operationError error) diagnostic {
+	errorPath := starlarkErrorPath(operationError)
+	if errorPath == "" || filepath.Clean(errorPath) == filepath.Clean(path) {
+		return diagnosticFromError(text, operationError)
+	}
+	file, parseError := syntax.Parse(path, text, 0)
+	if parseError != nil {
+		return diagnosticFromError(text, operationError)
+	}
+	var fallback *syntax.LoadStmt
+	for _, statement := range file.Stmts {
+		loadStatement, isLoad := statement.(*syntax.LoadStmt)
+		if !isLoad {
+			continue
+		}
+		if fallback == nil {
+			fallback = loadStatement
+		}
+		modulePath := loading.ResolveStarlarkModulePath(findWorkspaceRoot(filepath.Dir(path)), path, loadStatement.ModuleName())
+		if filepath.Clean(modulePath) == filepath.Clean(errorPath) || strings.Contains(operationError.Error(), loadStatement.ModuleName()) {
+			start, end := loadStatement.Module.Span()
+			return diagnostic{Range: rangeFromSyntaxPositions(text, start, end), Severity: 1, Source: "grog", Message: operationError.Error()}
+		}
+	}
+	if fallback != nil {
+		start, end := fallback.Module.Span()
+		return diagnostic{Range: rangeFromSyntaxPositions(text, start, end), Severity: 1, Source: "grog", Message: operationError.Error()}
+	}
+	return diagnosticFromError(text, operationError)
+}
+
+func starlarkErrorPath(operationError error) string {
+	var syntaxError syntax.Error
+	if errors.As(operationError, &syntaxError) {
+		return syntaxError.Pos.Filename()
+	}
+	var evaluationError *starlark.EvalError
+	if errors.As(operationError, &evaluationError) && len(evaluationError.CallStack) > 0 {
+		return evaluationError.CallStack[len(evaluationError.CallStack)-1].Pos.Filename()
+	}
+	return ""
 }
 
 func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -6,19 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 
 	"grog/internal/loading"
 
-	"github.com/pelletier/go-toml/v2"
-	"github.com/subosito/gotenv"
-	starlarkjson "go.starlark.net/lib/json"
-	"go.starlark.net/lib/math"
-	starlarktime "go.starlark.net/lib/time"
-	"go.starlark.net/starlark"
-	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
 )
@@ -35,7 +28,7 @@ func diagnosticsFor(documentURI string, text string) []diagnostic {
 	if isStarlarkFile(name) {
 		return starlarkDiagnostics(path, text)
 	}
-	if name == "BUILD.yaml" || name == "BUILD.yml" {
+	if (loading.YamlLoader{}).Matches(name) {
 		return yamlDiagnostics(text)
 	}
 	return []diagnostic{}
@@ -57,272 +50,27 @@ func starlarkDiagnostics(path string, text string) []diagnostic {
 	return diagnostics
 }
 
-type starlarkEvaluationContext struct {
-	declarations []namedDeclaration
-	readText     func(path string) (string, error)
-}
-
-const starlarkEvaluationContextKey = "grog-lsp-evaluation"
-
 func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {
-	evaluationContext := &starlarkEvaluationContext{readText: readText}
-	thread := &starlark.Thread{Name: path, Load: loadModule(evaluationContext)}
-	thread.SetLocal(starlarkEvaluationContextKey, evaluationContext)
-	_, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, path, text, starlarkPredeclared(path))
-	return evaluationContext.declarations, operationError
+	declarations := []namedDeclaration{}
+	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	options.ReadFile = func(path string) ([]byte, error) {
+		content, operationError := readText(path)
+		return []byte(content), operationError
+	}
+	options.DeclarationCallback = func(declaration loading.StarlarkDeclaration) {
+		declarationRange := rangeValue{Start: position{Line: max(declaration.Line-1, 0)}, End: position{Line: max(declaration.Line-1, 0), Character: 1}}
+		if sourceText, operationError := readText(declaration.Path); operationError == nil {
+			start := positionFromOneBased(sourceText, declaration.Line, declaration.Column)
+			declarationRange = rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + 1}}
+		}
+		declarations = append(declarations, namedDeclaration{kind: declaration.Kind, name: declaration.Name, path: declaration.Path, rangeValue: declarationRange})
+	}
+	_, operationError := loading.EvaluateStarlark(path, []byte(text), options)
+	return declarations, operationError
 }
 
 func isRepeatedKeywordArgumentError(operationError error) bool {
 	return strings.Contains(operationError.Error(), "keyword argument") && strings.Contains(operationError.Error(), "is repeated")
-}
-
-func targetBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
-	var name string
-	var command string
-	var dependencies, inputs, excludeInputs, outputs, outputChecks, tags, platforms *starlark.List
-	var fingerprint, environmentVariables, ociPush *starlark.Dict
-	var binOutput, timeout, concurrencyGroup string
-	var binaryRequiresPush bool
-	if operationError := starlark.UnpackArgs("target", arguments, keywordArguments, "name", &name, "command?", &command, "dependencies?", &dependencies, "inputs?", &inputs, "exclude_inputs?", &excludeInputs, "outputs?", &outputs, "bin_output?", &binOutput, "binary_requires_push?", &binaryRequiresPush, "output_checks?", &outputChecks, "tags?", &tags, "fingerprint?", &fingerprint, "platforms?", &platforms, "environment_variables?", &environmentVariables, "timeout?", &timeout, "concurrency_group?", &concurrencyGroup, "oci_push?", &ociPush); operationError != nil {
-		return nil, operationError
-	}
-	listFields := []struct {
-		name   string
-		values *starlark.List
-	}{{"dependencies", dependencies}, {"inputs", inputs}, {"exclude_inputs", excludeInputs}, {"outputs", outputs}, {"tags", tags}, {"platforms", platforms}}
-	for _, field := range listFields {
-		if operationError := validateStringList(field.name, field.values); operationError != nil {
-			return nil, operationError
-		}
-	}
-	dictionaryFields := []struct {
-		name   string
-		values *starlark.Dict
-	}{{"fingerprint", fingerprint}, {"environment_variables", environmentVariables}}
-	for _, field := range dictionaryFields {
-		if operationError := validateStringDict(field.name, field.values); operationError != nil {
-			return nil, operationError
-		}
-	}
-	if operationError := validateOutputChecks(outputChecks); operationError != nil {
-		return nil, operationError
-	}
-	if operationError := validateOciPush(ociPush); operationError != nil {
-		return nil, operationError
-	}
-	recordDeclaration(thread, "target", name)
-	return starlark.None, nil
-}
-
-func aliasBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
-	var name string
-	var actual string
-	if operationError := starlark.UnpackArgs("alias", arguments, keywordArguments, "name", &name, "actual", &actual); operationError != nil {
-		return nil, operationError
-	}
-	recordDeclaration(thread, "alias", name)
-	return starlark.None, nil
-}
-
-func environmentBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
-	var name string
-	var environmentType string
-	var dependencies *starlark.List
-	var ociImage string
-	if operationError := starlark.UnpackArgs("environment", arguments, keywordArguments, "name", &name, "type", &environmentType, "dependencies?", &dependencies, "oci_image?", &ociImage); operationError != nil {
-		return nil, operationError
-	}
-	if operationError := validateStringList("dependencies", dependencies); operationError != nil {
-		return nil, operationError
-	}
-	recordDeclaration(thread, "environment", name)
-	return starlark.None, nil
-}
-
-func resourceBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
-	var name, up, down, ready, timeout string
-	var exports *starlark.Dict
-	var dependencies *starlark.List
-	if operationError := starlark.UnpackArgs("resource", arguments, keywordArguments, "name", &name, "up", &up, "down?", &down, "ready?", &ready, "timeout?", &timeout, "exports?", &exports, "dependencies?", &dependencies); operationError != nil {
-		return nil, operationError
-	}
-	if operationError := validateStringDict("exports", exports); operationError != nil {
-		return nil, operationError
-	}
-	if operationError := validateStringList("dependencies", dependencies); operationError != nil {
-		return nil, operationError
-	}
-	recordDeclaration(thread, "resource", name)
-	return starlark.None, nil
-}
-
-func validateStringList(field string, list *starlark.List) error {
-	if list == nil {
-		return nil
-	}
-	iterator := list.Iterate()
-	defer iterator.Done()
-	var value starlark.Value
-	for iterator.Next(&value) {
-		if _, isString := value.(starlark.String); !isString {
-			return fmt.Errorf("%s: expected string, got %s", field, value.Type()) //nolint:nilaway // Iterate assigns value before returning true.
-		}
-	}
-	return nil
-}
-
-func validateStringDict(field string, dictionary *starlark.Dict) error {
-	if dictionary == nil {
-		return nil
-	}
-	for _, item := range dictionary.Items() {
-		if _, isString := item[0].(starlark.String); !isString {
-			return fmt.Errorf("%s key must be string, got %s", field, item[0].Type())
-		}
-		if _, isString := item[1].(starlark.String); !isString {
-			return fmt.Errorf("%s value must be string, got %s", field, item[1].Type())
-		}
-	}
-	return nil
-}
-
-func validateOciPush(dictionary *starlark.Dict) error {
-	if dictionary == nil {
-		return nil
-	}
-	for _, item := range dictionary.Items() {
-		key, isString := item[0].(starlark.String)
-		if !isString {
-			return fmt.Errorf("oci_push key must be string, got %s", item[0].Type())
-		}
-		switch value := item[1].(type) {
-		case starlark.String:
-		case *starlark.List:
-			if operationError := validateStringList(fmt.Sprintf("oci_push[%q]", string(key)), value); operationError != nil {
-				return operationError
-			}
-		default:
-			return fmt.Errorf("oci_push[%q] must be string or list of strings, got %s", string(key), value.Type())
-		}
-	}
-	return nil
-}
-
-func validateOutputChecks(list *starlark.List) error {
-	if list == nil {
-		return nil
-	}
-	iterator := list.Iterate()
-	defer iterator.Done()
-	var value starlark.Value
-	for iterator.Next(&value) {
-		var command starlark.Value
-		var found bool
-		var operationError error
-		switch outputCheck := value.(type) {
-		case *starlark.Dict:
-			command, found, operationError = outputCheck.Get(starlark.String("command"))
-		case *starlarkstruct.Struct:
-			command, operationError = outputCheck.Attr("command")
-			found = operationError == nil
-		default:
-			return fmt.Errorf("output_check must be dict or struct, got %s", value.Type()) //nolint:nilaway // Iterate assigns value before returning true.
-		}
-		if operationError != nil {
-			return operationError
-		}
-		if !found {
-			return fmt.Errorf("output_check missing 'command' field")
-		}
-		if _, isString := command.(starlark.String); !isString {
-			return fmt.Errorf("output_check 'command' must be string")
-		}
-	}
-	return nil
-}
-
-func recordDeclaration(thread *starlark.Thread, kind string, name string) {
-	evaluationContext, exists := thread.Local(starlarkEvaluationContextKey).(*starlarkEvaluationContext)
-	if !exists {
-		return
-	}
-	callPosition := thread.CallFrame(1).Pos
-	declarationRange := rangeValue{Start: position{Line: max(int(callPosition.Line)-1, 0)}, End: position{Line: max(int(callPosition.Line)-1, 0), Character: 1}}
-	if sourceText, operationError := evaluationContext.readText(callPosition.Filename()); operationError == nil {
-		start := positionFromSyntaxPosition(sourceText, callPosition)
-		declarationRange = rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + 1}}
-	}
-	evaluationContext.declarations = append(evaluationContext.declarations, namedDeclaration{kind: kind, name: name, path: callPosition.Filename(), rangeValue: declarationRange})
-}
-
-func starlarkPredeclared(currentPath string) starlark.StringDict {
-	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
-	platformTags := starlark.NewList(nil)
-	platformTags.Freeze()
-	predeclared := starlark.StringDict{
-		"target":              starlark.NewBuiltin("target", targetBuiltin),
-		"alias":               starlark.NewBuiltin("alias", aliasBuiltin),
-		"resource":            starlark.NewBuiltin("resource", resourceBuiltin),
-		"environment":         starlark.NewBuiltin("environment", environmentBuiltin),
-		"json":                starlarkjson.Module,
-		"math":                math.Module,
-		"time":                starlarktime.Module,
-		"GROG_OS":             starlark.String(runtime.GOOS),
-		"GROG_ARCH":           starlark.String(runtime.GOARCH),
-		"GROG_PLATFORM":       starlark.String(runtime.GOOS + "/" + runtime.GOARCH),
-		"GROG_PLATFORM_TAGS":  platformTags,
-		"GROG_ENV_FILE":       starlark.String(""),
-		"GROG_WORKSPACE_ROOT": starlark.String(workspaceRoot),
-		"GROG_GIT_HASH":       starlark.String(""),
-	}
-	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
-	if operationError != nil {
-		return predeclared
-	}
-	var configuration struct {
-		EnvironmentVariables     map[string]string `toml:"environment_variables"`
-		EnvironmentVariablesFile string            `toml:"environment_variables_file"`
-		OperatingSystem          string            `toml:"os"`
-		Architecture             string            `toml:"arch"`
-		PlatformTags             []string          `toml:"platform_tag"`
-	}
-	if toml.Unmarshal(configurationBytes, &configuration) != nil {
-		return predeclared
-	}
-	operatingSystem := runtime.GOOS
-	if configuration.OperatingSystem != "" {
-		operatingSystem = configuration.OperatingSystem
-	}
-	architecture := runtime.GOARCH
-	if configuration.Architecture != "" {
-		architecture = configuration.Architecture
-	}
-	predeclared["GROG_OS"] = starlark.String(operatingSystem)
-	predeclared["GROG_ARCH"] = starlark.String(architecture)
-	predeclared["GROG_PLATFORM"] = starlark.String(operatingSystem + "/" + architecture)
-	values := make([]starlark.Value, 0, len(configuration.PlatformTags))
-	for _, tag := range configuration.PlatformTags {
-		values = append(values, starlark.String(tag))
-	}
-	platformTags = starlark.NewList(values)
-	platformTags.Freeze()
-	predeclared["GROG_PLATFORM_TAGS"] = platformTags
-	if configuration.EnvironmentVariablesFile != "" {
-		environmentFilePath := configuration.EnvironmentVariablesFile
-		if !filepath.IsAbs(environmentFilePath) {
-			environmentFilePath = filepath.Join(workspaceRoot, environmentFilePath)
-		}
-		predeclared["GROG_ENV_FILE"] = starlark.String(environmentFilePath)
-		if environmentVariables, readError := gotenv.Read(environmentFilePath); readError == nil {
-			for name, value := range environmentVariables {
-				predeclared[name] = starlark.String(value)
-			}
-		}
-	}
-	for name, value := range configuration.EnvironmentVariables {
-		predeclared[name] = starlark.String(value)
-	}
-	return predeclared
 }
 
 type namedDeclaration struct {
@@ -369,7 +117,11 @@ func starlarkNamedDeclarations(text string) []namedDeclaration {
 		}
 		return declarations
 	}
-	pattern := regexp.MustCompile(`(?s)\b(target|alias|resource|environment)\s*\([^)]*?\bname\s*=\s*["']([^"']+)["']`)
+	declarationKinds := loading.StarlarkBuiltinNames()
+	for index, declarationKind := range declarationKinds {
+		declarationKinds[index] = regexp.QuoteMeta(declarationKind)
+	}
+	pattern := regexp.MustCompile(`(?s)\b(` + strings.Join(declarationKinds, "|") + `)\s*\([^)]*?\bname\s*=\s*["']([^"']+)["']`)
 	declarations := []namedDeclaration{}
 	matches := pattern.FindAllStringSubmatchIndex(text, -1)
 	for _, match := range matches {
@@ -383,7 +135,7 @@ func starlarkNamedDeclarations(text string) []namedDeclaration {
 }
 
 func isDeclarationKind(name string) bool {
-	return name == "target" || name == "alias" || name == "resource" || name == "environment"
+	return slices.Contains(loading.StarlarkBuiltinNames(), name)
 }
 
 func duplicateKeywordArgumentDiagnostics(text string) []diagnostic {
@@ -441,28 +193,37 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 	}
 	diagnostics := []diagnostic{}
 	declarations := []namedDeclaration{}
+	declarationKinds := yamlDeclarationKinds()
 	for index := 0; index+1 < len(root.Content); index += 2 {
 		key := root.Content[index]
 		value := root.Content[index+1]
-		switch key.Value {
-		case "targets", "aliases", "resources", "environments":
-			kind := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}[key.Value]
-			if value.Kind != yaml.SequenceNode {
-				diagnostics = append(diagnostics, yamlNodeDiagnostic(text, value, fmt.Sprintf("%s must be a list", key.Value)))
+		kind, isDeclarationList := declarationKinds[key.Value]
+		if !isDeclarationList {
+			continue
+		}
+		if value.Kind != yaml.SequenceNode {
+			diagnostics = append(diagnostics, yamlNodeDiagnostic(text, value, fmt.Sprintf("%s must be a list", key.Value)))
+			continue
+		}
+		for _, item := range value.Content {
+			nameNode := yamlMappingValue(item, "name")
+			if nameNode == nil || nameNode.Value == "" {
+				diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires name", kind)))
 				continue
 			}
-			for _, item := range value.Content {
-				nameNode := yamlMappingValue(item, "name")
-				if nameNode == nil || nameNode.Value == "" {
-					diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires name", kind)))
-					continue
-				}
-				declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
-			}
+			declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
 		}
 	}
 	diagnostics = append(diagnostics, duplicateNameDiagnostics(declarations)...)
 	return diagnostics
+}
+
+func yamlDeclarationKinds() map[string]string {
+	kinds := make(map[string]string)
+	for _, schema := range loading.BuildDeclarationSchemas("yaml") {
+		kinds[schema.Collection] = schema.Kind
+	}
+	return kinds
 }
 
 func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
@@ -504,41 +265,8 @@ func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 	return rangeValue{Start: start, End: end}
 }
 
-func loadModule(evaluationContext *starlarkEvaluationContext) func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
-	loaded := map[string]starlark.StringDict{}
-	loadingModules := map[string]bool{}
-	var load func(thread *starlark.Thread, module string) (starlark.StringDict, error)
-	load = func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
-		modulePath := resolveStarlarkModulePath(thread.Name, module)
-		if globals, isLoaded := loaded[modulePath]; isLoaded {
-			return globals, nil
-		}
-		if loadingModules[modulePath] {
-			return nil, fmt.Errorf("cycle detected while loading %q", module)
-		}
-		source, operationError := evaluationContext.readText(modulePath)
-		if operationError != nil {
-			return nil, fmt.Errorf("load %q: %w", module, operationError)
-		}
-		loadingModules[modulePath] = true
-		defer delete(loadingModules, modulePath)
-		moduleThread := &starlark.Thread{Name: modulePath, Load: load}
-		moduleThread.SetLocal(starlarkEvaluationContextKey, evaluationContext)
-		globals, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, moduleThread, modulePath, source, starlarkPredeclared(modulePath))
-		if operationError != nil {
-			return nil, operationError
-		}
-		loaded[modulePath] = globals
-		return globals, nil
-	}
-	return load
-}
-
 func yamlDiagnostics(text string) []diagnostic {
-	var packageDTO loading.PackageDTO
-	decoder := yaml.NewDecoder(strings.NewReader(text))
-	decoder.KnownFields(true)
-	if operationError := decoder.Decode(&packageDTO); operationError != nil {
+	if _, operationError := loading.DecodeYAML([]byte(text)); operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	var root yaml.Node

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -165,6 +165,9 @@ func evaluateStarlarkWithOptions(path string, text string, readText func(path st
 	}
 	packageDTO, operationError := loading.EvaluateStarlark(path, []byte(text), options)
 	if operationError == nil {
+		operationError = loading.ValidatePackageRequiredFields(packageDTO)
+	}
+	if operationError == nil {
 		operationError = loading.ValidatePackageTimeouts(packageDTO)
 	}
 	if operationError == nil {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -53,13 +53,65 @@ func diagnosticsFor(documentURI string, text string) []diagnostic {
 }
 
 func (server *server) diagnosticsFor(documentURI string, text string) []diagnostic {
-	return diagnosticsForReader(documentURI, text, func(path string) (string, error) {
+	diagnostics := diagnosticsForReader(documentURI, text, func(path string) (string, error) {
 		if content, isOpen := server.documents[pathToURI(path)]; isOpen {
 			return content, nil
 		}
 		content, operationError := os.ReadFile(path)
 		return string(content), operationError
 	})
+	return append(diagnostics, server.siblingPackageDiagnostics(uriPath(documentURI), text)...)
+}
+
+func (server *server) siblingPackageDiagnostics(path string, text string) []diagnostic {
+	if !loading.IsPackageFile(filepath.Base(path)) {
+		return nil
+	}
+	packageLoader := loading.NewPackageLoader(nil)
+	currentDeclarations := server.declarationsForPath(path, text)
+	entries, operationError := os.ReadDir(filepath.Dir(path))
+	if operationError != nil {
+		return nil
+	}
+	type siblingDeclaration struct {
+		kind     string
+		fileName string
+	}
+	siblingDeclarations := map[string]siblingDeclaration{}
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(path))
+	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
+	for _, entry := range entries {
+		siblingPath := filepath.Join(filepath.Dir(path), entry.Name())
+		if entry.IsDir() || filepath.Clean(siblingPath) == filepath.Clean(path) || !loading.IsPackageFile(entry.Name()) {
+			continue
+		}
+		if !includeHidden && isHiddenWorkspacePath(workspaceRoot, siblingPath) {
+			continue
+		}
+		siblingText := server.documentText(pathToURI(siblingPath))
+		var declarations []namedDeclaration
+		if isStarlarkFile(entry.Name()) {
+			declarations = server.declarationsForPath(siblingPath, siblingText)
+		} else {
+			declarations = packageFileDeclarations(siblingPath, siblingText, packageLoader)
+		}
+		for _, declaration := range declarations {
+			if loading.IsBuildLabelKind(declaration.kind) {
+				siblingDeclarations[declaration.name] = siblingDeclaration{kind: declaration.kind, fileName: entry.Name()}
+			}
+		}
+	}
+	diagnostics := []diagnostic{}
+	reported := map[string]bool{}
+	for _, declaration := range currentDeclarations {
+		sibling, duplicate := siblingDeclarations[declaration.name]
+		if !duplicate || !loading.IsBuildLabelKind(declaration.kind) || reported[declaration.name] {
+			continue
+		}
+		diagnostics = append(diagnostics, diagnostic{Range: declaration.rangeValue, Severity: 1, Source: "grog", Message: fmt.Sprintf("duplicate declaration name %q; also declared as %s in %s", declaration.name, sibling.kind, sibling.fileName)})
+		reported[declaration.name] = true
+	}
+	return diagnostics
 }
 
 func diagnosticsForReader(documentURI string, text string, readText func(path string) (string, error)) []diagnostic {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -230,7 +230,7 @@ func starlarkNamedDeclarations(text string) []namedDeclaration {
 		kind := text[match[2]:match[3]]
 		name := text[match[4]:match[5]]
 		start := positionForOffset(text, match[4])
-		end := position{Line: start.Line, Character: start.Character + len(name)}
+		end := position{Line: start.Line, Character: start.Character + utf16Length(name)}
 		declarations = append(declarations, namedDeclaration{kind: kind, name: name, rangeValue: rangeValue{Start: start, End: end}})
 	}
 	return declarations
@@ -338,13 +338,13 @@ func yamlNodeDiagnostic(text string, node *yaml.Node, message string) diagnostic
 func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 	line := 0
 	character := 0
-	endCharacter := 1
+	width := 1
 	if node != nil {
 		line = node.Line - 1
 		character = node.Column - 1
-		endCharacter = character + len(node.Value)
-		if endCharacter <= character {
-			endCharacter = character + 1
+		width = utf16Length(node.Value)
+		if width == 0 {
+			width = 1
 		}
 	}
 	if line < 0 {
@@ -354,7 +354,7 @@ func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 		character = 0
 	}
 	start := positionFromOneBased(text, line+1, character+1)
-	end := position{Line: start.Line, Character: start.Character + endCharacter - character}
+	end := position{Line: start.Line, Character: start.Character + width}
 	return rangeValue{Start: start, End: end}
 }
 

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -145,9 +145,12 @@ func starlarkErrorPath(operationError error) string {
 }
 
 func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {
+	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	return evaluateStarlarkWithOptions(path, text, readText, options)
+}
+
+func evaluateStarlarkWithOptions(path string, text string, readText func(path string) (string, error), options loading.StarlarkEvaluationOptions) ([]namedDeclaration, error) {
 	declarations := []namedDeclaration{}
-	workspaceRoot := findWorkspaceRoot(filepath.Dir(path))
-	options := loading.StarlarkOptionsForWorkspace(workspaceRoot)
 	options.ReadFile = func(path string) ([]byte, error) {
 		content, operationError := readText(path)
 		return []byte(content), operationError
@@ -168,7 +171,7 @@ func evaluateStarlark(path string, text string, readText func(path string) (stri
 		operationError = loading.ValidatePackageOutputs(packageDTO)
 	}
 	if operationError == nil {
-		packagePath, relativePathError := filepath.Rel(workspaceRoot, filepath.Dir(path))
+		packagePath, relativePathError := filepath.Rel(options.WorkspaceRoot, filepath.Dir(path))
 		if relativePathError == nil {
 			operationError = loading.ValidatePackageLabels(packageDTO, filepath.ToSlash(packagePath))
 		}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -31,6 +31,10 @@ func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
 	if !loading.IsStarlarkSourceFile(fileName) || (loading.StarlarkLoader{}).Matches(fileName) {
 		return nil
 	}
+	return server.publishOpenStarlarkBuildDiagnostics()
+}
+
+func (server *server) publishOpenStarlarkBuildDiagnostics() error {
 	for openDocumentURI := range server.documents {
 		if (loading.StarlarkLoader{}).Matches(filepath.Base(uriPath(openDocumentURI))) {
 			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
@@ -65,7 +69,7 @@ func diagnosticsForReader(documentURI string, text string, readText func(path st
 		return starlarkDiagnostics(path, text, readText)
 	}
 	if (loading.YamlLoader{}).Matches(name) {
-		return yamlDiagnostics(text)
+		return yamlDiagnostics(path, text)
 	}
 	return []diagnostic{}
 }
@@ -142,7 +146,8 @@ func starlarkErrorPath(operationError error) string {
 
 func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {
 	declarations := []namedDeclaration{}
-	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(path))
+	options := loading.StarlarkOptionsForWorkspace(workspaceRoot)
 	options.ReadFile = func(path string) ([]byte, error) {
 		content, operationError := readText(path)
 		return []byte(content), operationError
@@ -158,6 +163,12 @@ func evaluateStarlark(path string, text string, readText func(path string) (stri
 	packageDTO, operationError := loading.EvaluateStarlark(path, []byte(text), options)
 	if operationError == nil {
 		operationError = loading.ValidatePackageTimeouts(packageDTO)
+	}
+	if operationError == nil {
+		packagePath, relativePathError := filepath.Rel(workspaceRoot, filepath.Dir(path))
+		if relativePathError == nil {
+			operationError = loading.ValidatePackageLabels(packageDTO, filepath.ToSlash(packagePath))
+		}
 	}
 	return declarations, operationError
 }
@@ -367,12 +378,20 @@ func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 	return rangeValue{Start: start, End: end}
 }
 
-func yamlDiagnostics(text string) []diagnostic {
+func yamlDiagnostics(path string, text string) []diagnostic {
 	packageDTO, operationError := loading.DecodeYAML([]byte(text))
 	if operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	if operationError := loading.ValidatePackageTimeouts(packageDTO); operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(path))
+	packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(path))
+	if operationError == nil {
+		operationError = loading.ValidatePackageLabels(packageDTO, filepath.ToSlash(packagePath))
+	}
+	if operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	var root yaml.Node

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -165,6 +165,9 @@ func evaluateStarlark(path string, text string, readText func(path string) (stri
 		operationError = loading.ValidatePackageTimeouts(packageDTO)
 	}
 	if operationError == nil {
+		operationError = loading.ValidatePackageOutputs(packageDTO)
+	}
+	if operationError == nil {
 		packagePath, relativePathError := filepath.Rel(workspaceRoot, filepath.Dir(path))
 		if relativePathError == nil {
 			operationError = loading.ValidatePackageLabels(packageDTO, filepath.ToSlash(packagePath))
@@ -384,6 +387,9 @@ func yamlDiagnostics(path string, text string) []diagnostic {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	if operationError := loading.ValidatePackageTimeouts(packageDTO); operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	if operationError := loading.ValidatePackageOutputs(packageDTO); operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	workspaceRoot := findWorkspaceRoot(filepath.Dir(path))

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -28,15 +28,15 @@ func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
 		return operationError
 	}
 	fileName := filepath.Base(uriPath(documentURI))
-	if !loading.IsStarlarkSourceFile(fileName) || (loading.StarlarkLoader{}).Matches(fileName) {
+	if !loading.IsStarlarkSourceFile(fileName) {
 		return nil
 	}
-	return server.publishOpenStarlarkBuildDiagnostics()
+	return server.publishOpenStarlarkBuildDiagnostics(documentURI)
 }
 
-func (server *server) publishOpenStarlarkBuildDiagnostics() error {
+func (server *server) publishOpenStarlarkBuildDiagnostics(excludedDocumentURI string) error {
 	for openDocumentURI := range server.documents {
-		if (loading.StarlarkLoader{}).Matches(filepath.Base(uriPath(openDocumentURI))) {
+		if openDocumentURI != excludedDocumentURI && (loading.StarlarkLoader{}).Matches(filepath.Base(uriPath(openDocumentURI))) {
 			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
 				return operationError
 			}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -28,15 +28,15 @@ func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
 		return operationError
 	}
 	fileName := filepath.Base(uriPath(documentURI))
-	if !loading.IsStarlarkSourceFile(fileName) {
+	if !loading.IsStarlarkSourceFile(fileName) && !loading.IsPackageFile(fileName) {
 		return nil
 	}
-	return server.publishOpenStarlarkBuildDiagnostics(documentURI)
+	return server.publishOpenPackageDiagnostics(documentURI)
 }
 
-func (server *server) publishOpenStarlarkBuildDiagnostics(excludedDocumentURI string) error {
+func (server *server) publishOpenPackageDiagnostics(excludedDocumentURI string) error {
 	for openDocumentURI := range server.documents {
-		if openDocumentURI != excludedDocumentURI && loading.IsStarlarkPackageFile(filepath.Base(uriPath(openDocumentURI))) {
+		if openDocumentURI != excludedDocumentURI && loading.IsPackageFile(filepath.Base(uriPath(openDocumentURI))) {
 			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
 				return operationError
 			}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -81,7 +81,11 @@ func starlarkDiagnostics(path string, text string, readText func(path string) (s
 	declarations, operationError := evaluateStarlark(path, text, readText)
 	for index, declaration := range declarations {
 		if declaration.path != "" && filepath.Clean(declaration.path) != filepath.Clean(path) {
-			if loadRange, found := starlarkLoadRange(path, text, declaration.path, ""); found {
+			loadedPath := declaration.path
+			if directPath, found := starlarkDirectLoadPath(path, text, declaration.path, readText); found {
+				loadedPath = directPath
+			}
+			if loadRange, found := starlarkLoadRange(path, text, loadedPath, ""); found {
 				declarations[index].rangeValue = loadRange
 			}
 		}
@@ -92,6 +96,52 @@ func starlarkDiagnostics(path string, text string, readText func(path string) (s
 		diagnostics = append([]diagnostic{starlarkDiagnosticFromError(path, text, operationError)}, diagnostics...)
 	}
 	return diagnostics
+}
+
+func starlarkDirectLoadPath(buildPath string, text string, targetPath string, readText func(path string) (string, error)) (string, bool) {
+	file, operationError := syntax.Parse(buildPath, text, 0)
+	if operationError != nil {
+		return "", false
+	}
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(buildPath))
+	for _, statement := range file.Stmts {
+		loadStatement, isLoad := statement.(*syntax.LoadStmt)
+		if !isLoad {
+			continue
+		}
+		directPath := loading.ResolveStarlarkModulePath(workspaceRoot, buildPath, loadStatement.ModuleName())
+		if filepath.Clean(directPath) == filepath.Clean(targetPath) || starlarkModuleLoadsPath(workspaceRoot, directPath, targetPath, readText, map[string]bool{}) {
+			return directPath, true
+		}
+	}
+	return "", false
+}
+
+func starlarkModuleLoadsPath(workspaceRoot string, modulePath string, targetPath string, readText func(path string) (string, error), visited map[string]bool) bool {
+	modulePath = filepath.Clean(modulePath)
+	if visited[modulePath] {
+		return false
+	}
+	visited[modulePath] = true
+	text, operationError := readText(modulePath)
+	if operationError != nil {
+		return false
+	}
+	file, operationError := syntax.Parse(modulePath, text, 0)
+	if operationError != nil {
+		return false
+	}
+	for _, statement := range file.Stmts {
+		loadStatement, isLoad := statement.(*syntax.LoadStmt)
+		if !isLoad {
+			continue
+		}
+		loadedPath := loading.ResolveStarlarkModulePath(workspaceRoot, modulePath, loadStatement.ModuleName())
+		if filepath.Clean(loadedPath) == filepath.Clean(targetPath) || starlarkModuleLoadsPath(workspaceRoot, loadedPath, targetPath, readText, visited) {
+			return true
+		}
+	}
+	return false
 }
 
 func starlarkDiagnosticFromError(path string, text string, operationError error) diagnostic {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -287,6 +287,9 @@ func duplicateNameDiagnostics(declarations []namedDeclaration) []diagnostic {
 	seen := map[string]namedDeclaration{}
 	diagnostics := []diagnostic{}
 	for _, declaration := range declarations {
+		if !loading.IsBuildLabelKind(declaration.kind) {
+			continue
+		}
 		previous, exists := seen[declaration.name]
 		if !exists {
 			seen[declaration.name] = declaration

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -1,0 +1,435 @@
+package lsp
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"grog/internal/loading"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/subosito/gotenv"
+	starlarkjson "go.starlark.net/lib/json"
+	"go.starlark.net/lib/math"
+	starlarktime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+	"gopkg.in/yaml.v3"
+)
+
+func (server *server) publishDiagnostics(documentURI string) error {
+	text := server.documentText(documentURI)
+	diagnostics := diagnosticsFor(documentURI, text)
+	return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": documentURI, "diagnostics": diagnostics})
+}
+
+func diagnosticsFor(documentURI string, text string) []diagnostic {
+	path := uriPath(documentURI)
+	name := filepath.Base(path)
+	if isStarlarkFile(name) {
+		return starlarkDiagnostics(path, text)
+	}
+	if name == "BUILD.yaml" || name == "BUILD.yml" {
+		return yamlDiagnostics(text)
+	}
+	return []diagnostic{}
+}
+
+func starlarkDiagnostics(path string, text string) []diagnostic {
+	if _, operationError := syntax.Parse(path, text, syntax.RetainComments); operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	thread := &starlark.Thread{
+		Name: path,
+		Load: loadModule(),
+	}
+	_, operationError := starlark.ExecFileOptions(&syntax.FileOptions{Set: true}, thread, path, text, starlarkPredeclared(path))
+	diagnostics := starlarkSemanticDiagnostics(text)
+	if operationError != nil && !isRepeatedKeywordArgumentError(operationError) {
+		diagnostics = append([]diagnostic{diagnosticFromError(text, operationError)}, diagnostics...)
+	}
+	return diagnostics
+}
+
+func isRepeatedKeywordArgumentError(operationError error) bool {
+	return strings.Contains(operationError.Error(), "keyword argument") && strings.Contains(operationError.Error(), "is repeated")
+}
+
+func targetBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	var command string
+	var dependencies, inputs, excludeInputs, outputs, outputChecks, tags, platforms *starlark.List
+	var fingerprint, environmentVariables, ociPush *starlark.Dict
+	var binOutput, timeout, concurrencyGroup string
+	var binaryRequiresPush bool
+	if operationError := starlark.UnpackArgs("target", arguments, keywordArguments, "name", &name, "command?", &command, "dependencies?", &dependencies, "inputs?", &inputs, "exclude_inputs?", &excludeInputs, "outputs?", &outputs, "bin_output?", &binOutput, "binary_requires_push?", &binaryRequiresPush, "output_checks?", &outputChecks, "tags?", &tags, "fingerprint?", &fingerprint, "platforms?", &platforms, "environment_variables?", &environmentVariables, "timeout?", &timeout, "concurrency_group?", &concurrencyGroup, "oci_push?", &ociPush); operationError != nil {
+		return nil, operationError
+	}
+	return starlark.None, nil
+}
+
+func aliasBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	var actual string
+	if operationError := starlark.UnpackArgs("alias", arguments, keywordArguments, "name", &name, "actual", &actual); operationError != nil {
+		return nil, operationError
+	}
+	return starlark.None, nil
+}
+
+func environmentBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
+	var name string
+	var environmentType string
+	var dependencies *starlark.List
+	var ociImage string
+	if operationError := starlark.UnpackArgs("environment", arguments, keywordArguments, "name", &name, "type", &environmentType, "dependencies?", &dependencies, "oci_image?", &ociImage); operationError != nil {
+		return nil, operationError
+	}
+	return starlark.None, nil
+}
+
+func resourceBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments starlark.Tuple, keywordArguments []starlark.Tuple) (starlark.Value, error) {
+	var name, up, down, ready, timeout string
+	var exports *starlark.Dict
+	var dependencies *starlark.List
+	if operationError := starlark.UnpackArgs("resource", arguments, keywordArguments, "name", &name, "up", &up, "down?", &down, "ready?", &ready, "timeout?", &timeout, "exports?", &exports, "dependencies?", &dependencies); operationError != nil {
+		return nil, operationError
+	}
+	return starlark.None, nil
+}
+
+func starlarkPredeclared(currentPath string) starlark.StringDict {
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
+	platformTags := starlark.NewList(nil)
+	platformTags.Freeze()
+	predeclared := starlark.StringDict{
+		"target":              starlark.NewBuiltin("target", targetBuiltin),
+		"alias":               starlark.NewBuiltin("alias", aliasBuiltin),
+		"resource":            starlark.NewBuiltin("resource", resourceBuiltin),
+		"environment":         starlark.NewBuiltin("environment", environmentBuiltin),
+		"json":                starlarkjson.Module,
+		"math":                math.Module,
+		"time":                starlarktime.Module,
+		"GROG_OS":             starlark.String(runtime.GOOS),
+		"GROG_ARCH":           starlark.String(runtime.GOARCH),
+		"GROG_PLATFORM":       starlark.String(runtime.GOOS + "/" + runtime.GOARCH),
+		"GROG_PLATFORM_TAGS":  platformTags,
+		"GROG_ENV_FILE":       starlark.String(""),
+		"GROG_WORKSPACE_ROOT": starlark.String(workspaceRoot),
+		"GROG_GIT_HASH":       starlark.String(""),
+	}
+	configurationBytes, operationError := os.ReadFile(filepath.Join(workspaceRoot, "grog.toml"))
+	if operationError != nil {
+		return predeclared
+	}
+	var configuration struct {
+		EnvironmentVariables     map[string]string `toml:"environment_variables"`
+		EnvironmentVariablesFile string            `toml:"environment_variables_file"`
+		OperatingSystem          string            `toml:"os"`
+		Architecture             string            `toml:"arch"`
+		PlatformTags             []string          `toml:"platform_tag"`
+	}
+	if toml.Unmarshal(configurationBytes, &configuration) != nil {
+		return predeclared
+	}
+	operatingSystem := runtime.GOOS
+	if configuration.OperatingSystem != "" {
+		operatingSystem = configuration.OperatingSystem
+	}
+	architecture := runtime.GOARCH
+	if configuration.Architecture != "" {
+		architecture = configuration.Architecture
+	}
+	predeclared["GROG_OS"] = starlark.String(operatingSystem)
+	predeclared["GROG_ARCH"] = starlark.String(architecture)
+	predeclared["GROG_PLATFORM"] = starlark.String(operatingSystem + "/" + architecture)
+	values := make([]starlark.Value, 0, len(configuration.PlatformTags))
+	for _, tag := range configuration.PlatformTags {
+		values = append(values, starlark.String(tag))
+	}
+	platformTags = starlark.NewList(values)
+	platformTags.Freeze()
+	predeclared["GROG_PLATFORM_TAGS"] = platformTags
+	if configuration.EnvironmentVariablesFile != "" {
+		environmentFilePath := configuration.EnvironmentVariablesFile
+		if !filepath.IsAbs(environmentFilePath) {
+			environmentFilePath = filepath.Join(workspaceRoot, environmentFilePath)
+		}
+		predeclared["GROG_ENV_FILE"] = starlark.String(environmentFilePath)
+		if environmentVariables, readError := gotenv.Read(environmentFilePath); readError == nil {
+			for name, value := range environmentVariables {
+				predeclared[name] = starlark.String(value)
+			}
+		}
+	}
+	for name, value := range configuration.EnvironmentVariables {
+		predeclared[name] = starlark.String(value)
+	}
+	return predeclared
+}
+
+func starlarkSemanticDiagnostics(text string) []diagnostic {
+	declarations := starlarkNamedDeclarations(text)
+	diagnostics := duplicateNameDiagnostics(declarations)
+	diagnostics = append(diagnostics, duplicateKeywordArgumentDiagnostics(text)...)
+	return diagnostics
+}
+
+type namedDeclaration struct {
+	kind       string
+	name       string
+	rangeValue rangeValue
+}
+
+func starlarkNamedDeclarations(text string) []namedDeclaration {
+	file, operationError := syntax.Parse("", text, 0)
+	if operationError == nil {
+		declarations := []namedDeclaration{}
+		for _, statement := range file.Stmts {
+			expressionStatement, isExpression := statement.(*syntax.ExprStmt)
+			if !isExpression {
+				continue
+			}
+			call, isCall := expressionStatement.X.(*syntax.CallExpr)
+			if !isCall {
+				continue
+			}
+			function, isIdentifier := call.Fn.(*syntax.Ident)
+			if !isIdentifier || !isDeclarationKind(function.Name) {
+				continue
+			}
+			for _, argument := range call.Args {
+				keyword, isKeyword := argument.(*syntax.BinaryExpr)
+				if !isKeyword || keyword.Op != syntax.EQ {
+					continue
+				}
+				keywordName, isName := keyword.X.(*syntax.Ident)
+				nameLiteral, isLiteral := keyword.Y.(*syntax.Literal)
+				if !isName || !isLiteral || keywordName.Name != "name" {
+					continue
+				}
+				name, isString := nameLiteral.Value.(string)
+				if isString {
+					start, end := nameLiteral.Span()
+					declarations = append(declarations, namedDeclaration{kind: function.Name, name: name, rangeValue: rangeFromSyntaxPositions(text, start, end)})
+					break
+				}
+			}
+		}
+		return declarations
+	}
+	pattern := regexp.MustCompile(`(?s)\b(target|alias|resource|environment)\s*\([^)]*?\bname\s*=\s*["']([^"']+)["']`)
+	declarations := []namedDeclaration{}
+	matches := pattern.FindAllStringSubmatchIndex(text, -1)
+	for _, match := range matches {
+		kind := text[match[2]:match[3]]
+		name := text[match[4]:match[5]]
+		start := positionForOffset(text, match[4])
+		end := position{Line: start.Line, Character: start.Character + len(name)}
+		declarations = append(declarations, namedDeclaration{kind: kind, name: name, rangeValue: rangeValue{Start: start, End: end}})
+	}
+	return declarations
+}
+
+func isDeclarationKind(name string) bool {
+	return name == "target" || name == "alias" || name == "resource" || name == "environment"
+}
+
+func duplicateKeywordArgumentDiagnostics(text string) []diagnostic {
+	file, operationError := syntax.Parse("", text, 0)
+	if operationError != nil {
+		return nil
+	}
+	diagnostics := []diagnostic{}
+	syntax.Walk(file, func(node syntax.Node) bool {
+		call, isCall := node.(*syntax.CallExpr)
+		if !isCall {
+			return true
+		}
+		seen := map[string]bool{}
+		for _, argument := range call.Args {
+			keyword, isKeyword := argument.(*syntax.BinaryExpr)
+			if !isKeyword || keyword.Op != syntax.EQ {
+				continue
+			}
+			identifier, isIdentifier := keyword.X.(*syntax.Ident)
+			if !isIdentifier {
+				continue
+			}
+			if seen[identifier.Name] {
+				start, end := identifier.Span()
+				diagnostics = append(diagnostics, diagnostic{Range: rangeFromSyntaxPositions(text, start, end), Severity: 1, Source: "grog", Message: fmt.Sprintf("duplicate keyword argument %q", identifier.Name)})
+			}
+			seen[identifier.Name] = true
+		}
+		return true
+	})
+	return diagnostics
+}
+
+func duplicateNameDiagnostics(declarations []namedDeclaration) []diagnostic {
+	seen := map[string]namedDeclaration{}
+	diagnostics := []diagnostic{}
+	for _, declaration := range declarations {
+		previous, exists := seen[declaration.name]
+		if !exists {
+			seen[declaration.name] = declaration
+			continue
+		}
+		diagnostics = append(diagnostics, diagnostic{Range: declaration.rangeValue, Severity: 1, Source: "grog", Message: fmt.Sprintf("duplicate declaration name %q; first declared as %s", declaration.name, previous.kind)})
+	}
+	return diagnostics
+}
+
+func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return []diagnostic{}
+	}
+	diagnostics := []diagnostic{}
+	declarations := []namedDeclaration{}
+	for index := 0; index+1 < len(root.Content); index += 2 {
+		key := root.Content[index]
+		value := root.Content[index+1]
+		switch key.Value {
+		case "targets", "aliases", "resources", "environments":
+			kind := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}[key.Value]
+			if value.Kind != yaml.SequenceNode {
+				diagnostics = append(diagnostics, yamlNodeDiagnostic(text, value, fmt.Sprintf("%s must be a list", key.Value)))
+				continue
+			}
+			for _, item := range value.Content {
+				nameNode := yamlMappingValue(item, "name")
+				if nameNode == nil || nameNode.Value == "" {
+					diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires name", kind)))
+					continue
+				}
+				declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
+			}
+		}
+	}
+	diagnostics = append(diagnostics, duplicateNameDiagnostics(declarations)...)
+	return diagnostics
+}
+
+func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			return node.Content[index+1]
+		}
+	}
+	return nil
+}
+
+func yamlNodeDiagnostic(text string, node *yaml.Node, message string) diagnostic {
+	return diagnostic{Range: yamlNodeRange(text, node), Severity: 1, Source: "grog", Message: message}
+}
+
+func yamlNodeRange(text string, node *yaml.Node) rangeValue {
+	line := 0
+	character := 0
+	endCharacter := 1
+	if node != nil {
+		line = node.Line - 1
+		character = node.Column - 1
+		endCharacter = character + len(node.Value)
+		if endCharacter <= character {
+			endCharacter = character + 1
+		}
+	}
+	if line < 0 {
+		line = 0
+	}
+	if character < 0 {
+		character = 0
+	}
+	start := positionFromOneBased(text, line+1, character+1)
+	end := position{Line: start.Line, Character: start.Character + endCharacter - character}
+	return rangeValue{Start: start, End: end}
+}
+
+func loadModule() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	loaded := map[string]starlark.StringDict{}
+	loadingModules := map[string]bool{}
+	var load func(thread *starlark.Thread, module string) (starlark.StringDict, error)
+	load = func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		modulePath := resolveStarlarkModulePath(thread.Name, module)
+		if globals, isLoaded := loaded[modulePath]; isLoaded {
+			return globals, nil
+		}
+		if loadingModules[modulePath] {
+			return nil, fmt.Errorf("cycle detected while loading %q", module)
+		}
+		source, operationError := os.ReadFile(modulePath)
+		if operationError != nil {
+			return nil, fmt.Errorf("load %q: %w", module, operationError)
+		}
+		loadingModules[modulePath] = true
+		defer delete(loadingModules, modulePath)
+		moduleThread := &starlark.Thread{Name: modulePath, Load: load}
+		globals, operationError := starlark.ExecFileOptions(&syntax.FileOptions{Set: true}, moduleThread, modulePath, source, starlarkPredeclared(modulePath))
+		if operationError != nil {
+			return nil, operationError
+		}
+		loaded[modulePath] = globals
+		return globals, nil
+	}
+	return load
+}
+
+func yamlDiagnostics(text string) []diagnostic {
+	var packageDTO loading.PackageDTO
+	decoder := yaml.NewDecoder(strings.NewReader(text))
+	decoder.KnownFields(true)
+	if operationError := decoder.Decode(&packageDTO); operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	var root yaml.Node
+	if operationError := yaml.Unmarshal([]byte(text), &root); operationError != nil {
+		return []diagnostic{diagnosticFromError(text, operationError)}
+	}
+	return yamlSemanticDiagnostics(text, &root)
+}
+
+func diagnosticFromError(text string, operationError error) diagnostic {
+	line, character := 0, 0
+	var syntaxError syntax.Error
+	if errors.As(operationError, &syntaxError) {
+		line = int(syntaxError.Pos.Line) - 1
+		character = int(syntaxError.Pos.Col) - 1
+	} else {
+		positionPattern := regexp.MustCompile(`:(\d+):(\d+)`)
+		matches := positionPattern.FindStringSubmatch(operationError.Error())
+		if len(matches) == 3 {
+			line, _ = strconv.Atoi(matches[1])
+			character, _ = strconv.Atoi(matches[2])
+			line--
+			character--
+		} else {
+			linePattern := regexp.MustCompile(`line (\d+):`)
+			matches = linePattern.FindStringSubmatch(operationError.Error())
+			if len(matches) == 2 {
+				line, _ = strconv.Atoi(matches[1])
+				line--
+			}
+		}
+	}
+	if line < 0 {
+		line = 0
+	}
+	if character < 0 {
+		character = 0
+	}
+	start := positionFromOneBased(text, line+1, character+1)
+	return diagnostic{Range: rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + 1}}, Severity: 1, Source: "grog", Message: operationError.Error()}
+}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -18,6 +18,7 @@ import (
 	"go.starlark.net/lib/math"
 	starlarktime "go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
 )
@@ -44,16 +45,31 @@ func starlarkDiagnostics(path string, text string) []diagnostic {
 	if _, operationError := syntax.Parse(path, text, syntax.RetainComments); operationError != nil {
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
-	thread := &starlark.Thread{
-		Name: path,
-		Load: loadModule(),
-	}
-	_, operationError := starlark.ExecFileOptions(&syntax.FileOptions{Set: true}, thread, path, text, starlarkPredeclared(path))
-	diagnostics := starlarkSemanticDiagnostics(text)
+	declarations, operationError := evaluateStarlark(path, text, func(path string) (string, error) {
+		content, readError := os.ReadFile(path)
+		return string(content), readError
+	})
+	diagnostics := duplicateNameDiagnostics(declarations)
+	diagnostics = append(diagnostics, duplicateKeywordArgumentDiagnostics(text)...)
 	if operationError != nil && !isRepeatedKeywordArgumentError(operationError) {
 		diagnostics = append([]diagnostic{diagnosticFromError(text, operationError)}, diagnostics...)
 	}
 	return diagnostics
+}
+
+type starlarkEvaluationContext struct {
+	declarations []namedDeclaration
+	readText     func(path string) (string, error)
+}
+
+const starlarkEvaluationContextKey = "grog-lsp-evaluation"
+
+func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {
+	evaluationContext := &starlarkEvaluationContext{readText: readText}
+	thread := &starlark.Thread{Name: path, Load: loadModule(evaluationContext)}
+	thread.SetLocal(starlarkEvaluationContextKey, evaluationContext)
+	_, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, path, text, starlarkPredeclared(path))
+	return evaluationContext.declarations, operationError
 }
 
 func isRepeatedKeywordArgumentError(operationError error) bool {
@@ -70,6 +86,31 @@ func targetBuiltin(thread *starlark.Thread, function *starlark.Builtin, argument
 	if operationError := starlark.UnpackArgs("target", arguments, keywordArguments, "name", &name, "command?", &command, "dependencies?", &dependencies, "inputs?", &inputs, "exclude_inputs?", &excludeInputs, "outputs?", &outputs, "bin_output?", &binOutput, "binary_requires_push?", &binaryRequiresPush, "output_checks?", &outputChecks, "tags?", &tags, "fingerprint?", &fingerprint, "platforms?", &platforms, "environment_variables?", &environmentVariables, "timeout?", &timeout, "concurrency_group?", &concurrencyGroup, "oci_push?", &ociPush); operationError != nil {
 		return nil, operationError
 	}
+	listFields := []struct {
+		name   string
+		values *starlark.List
+	}{{"dependencies", dependencies}, {"inputs", inputs}, {"exclude_inputs", excludeInputs}, {"outputs", outputs}, {"tags", tags}, {"platforms", platforms}}
+	for _, field := range listFields {
+		if operationError := validateStringList(field.name, field.values); operationError != nil {
+			return nil, operationError
+		}
+	}
+	dictionaryFields := []struct {
+		name   string
+		values *starlark.Dict
+	}{{"fingerprint", fingerprint}, {"environment_variables", environmentVariables}}
+	for _, field := range dictionaryFields {
+		if operationError := validateStringDict(field.name, field.values); operationError != nil {
+			return nil, operationError
+		}
+	}
+	if operationError := validateOutputChecks(outputChecks); operationError != nil {
+		return nil, operationError
+	}
+	if operationError := validateOciPush(ociPush); operationError != nil {
+		return nil, operationError
+	}
+	recordDeclaration(thread, "target", name)
 	return starlark.None, nil
 }
 
@@ -79,6 +120,7 @@ func aliasBuiltin(thread *starlark.Thread, function *starlark.Builtin, arguments
 	if operationError := starlark.UnpackArgs("alias", arguments, keywordArguments, "name", &name, "actual", &actual); operationError != nil {
 		return nil, operationError
 	}
+	recordDeclaration(thread, "alias", name)
 	return starlark.None, nil
 }
 
@@ -90,6 +132,10 @@ func environmentBuiltin(thread *starlark.Thread, function *starlark.Builtin, arg
 	if operationError := starlark.UnpackArgs("environment", arguments, keywordArguments, "name", &name, "type", &environmentType, "dependencies?", &dependencies, "oci_image?", &ociImage); operationError != nil {
 		return nil, operationError
 	}
+	if operationError := validateStringList("dependencies", dependencies); operationError != nil {
+		return nil, operationError
+	}
+	recordDeclaration(thread, "environment", name)
 	return starlark.None, nil
 }
 
@@ -100,7 +146,113 @@ func resourceBuiltin(thread *starlark.Thread, function *starlark.Builtin, argume
 	if operationError := starlark.UnpackArgs("resource", arguments, keywordArguments, "name", &name, "up", &up, "down?", &down, "ready?", &ready, "timeout?", &timeout, "exports?", &exports, "dependencies?", &dependencies); operationError != nil {
 		return nil, operationError
 	}
+	if operationError := validateStringDict("exports", exports); operationError != nil {
+		return nil, operationError
+	}
+	if operationError := validateStringList("dependencies", dependencies); operationError != nil {
+		return nil, operationError
+	}
+	recordDeclaration(thread, "resource", name)
 	return starlark.None, nil
+}
+
+func validateStringList(field string, list *starlark.List) error {
+	if list == nil {
+		return nil
+	}
+	iterator := list.Iterate()
+	defer iterator.Done()
+	var value starlark.Value
+	for iterator.Next(&value) {
+		if _, isString := value.(starlark.String); !isString {
+			return fmt.Errorf("%s: expected string, got %s", field, value.Type()) //nolint:nilaway // Iterate assigns value before returning true.
+		}
+	}
+	return nil
+}
+
+func validateStringDict(field string, dictionary *starlark.Dict) error {
+	if dictionary == nil {
+		return nil
+	}
+	for _, item := range dictionary.Items() {
+		if _, isString := item[0].(starlark.String); !isString {
+			return fmt.Errorf("%s key must be string, got %s", field, item[0].Type())
+		}
+		if _, isString := item[1].(starlark.String); !isString {
+			return fmt.Errorf("%s value must be string, got %s", field, item[1].Type())
+		}
+	}
+	return nil
+}
+
+func validateOciPush(dictionary *starlark.Dict) error {
+	if dictionary == nil {
+		return nil
+	}
+	for _, item := range dictionary.Items() {
+		key, isString := item[0].(starlark.String)
+		if !isString {
+			return fmt.Errorf("oci_push key must be string, got %s", item[0].Type())
+		}
+		switch value := item[1].(type) {
+		case starlark.String:
+		case *starlark.List:
+			if operationError := validateStringList(fmt.Sprintf("oci_push[%q]", string(key)), value); operationError != nil {
+				return operationError
+			}
+		default:
+			return fmt.Errorf("oci_push[%q] must be string or list of strings, got %s", string(key), value.Type())
+		}
+	}
+	return nil
+}
+
+func validateOutputChecks(list *starlark.List) error {
+	if list == nil {
+		return nil
+	}
+	iterator := list.Iterate()
+	defer iterator.Done()
+	var value starlark.Value
+	for iterator.Next(&value) {
+		var command starlark.Value
+		var found bool
+		var operationError error
+		switch outputCheck := value.(type) {
+		case *starlark.Dict:
+			command, found, operationError = outputCheck.Get(starlark.String("command"))
+		case *starlarkstruct.Struct:
+			command, operationError = outputCheck.Attr("command")
+			found = operationError == nil
+		default:
+			return fmt.Errorf("output_check must be dict or struct, got %s", value.Type()) //nolint:nilaway // Iterate assigns value before returning true.
+		}
+		if operationError != nil {
+			return operationError
+		}
+		if !found {
+			return fmt.Errorf("output_check missing 'command' field")
+		}
+		if _, isString := command.(starlark.String); !isString {
+			return fmt.Errorf("output_check 'command' must be string")
+		}
+	}
+	return nil
+}
+
+func recordDeclaration(thread *starlark.Thread, kind string, name string) {
+	evaluationContext, exists := thread.Local(starlarkEvaluationContextKey).(*starlarkEvaluationContext)
+	if !exists {
+		return
+	}
+	callPosition := thread.CallFrame(1).Pos
+	declarationRange := rangeValue{Start: position{Line: max(int(callPosition.Line)-1, 0)}, End: position{Line: max(int(callPosition.Line)-1, 0), Character: 1}}
+	if sourceText, operationError := evaluationContext.readText(callPosition.Filename()); operationError == nil {
+		start := positionFromSyntaxPosition(sourceText, callPosition)
+		declarationRange = rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + 1}}
+	}
+	evaluationContext.declarations = append(evaluationContext.declarations, namedDeclaration{kind: kind, name: name, path: callPosition.Filename(), rangeValue: declarationRange})
 }
 
 func starlarkPredeclared(currentPath string) starlark.StringDict {
@@ -173,16 +325,10 @@ func starlarkPredeclared(currentPath string) starlark.StringDict {
 	return predeclared
 }
 
-func starlarkSemanticDiagnostics(text string) []diagnostic {
-	declarations := starlarkNamedDeclarations(text)
-	diagnostics := duplicateNameDiagnostics(declarations)
-	diagnostics = append(diagnostics, duplicateKeywordArgumentDiagnostics(text)...)
-	return diagnostics
-}
-
 type namedDeclaration struct {
 	kind       string
 	name       string
+	path       string
 	rangeValue rangeValue
 }
 
@@ -358,7 +504,7 @@ func yamlNodeRange(text string, node *yaml.Node) rangeValue {
 	return rangeValue{Start: start, End: end}
 }
 
-func loadModule() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+func loadModule(evaluationContext *starlarkEvaluationContext) func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
 	loaded := map[string]starlark.StringDict{}
 	loadingModules := map[string]bool{}
 	var load func(thread *starlark.Thread, module string) (starlark.StringDict, error)
@@ -370,14 +516,15 @@ func loadModule() func(thread *starlark.Thread, module string) (starlark.StringD
 		if loadingModules[modulePath] {
 			return nil, fmt.Errorf("cycle detected while loading %q", module)
 		}
-		source, operationError := os.ReadFile(modulePath)
+		source, operationError := evaluationContext.readText(modulePath)
 		if operationError != nil {
 			return nil, fmt.Errorf("load %q: %w", module, operationError)
 		}
 		loadingModules[modulePath] = true
 		defer delete(loadingModules, modulePath)
 		moduleThread := &starlark.Thread{Name: modulePath, Load: load}
-		globals, operationError := starlark.ExecFileOptions(&syntax.FileOptions{Set: true}, moduleThread, modulePath, source, starlarkPredeclared(modulePath))
+		moduleThread.SetLocal(starlarkEvaluationContextKey, evaluationContext)
+		globals, operationError := starlark.ExecFileOptions(&syntax.FileOptions{}, moduleThread, modulePath, source, starlarkPredeclared(modulePath))
 		if operationError != nil {
 			return nil, operationError
 		}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -36,7 +36,8 @@ func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
 
 func (server *server) publishOpenPackageDiagnostics(excludedDocumentURI string) error {
 	for openDocumentURI := range server.documents {
-		if openDocumentURI != excludedDocumentURI && loading.IsPackageFile(filepath.Base(uriPath(openDocumentURI))) {
+		fileName := filepath.Base(uriPath(openDocumentURI))
+		if openDocumentURI != excludedDocumentURI && (loading.IsPackageFile(fileName) || loading.IsStarlarkSourceFile(fileName)) {
 			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
 				return operationError
 			}
@@ -417,17 +418,18 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 	declarationKinds := yamlDeclarationKinds()
 	for index := 0; index+1 < len(root.Content); index += 2 {
 		key := root.Content[index]
-		value := yamlDereferenceAlias(root.Content[index+1])
+		rawValue := root.Content[index+1]
+		value := yamlDereferenceAlias(rawValue)
 		kind, isDeclarationList := declarationKinds[key.Value]
 		if !isDeclarationList {
 			continue
 		}
-		if value.Kind != yaml.SequenceNode {
-			diagnostics = append(diagnostics, yamlNodeDiagnostic(text, value, fmt.Sprintf("%s must be a list", key.Value)))
+		if value == nil || value.Kind != yaml.SequenceNode {
+			diagnostics = append(diagnostics, yamlNodeDiagnostic(text, rawValue, fmt.Sprintf("%s must be a list", key.Value)))
 			continue
 		}
 		for _, item := range value.Content {
-			nameNode := yamlMappingValue(item, "name")
+			nameNode := yamlDereferenceAlias(yamlMappingValue(item, "name"))
 			if nameNode == nil || nameNode.Value == "" {
 				diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires name", kind)))
 				continue
@@ -436,7 +438,7 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 				if !parameter.Required || parameter.Name == "name" {
 					continue
 				}
-				fieldNode := yamlMappingValue(item, parameter.Name)
+				fieldNode := yamlDereferenceAlias(yamlMappingValue(item, parameter.Name))
 				if fieldNode == nil || fieldNode.Value == "" {
 					diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires %s", kind, parameter.Name)))
 				}

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -36,7 +36,7 @@ func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
 
 func (server *server) publishOpenStarlarkBuildDiagnostics(excludedDocumentURI string) error {
 	for openDocumentURI := range server.documents {
-		if openDocumentURI != excludedDocumentURI && (loading.StarlarkLoader{}).Matches(filepath.Base(uriPath(openDocumentURI))) {
+		if openDocumentURI != excludedDocumentURI && loading.IsStarlarkPackageFile(filepath.Base(uriPath(openDocumentURI))) {
 			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
 				return operationError
 			}
@@ -68,7 +68,7 @@ func diagnosticsForReader(documentURI string, text string, readText func(path st
 	if isStarlarkFile(name) {
 		return starlarkDiagnostics(path, text, readText)
 	}
-	if (loading.YamlLoader{}).Matches(name) {
+	if loading.IsYAMLPackageFile(name) {
 		return yamlDiagnostics(path, text)
 	}
 	return []diagnostic{}
@@ -402,12 +402,40 @@ func yamlDeclarationKinds() map[string]string {
 }
 
 func yamlMappingValue(node *yaml.Node, key string) *yaml.Node {
-	if node == nil || node.Kind != yaml.MappingNode {
+	return yamlMappingValueVisited(node, key, map[*yaml.Node]bool{})
+}
+
+func yamlMappingValueVisited(node *yaml.Node, key string, visited map[*yaml.Node]bool) *yaml.Node {
+	if node == nil || visited[node] {
+		return nil
+	}
+	visited[node] = true
+	if node.Kind == yaml.AliasNode {
+		return yamlMappingValueVisited(node.Alias, key, visited)
+	}
+	if node.Kind != yaml.MappingNode {
 		return nil
 	}
 	for index := 0; index+1 < len(node.Content); index += 2 {
-		if node.Content[index].Value == key {
+		if node.Content[index].Value == key && key != "<<" {
 			return node.Content[index+1]
+		}
+	}
+	for index := 0; index+1 < len(node.Content); index += 2 {
+		if node.Content[index].Value != "<<" {
+			continue
+		}
+		merged := node.Content[index+1]
+		if merged.Kind == yaml.SequenceNode {
+			for _, item := range merged.Content {
+				if value := yamlMappingValueVisited(item, key, visited); value != nil {
+					return value
+				}
+			}
+			continue
+		}
+		if value := yamlMappingValueVisited(merged, key, visited); value != nil {
+			return value
 		}
 	}
 	return nil

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -247,7 +247,10 @@ func starlarkErrorPath(operationError error) string {
 }
 
 func evaluateStarlark(path string, text string, readText func(path string) (string, error)) ([]namedDeclaration, error) {
-	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	options, operationError := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	if operationError != nil {
+		return nil, operationError
+	}
 	return evaluateStarlarkWithOptions(path, text, readText, options)
 }
 
@@ -414,7 +417,7 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 	declarationKinds := yamlDeclarationKinds()
 	for index := 0; index+1 < len(root.Content); index += 2 {
 		key := root.Content[index]
-		value := root.Content[index+1]
+		value := yamlDereferenceAlias(root.Content[index+1])
 		kind, isDeclarationList := declarationKinds[key.Value]
 		if !isDeclarationList {
 			continue
@@ -443,6 +446,15 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 	}
 	diagnostics = append(diagnostics, duplicateNameDiagnostics(declarations)...)
 	return diagnostics
+}
+
+func yamlDereferenceAlias(node *yaml.Node) *yaml.Node {
+	visited := map[*yaml.Node]bool{}
+	for node != nil && node.Kind == yaml.AliasNode && !visited[node] {
+		visited[node] = true
+		node = node.Alias
+	}
+	return node
 }
 
 func yamlDeclarationKinds() map[string]string {

--- a/internal/lsp/diagnostics.go
+++ b/internal/lsp/diagnostics.go
@@ -23,6 +23,24 @@ func (server *server) publishDiagnostics(documentURI string) error {
 	return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": documentURI, "diagnostics": diagnostics})
 }
 
+func (server *server) publishDiagnosticsAfterChange(documentURI string) error {
+	if operationError := server.publishDiagnostics(documentURI); operationError != nil {
+		return operationError
+	}
+	fileName := filepath.Base(uriPath(documentURI))
+	if !loading.IsStarlarkSourceFile(fileName) || (loading.StarlarkLoader{}).Matches(fileName) {
+		return nil
+	}
+	for openDocumentURI := range server.documents {
+		if (loading.StarlarkLoader{}).Matches(filepath.Base(uriPath(openDocumentURI))) {
+			if operationError := server.publishDiagnostics(openDocumentURI); operationError != nil {
+				return operationError
+			}
+		}
+	}
+	return nil
+}
+
 func diagnosticsFor(documentURI string, text string) []diagnostic {
 	return diagnosticsForReader(documentURI, text, func(path string) (string, error) {
 		content, operationError := os.ReadFile(path)
@@ -57,6 +75,13 @@ func starlarkDiagnostics(path string, text string, readText func(path string) (s
 		return []diagnostic{diagnosticFromError(text, operationError)}
 	}
 	declarations, operationError := evaluateStarlark(path, text, readText)
+	for index, declaration := range declarations {
+		if declaration.path != "" && filepath.Clean(declaration.path) != filepath.Clean(path) {
+			if loadRange, found := starlarkLoadRange(path, text, declaration.path, ""); found {
+				declarations[index].rangeValue = loadRange
+			}
+		}
+	}
 	diagnostics := duplicateNameDiagnostics(declarations)
 	diagnostics = append(diagnostics, duplicateKeywordArgumentDiagnostics(text)...)
 	if operationError != nil && !isRepeatedKeywordArgumentError(operationError) {
@@ -70,9 +95,16 @@ func starlarkDiagnosticFromError(path string, text string, operationError error)
 	if errorPath == "" || filepath.Clean(errorPath) == filepath.Clean(path) {
 		return diagnosticFromError(text, operationError)
 	}
+	if loadRange, found := starlarkLoadRange(path, text, errorPath, operationError.Error()); found {
+		return diagnostic{Range: loadRange, Severity: 1, Source: "grog", Message: operationError.Error()}
+	}
+	return diagnosticFromError(text, operationError)
+}
+
+func starlarkLoadRange(path string, text string, loadedPath string, errorMessage string) (rangeValue, bool) {
 	file, parseError := syntax.Parse(path, text, 0)
 	if parseError != nil {
-		return diagnosticFromError(text, operationError)
+		return rangeValue{}, false
 	}
 	var fallback *syntax.LoadStmt
 	for _, statement := range file.Stmts {
@@ -84,16 +116,16 @@ func starlarkDiagnosticFromError(path string, text string, operationError error)
 			fallback = loadStatement
 		}
 		modulePath := loading.ResolveStarlarkModulePath(findWorkspaceRoot(filepath.Dir(path)), path, loadStatement.ModuleName())
-		if filepath.Clean(modulePath) == filepath.Clean(errorPath) || strings.Contains(operationError.Error(), loadStatement.ModuleName()) {
+		if filepath.Clean(modulePath) == filepath.Clean(loadedPath) || errorMessage != "" && strings.Contains(errorMessage, loadStatement.ModuleName()) {
 			start, end := loadStatement.Module.Span()
-			return diagnostic{Range: rangeFromSyntaxPositions(text, start, end), Severity: 1, Source: "grog", Message: operationError.Error()}
+			return rangeFromSyntaxPositions(text, start, end), true
 		}
 	}
 	if fallback != nil {
 		start, end := fallback.Module.Span()
-		return diagnostic{Range: rangeFromSyntaxPositions(text, start, end), Severity: 1, Source: "grog", Message: operationError.Error()}
+		return rangeFromSyntaxPositions(text, start, end), true
 	}
-	return diagnosticFromError(text, operationError)
+	return rangeValue{}, false
 }
 
 func starlarkErrorPath(operationError error) string {
@@ -271,6 +303,15 @@ func yamlSemanticDiagnostics(text string, root *yaml.Node) []diagnostic {
 			if nameNode == nil || nameNode.Value == "" {
 				diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires name", kind)))
 				continue
+			}
+			for _, parameter := range loading.StarlarkParameters(kind) {
+				if !parameter.Required || parameter.Name == "name" {
+					continue
+				}
+				fieldNode := yamlMappingValue(item, parameter.Name)
+				if fieldNode == nil || fieldNode.Value == "" {
+					diagnostics = append(diagnostics, yamlNodeDiagnostic(text, item, fmt.Sprintf("%s requires %s", kind, parameter.Name)))
+				}
 			}
 			declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
 		}

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	"grog/internal/config"
 	"grog/internal/label"
 	"grog/internal/loading"
 
@@ -195,9 +196,10 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel {
 	labels := []indexedLabel{}
 	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
+	evaluationOptions := loading.StarlarkOptionsForWorkspace(workspaceRoot)
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
-			if !includeHidden && directoryEntry != nil && directoryEntry.IsDir() && strings.HasPrefix(directoryEntry.Name(), ".") && directoryEntry.Name() != "." {
+			if !includeHidden && directoryEntry != nil && directoryEntry.IsDir() && filepath.Clean(path) != filepath.Clean(workspaceRoot) && strings.HasPrefix(directoryEntry.Name(), ".") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -205,7 +207,7 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 		if !isSupportedBuildFile(filepath.Base(path)) {
 			return nil
 		}
-		for _, declaration := range server.declarationsForPath(path, server.documentText(pathToURI(path))) {
+		for _, declaration := range server.declarationsForPathWithOptions(path, server.documentText(pathToURI(path)), evaluationOptions) {
 			if loading.IsBuildLabelKind(declaration.kind) {
 				labels = append(labels, indexedLabel{path: path, name: declaration.name})
 			}
@@ -234,14 +236,22 @@ func (server *server) declarationsForPath(path string, text string) []namedDecla
 	if !isStarlarkFile(filepath.Base(path)) {
 		return declarationsForFile(filepath.Base(path), text)
 	}
-	declarations, operationError := evaluateStarlark(path, text, func(modulePath string) (string, error) {
+	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	return server.declarationsForPathWithOptions(path, text, options)
+}
+
+func (server *server) declarationsForPathWithOptions(path string, text string, options loading.StarlarkEvaluationOptions) []namedDeclaration {
+	if !isStarlarkFile(filepath.Base(path)) {
+		return declarationsForFile(filepath.Base(path), text)
+	}
+	declarations, operationError := evaluateStarlarkWithOptions(path, text, func(modulePath string) (string, error) {
 		moduleURI := pathToURI(modulePath)
 		if moduleText, isOpen := server.documents[moduleURI]; isOpen {
 			return moduleText, nil
 		}
 		content, readError := os.ReadFile(modulePath)
 		return string(content), readError
-	})
+	}, options)
 	if operationError != nil {
 		return starlarkNamedDeclarations(text)
 	}
@@ -339,12 +349,15 @@ func isSupportedBuildFile(fileName string) bool {
 }
 
 func watchedFileRegistrations() []map[string]any {
-	patterns := make([]string, 0)
+	patterns := []string{"**/grog*.toml"}
 	for _, fileName := range loading.BuildFileNames() {
 		patterns = append(patterns, "**/"+fileName)
 	}
 	for _, extension := range loading.StarlarkSourceExtensions() {
 		patterns = append(patterns, "**/*"+extension)
+	}
+	if config.Global.EnvironmentVariablesFile != "" {
+		patterns = append(patterns, "**/"+filepath.Base(config.Global.EnvironmentVariablesFile))
 	}
 	registrations := make([]map[string]any, 0, len(patterns))
 	for _, pattern := range patterns {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -303,7 +303,7 @@ func packageFileDeclarations(path string, text string, packageLoader *loading.Pa
 	if loading.IsYAMLPackageFile(filepath.Base(path)) {
 		return declarationsForFile(filepath.Base(path), text)
 	}
-	packageDTO, matched, operationError := packageLoader.LoadIfMatched(context.Background(), path, filepath.Base(path))
+	packageDTO, matched, operationError := packageLoader.LoadSourceIfMatched(context.Background(), path, filepath.Base(path), []byte(text))
 	if operationError != nil || !matched {
 		return nil
 	}
@@ -354,11 +354,11 @@ func declarationsForFile(fileName string, text string) []namedDeclaration {
 		key := root.Content[index]
 		value := yamlDereferenceAlias(root.Content[index+1])
 		kind, isDeclarationList := declarationKinds[key.Value]
-		if !isDeclarationList || value.Kind != yaml.SequenceNode {
+		if !isDeclarationList || value == nil || value.Kind != yaml.SequenceNode {
 			continue
 		}
 		for _, item := range value.Content {
-			nameNode := yamlMappingValue(item, "name")
+			nameNode := yamlDereferenceAlias(yamlMappingValue(item, "name"))
 			if nameNode != nil && nameNode.Value != "" {
 				declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
 			}

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -237,7 +238,7 @@ func pathWithinWorkspace(workspaceRoot string, path string) bool {
 
 func (server *server) declarationsForPath(path string, text string) []namedDeclaration {
 	if !isStarlarkFile(filepath.Base(path)) {
-		return declarationsForFile(filepath.Base(path), text)
+		return packageFileDeclarations(path, text)
 	}
 	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
 	return server.declarationsForPathWithOptions(path, text, options)
@@ -245,7 +246,7 @@ func (server *server) declarationsForPath(path string, text string) []namedDecla
 
 func (server *server) declarationsForPathWithOptions(path string, text string, options loading.StarlarkEvaluationOptions) []namedDeclaration {
 	if !isStarlarkFile(filepath.Base(path)) {
-		return declarationsForFile(filepath.Base(path), text)
+		return packageFileDeclarations(path, text)
 	}
 	declarations, operationError := evaluateStarlarkWithOptions(path, text, func(modulePath string) (string, error) {
 		moduleURI := pathToURI(modulePath)
@@ -257,6 +258,30 @@ func (server *server) declarationsForPathWithOptions(path string, text string, o
 	}, options)
 	if operationError != nil {
 		return starlarkNamedDeclarations(text)
+	}
+	return declarations
+}
+
+func packageFileDeclarations(path string, text string) []namedDeclaration {
+	if loading.IsYAMLPackageFile(filepath.Base(path)) {
+		return declarationsForFile(filepath.Base(path), text)
+	}
+	packageDTO, matched, operationError := loading.LoadPackageFile(context.Background(), path)
+	if operationError != nil || !matched {
+		return nil
+	}
+	declarations := []namedDeclaration{}
+	for _, declaration := range loading.PackageDeclarations(packageDTO) {
+		start := position{}
+		if offset := strings.Index(text, declaration.Name); offset >= 0 {
+			start = positionForOffset(text, offset)
+		}
+		declarations = append(declarations, namedDeclaration{
+			kind:       declaration.Kind,
+			name:       declaration.Name,
+			path:       path,
+			rangeValue: rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + utf16Length(declaration.Name)}},
+		})
 	}
 	return declarations
 }
@@ -348,13 +373,13 @@ func isStarlarkFile(fileName string) bool {
 }
 
 func isSupportedBuildFile(fileName string) bool {
-	return (loading.StarlarkLoader{}).Matches(fileName) || (loading.YamlLoader{}).Matches(fileName)
+	return loading.IsPackageFile(fileName)
 }
 
 func watchedFileRegistrations() []map[string]any {
 	patterns := []string{"**/grog*.toml"}
-	for _, fileName := range loading.BuildFileNames() {
-		patterns = append(patterns, "**/"+fileName)
+	for _, pattern := range loading.PackageFilePatterns() {
+		patterns = append(patterns, "**/"+pattern)
 	}
 	for _, extension := range loading.StarlarkSourceExtensions() {
 		patterns = append(patterns, "**/*"+extension)

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -207,7 +207,10 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel {
 	labels := []indexedLabel{}
 	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
-	evaluationOptions := loading.StarlarkOptionsForWorkspace(workspaceRoot)
+	evaluationOptions, optionsError := loading.StarlarkOptionsForWorkspace(workspaceRoot)
+	if optionsError != nil {
+		return labels
+	}
 	packageLoader := loading.NewPackageLoader(nil)
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
@@ -271,7 +274,10 @@ func (server *server) declarationsForPath(path string, text string) []namedDecla
 	if !isStarlarkFile(filepath.Base(path)) {
 		return packageFileDeclarations(path, text, loading.NewPackageLoader(nil))
 	}
-	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	options, operationError := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
+	if operationError != nil {
+		return starlarkNamedDeclarations(text)
+	}
 	return server.declarationsForPathWithOptions(path, text, options)
 }
 
@@ -346,7 +352,7 @@ func declarationsForFile(fileName string, text string) []namedDeclaration {
 	}
 	for index := 0; index+1 < len(root.Content); index += 2 {
 		key := root.Content[index]
-		value := root.Content[index+1]
+		value := yamlDereferenceAlias(root.Content[index+1])
 		kind, isDeclarationList := declarationKinds[key.Value]
 		if !isDeclarationList || value.Kind != yaml.SequenceNode {
 			continue

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -109,23 +109,26 @@ func labelAt(text string, textPosition position) string {
 	if characterOffset < 0 {
 		return ""
 	}
-	start := characterOffset
-	for start > 0 && isLabelCharacter(line[start-1]) {
-		start--
+	if quoteStart := strings.LastIndexAny(line[:characterOffset], "\"'"); quoteStart >= 0 {
+		quote := line[quoteStart]
+		if quoteEnd := strings.IndexByte(line[characterOffset:], quote); quoteEnd >= 0 {
+			candidate := line[quoteStart+1 : characterOffset+quoteEnd]
+			if _, operationError := label.ParseTargetLabel("", candidate); operationError == nil {
+				return candidate
+			}
+		}
 	}
-	end := characterOffset
-	for end < len(line) && isLabelCharacter(line[end]) {
-		end++
+	start := strings.LastIndexAny(line[:characterOffset], " \t,[](){}=") + 1
+	endRelative := strings.IndexAny(line[characterOffset:], " \t,[](){}=")
+	end := len(line)
+	if endRelative >= 0 {
+		end = characterOffset + endRelative
 	}
-	label := line[start:end]
-	if strings.HasPrefix(label, ":") || strings.HasPrefix(label, "//") {
-		return label
+	candidate := strings.Trim(line[start:end], "\"'")
+	if _, operationError := label.ParseTargetLabel("", candidate); operationError == nil {
+		return candidate
 	}
 	return ""
-}
-
-func isLabelCharacter(character byte) bool {
-	return isWordCharacter(character) || character == ':' || character == '/' || character == '-' || character == '.'
 }
 
 func findWorkspaceRoot(directory string) string {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -221,7 +221,7 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 }
 
 func (server *server) invalidateLabelIndexForDocument(documentURI string) {
-	if loading.IsStarlarkSourceFile(filepath.Base(uriPath(documentURI))) && !isSupportedBuildFile(filepath.Base(uriPath(documentURI))) {
+	if loading.IsStarlarkSourceFile(filepath.Base(uriPath(documentURI))) {
 		server.invalidateLabelIndex()
 	}
 }

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -194,9 +194,10 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 
 func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel {
 	labels := []indexedLabel{}
+	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
-			if directoryEntry != nil && directoryEntry.IsDir() && strings.HasPrefix(directoryEntry.Name(), ".") && directoryEntry.Name() != "." {
+			if !includeHidden && directoryEntry != nil && directoryEntry.IsDir() && strings.HasPrefix(directoryEntry.Name(), ".") && directoryEntry.Name() != "." {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -68,17 +68,23 @@ func (server *server) labelDefinition(currentPath string, targetLabel string) an
 		return nil
 	}
 	directory := filepath.Join(workspaceRoot, filepath.FromSlash(parsedLabel.Package))
+	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
 	fileNames := []string{}
-	if filepath.Clean(directory) == filepath.Clean(filepath.Dir(currentPath)) {
+	if filepath.Clean(directory) == filepath.Clean(filepath.Dir(currentPath)) && (includeHidden || !isHiddenWorkspacePath(workspaceRoot, currentPath)) {
 		fileNames = append(fileNames, filepath.Base(currentPath))
 	}
 	entries, operationError := os.ReadDir(directory)
 	if operationError == nil {
 		for _, entry := range entries {
 			fileName := entry.Name()
-			if !entry.IsDir() && isSupportedBuildFile(fileName) && !slices.Contains(fileNames, fileName) {
-				fileNames = append(fileNames, fileName)
+			definitionPath := filepath.Join(directory, fileName)
+			if entry.IsDir() || !isSupportedBuildFile(fileName) || slices.Contains(fileNames, fileName) {
+				continue
 			}
+			if !includeHidden && isHiddenWorkspacePath(workspaceRoot, definitionPath) {
+				continue
+			}
+			fileNames = append(fileNames, fileName)
 		}
 	}
 	for _, fileName := range fileNames {
@@ -157,9 +163,10 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 	}
 	openBuildFiles := make(map[string]bool)
 	openLabels := []indexedLabel{}
+	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
 	for documentURI, text := range server.documents {
 		path := uriPath(documentURI)
-		if !isSupportedBuildFile(filepath.Base(path)) || !pathWithinWorkspace(workspaceRoot, path) {
+		if !isSupportedBuildFile(filepath.Base(path)) || !pathWithinWorkspace(workspaceRoot, path) || (!includeHidden && isHiddenWorkspacePath(workspaceRoot, path)) {
 			continue
 		}
 		openBuildFiles[filepath.Clean(path)] = true
@@ -212,6 +219,9 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 		if !isSupportedBuildFile(filepath.Base(path)) {
 			return nil
 		}
+		if !includeHidden && isHiddenWorkspacePath(workspaceRoot, path) {
+			return nil
+		}
 		text := server.documentText(pathToURI(path))
 		var declarations []namedDeclaration
 		if isStarlarkFile(filepath.Base(path)) {
@@ -227,6 +237,19 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 		return nil
 	})
 	return labels
+}
+
+func isHiddenWorkspacePath(workspaceRoot string, path string) bool {
+	relativePath, operationError := filepath.Rel(workspaceRoot, path)
+	if operationError != nil {
+		return false
+	}
+	for _, component := range strings.Split(relativePath, string(filepath.Separator)) {
+		if strings.HasPrefix(component, ".") && component != "." && component != ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func (server *server) invalidateLabelIndexForDocument(documentURI string) {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -371,9 +371,26 @@ func pathToURIForOperatingSystem(path string, operatingSystem string) string {
 }
 
 func starlarkIdentifierDefinitionRange(text string, identifier string) (rangeValue, bool) {
+	file, operationError := syntax.Parse("", text, 0)
+	if operationError == nil {
+		for _, statement := range file.Stmts {
+			var definition *syntax.Ident
+			switch statement := statement.(type) {
+			case *syntax.DefStmt:
+				definition = statement.Name
+			case *syntax.AssignStmt:
+				definition, _ = statement.LHS.(*syntax.Ident)
+			}
+			if definition != nil && definition.Name == identifier {
+				start, end := definition.Span()
+				return rangeFromSyntaxPositions(text, start, end), true
+			}
+		}
+		return rangeValue{}, false
+	}
 	patterns := []*regexp.Regexp{
-		regexp.MustCompile(`^\s*def\s+` + regexp.QuoteMeta(identifier) + `\s*\(`),
-		regexp.MustCompile(`^\s*` + regexp.QuoteMeta(identifier) + `\s*=`),
+		regexp.MustCompile(`^def\s+` + regexp.QuoteMeta(identifier) + `\s*\(`),
+		regexp.MustCompile(`^` + regexp.QuoteMeta(identifier) + `\s*=`),
 	}
 	lines := strings.Split(text, "\n")
 	for lineNumber, line := range lines {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 
@@ -14,6 +15,11 @@ import (
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
 )
+
+type indexedLabel struct {
+	path string
+	name string
+}
 
 func (server *server) definition(documentURI string, textPosition position) any {
 	path := uriPath(documentURI)
@@ -81,7 +87,7 @@ func (server *server) labelDefinition(currentPath string, targetLabel string) an
 			continue
 		}
 		for _, declaration := range server.declarationsForPath(definitionPath, definitionText) {
-			if declaration.name == parsedLabel.Name {
+			if declaration.name == parsedLabel.Name && loading.IsBuildLabelKind(declaration.kind) {
 				if declaration.path != "" {
 					definitionURI = pathToURI(declaration.path)
 				}
@@ -136,7 +142,58 @@ func findWorkspaceRoot(directory string) string {
 }
 
 func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []string {
+	indexedLabels, isCached := server.workspaceLabels[workspaceRoot]
+	if !isCached {
+		indexedLabels = server.indexWorkspaceLabels(workspaceRoot)
+		if server.workspaceLabels == nil {
+			server.workspaceLabels = make(map[string][]indexedLabel)
+		}
+		server.workspaceLabels[workspaceRoot] = indexedLabels
+	}
+	openBuildFiles := make(map[string]bool)
+	openLabels := []indexedLabel{}
+	for documentURI, text := range server.documents {
+		path := uriPath(documentURI)
+		if !isSupportedBuildFile(filepath.Base(path)) || !pathWithinWorkspace(workspaceRoot, path) {
+			continue
+		}
+		openBuildFiles[filepath.Clean(path)] = true
+		for _, declaration := range server.declarationsForPath(path, text) {
+			if loading.IsBuildLabelKind(declaration.kind) {
+				openLabels = append(openLabels, indexedLabel{path: path, name: declaration.name})
+			}
+		}
+	}
+	labelsToRender := make([]indexedLabel, 0, len(indexedLabels)+len(openLabels))
+	for _, indexedLabel := range indexedLabels {
+		if !openBuildFiles[filepath.Clean(indexedLabel.path)] {
+			labelsToRender = append(labelsToRender, indexedLabel)
+		}
+	}
+	labelsToRender = append(labelsToRender, openLabels...)
 	labels := []string{}
+	seen := make(map[string]bool)
+	for _, indexedLabel := range labelsToRender {
+		packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(indexedLabel.path))
+		if operationError != nil || packagePath == "." {
+			packagePath = ""
+		}
+		label := "//" + filepath.ToSlash(packagePath) + ":" + indexedLabel.name
+		if !seen[label] {
+			labels = append(labels, label)
+			seen[label] = true
+		}
+		localLabel := ":" + indexedLabel.name
+		if filepath.Clean(filepath.Dir(indexedLabel.path)) == filepath.Clean(currentDirectory) && !seen[localLabel] {
+			labels = append(labels, localLabel)
+			seen[localLabel] = true
+		}
+	}
+	return labels
+}
+
+func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel {
+	labels := []indexedLabel{}
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
 			if directoryEntry != nil && directoryEntry.IsDir() && strings.HasPrefix(directoryEntry.Name(), ".") && directoryEntry.Name() != "." {
@@ -144,29 +201,32 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 			}
 			return nil
 		}
-		name := filepath.Base(path)
-		if !isSupportedBuildFile(name) {
+		if !isSupportedBuildFile(filepath.Base(path)) {
 			return nil
 		}
-		content := server.documentText(pathToURI(path))
-		packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(path))
-		if operationError != nil || packagePath == "." {
-			packagePath = ""
-		}
-		prefix := "//"
-		if packagePath != "" {
-			prefix += filepath.ToSlash(packagePath)
-		}
-		for _, declaration := range server.declarationsForPath(path, content) {
-			label := prefix + ":" + declaration.name
-			labels = append(labels, label)
-			if filepath.Clean(filepath.Dir(path)) == filepath.Clean(currentDirectory) {
-				labels = append(labels, ":"+declaration.name)
+		for _, declaration := range server.declarationsForPath(path, server.documentText(pathToURI(path))) {
+			if loading.IsBuildLabelKind(declaration.kind) {
+				labels = append(labels, indexedLabel{path: path, name: declaration.name})
 			}
 		}
 		return nil
 	})
 	return labels
+}
+
+func (server *server) invalidateLabelIndexForDocument(documentURI string) {
+	if loading.IsStarlarkSourceFile(filepath.Base(uriPath(documentURI))) && !isSupportedBuildFile(filepath.Base(uriPath(documentURI))) {
+		server.invalidateLabelIndex()
+	}
+}
+
+func (server *server) invalidateLabelIndex() {
+	clear(server.workspaceLabels)
+}
+
+func pathWithinWorkspace(workspaceRoot string, path string) bool {
+	relativePath, operationError := filepath.Rel(workspaceRoot, path)
+	return operationError == nil && relativePath != ".." && !strings.HasPrefix(relativePath, ".."+string(filepath.Separator))
 }
 
 func (server *server) declarationsForPath(path string, text string) []namedDeclaration {
@@ -278,6 +338,20 @@ func isSupportedBuildFile(fileName string) bool {
 }
 
 func pathToURI(path string) string {
+	return pathToURIForOperatingSystem(path, runtime.GOOS)
+}
+
+func pathToURIForOperatingSystem(path string, operatingSystem string) string {
+	if operatingSystem == "windows" {
+		path = strings.ReplaceAll(path, `\`, "/")
+		if strings.HasPrefix(path, "//") {
+			host, uriPath, _ := strings.Cut(strings.TrimPrefix(path, "//"), "/")
+			return (&url.URL{Scheme: "file", Host: host, Path: "/" + uriPath}).String()
+		}
+		if len(path) >= 2 && path[1] == ':' {
+			path = "/" + path
+		}
+	}
 	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
@@ -370,9 +444,24 @@ func positionFromOneBased(text string, line int, column int) position {
 }
 
 func uriPath(documentURI string) string {
+	return uriPathForOperatingSystem(documentURI, runtime.GOOS)
+}
+
+func uriPathForOperatingSystem(documentURI string, operatingSystem string) string {
 	parsed, operationError := url.Parse(documentURI)
 	if operationError != nil || parsed.Scheme != "file" {
 		return documentURI
+	}
+	if operatingSystem == "windows" {
+		path := parsed.Path
+		if len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+			path = path[1:]
+		}
+		path = strings.ReplaceAll(path, "/", `\`)
+		if parsed.Host != "" && parsed.Host != "localhost" {
+			return `\\` + parsed.Host + path
+		}
+		return path
 	}
 	return parsed.Path
 }

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -5,9 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"grog/internal/label"
+	"grog/internal/loading"
 
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
@@ -58,7 +60,20 @@ func (server *server) labelDefinition(currentPath string, targetLabel string) an
 		return nil
 	}
 	directory := filepath.Join(workspaceRoot, filepath.FromSlash(parsedLabel.Package))
-	for _, fileName := range []string{"BUILD.star", "BUILD.bzl", "BUILD.yaml", "BUILD.yml"} {
+	fileNames := []string{}
+	if filepath.Clean(directory) == filepath.Clean(filepath.Dir(currentPath)) {
+		fileNames = append(fileNames, filepath.Base(currentPath))
+	}
+	entries, operationError := os.ReadDir(directory)
+	if operationError == nil {
+		for _, entry := range entries {
+			fileName := entry.Name()
+			if !entry.IsDir() && isSupportedBuildFile(fileName) && !slices.Contains(fileNames, fileName) {
+				fileNames = append(fileNames, fileName)
+			}
+		}
+	}
+	for _, fileName := range fileNames {
 		definitionPath := filepath.Join(directory, fileName)
 		definitionURI := pathToURI(definitionPath)
 		definitionText := server.documentText(definitionURI)
@@ -130,7 +145,7 @@ func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirect
 			return nil
 		}
 		name := filepath.Base(path)
-		if name != "BUILD.star" && name != "BUILD.bzl" && name != "BUILD.yaml" && name != "BUILD.yml" {
+		if !isSupportedBuildFile(name) {
 			return nil
 		}
 		content := server.documentText(pathToURI(path))
@@ -184,13 +199,14 @@ func declarationsForFile(fileName string, text string) []namedDeclaration {
 		root = *root.Content[0]
 	}
 	declarations := []namedDeclaration{}
+	declarationKinds := yamlDeclarationKinds()
 	if root.Kind != yaml.MappingNode {
 		return declarations
 	}
 	for index := 0; index+1 < len(root.Content); index += 2 {
 		key := root.Content[index]
 		value := root.Content[index+1]
-		kind, isDeclarationList := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}[key.Value]
+		kind, isDeclarationList := declarationKinds[key.Value]
 		if !isDeclarationList || value.Kind != yaml.SequenceNode {
 			continue
 		}
@@ -205,19 +221,23 @@ func declarationsForFile(fileName string, text string) []namedDeclaration {
 }
 
 func incompleteYamlDeclarations(text string) []namedDeclaration {
-	sectionPattern := regexp.MustCompile(`^(targets|aliases|resources|environments):`)
 	namePattern := regexp.MustCompile(`^-\s+name:\s*["']?([^\s"'#]+)`)
-	kinds := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}
+	declarationKinds := yamlDeclarationKinds()
 	declarations := []namedDeclaration{}
 	kind := ""
 	for lineNumber, line := range strings.Split(text, "\n") {
 		trimmedLine := strings.TrimSpace(line)
-		if matches := sectionPattern.FindStringSubmatch(trimmedLine); len(matches) == 2 {
-			kind = kinds[matches[1]]
+		if collection, _, found := strings.Cut(trimmedLine, ":"); found {
+			if declarationKind, isDeclarationList := declarationKinds[collection]; isDeclarationList {
+				kind = declarationKind
+				continue
+			}
+		}
+		if kind == "" {
 			continue
 		}
 		matches := namePattern.FindStringSubmatchIndex(trimmedLine)
-		if kind == "" || len(matches) != 4 {
+		if len(matches) != 4 {
 			continue
 		}
 		name := trimmedLine[matches[2]:matches[3]]
@@ -241,25 +261,20 @@ func starlarkLoadedSymbol(currentPath string, text string, identifier string) (s
 		}
 		for index, localIdentifier := range loadStatement.To {
 			if localIdentifier.Name == identifier {
-				return resolveStarlarkModulePath(currentPath, loadStatement.ModuleName()), loadStatement.From[index].Name, true
+				workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
+				return loading.ResolveStarlarkModulePath(workspaceRoot, currentPath, loadStatement.ModuleName()), loadStatement.From[index].Name, true
 			}
 		}
 	}
 	return "", "", false
 }
 
-func resolveStarlarkModulePath(currentPath string, module string) string {
-	if strings.HasPrefix(module, "//") {
-		return filepath.Join(findWorkspaceRoot(filepath.Dir(currentPath)), strings.TrimPrefix(module, "//"))
-	}
-	if filepath.IsAbs(module) {
-		return filepath.Clean(module)
-	}
-	return filepath.Clean(filepath.Join(filepath.Dir(currentPath), module))
+func isStarlarkFile(fileName string) bool {
+	return loading.IsStarlarkSourceFile(fileName)
 }
 
-func isStarlarkFile(fileName string) bool {
-	return fileName == "BUILD.star" || fileName == "BUILD.bzl" || strings.HasSuffix(fileName, ".star") || strings.HasSuffix(fileName, ".bzl")
+func isSupportedBuildFile(fileName string) bool {
+	return (loading.StarlarkLoader{}).Matches(fileName) || (loading.YamlLoader{}).Matches(fileName)
 }
 
 func pathToURI(path string) string {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -1,0 +1,316 @@
+package lsp
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.starlark.net/syntax"
+	"gopkg.in/yaml.v3"
+)
+
+func (server *server) definition(documentURI string, textPosition position) any {
+	path := uriPath(documentURI)
+	if !isStarlarkFile(filepath.Base(path)) {
+		return nil
+	}
+	text := server.documentText(documentURI)
+	label := labelAt(text, textPosition)
+	if label != "" {
+		return server.labelDefinition(path, label)
+	}
+	word := wordAt(text, textPosition)
+	if word == "" {
+		return nil
+	}
+	definitionRange, found := starlarkIdentifierDefinitionRange(text, word)
+	if found {
+		return map[string]any{"uri": documentURI, "range": definitionRange}
+	}
+	modulePath, moduleSymbol, found := starlarkLoadedSymbol(path, text, word)
+	if !found {
+		return nil
+	}
+	moduleURI := pathToURI(modulePath)
+	moduleText := server.documentText(moduleURI)
+	if moduleText == "" {
+		return nil
+	}
+	definitionRange, found = starlarkIdentifierDefinitionRange(moduleText, moduleSymbol)
+	if !found {
+		return nil
+	}
+	return map[string]any{"uri": moduleURI, "range": definitionRange}
+}
+
+func (server *server) labelDefinition(currentPath string, label string) any {
+	targetName := strings.TrimPrefix(label, ":")
+	directory := filepath.Dir(currentPath)
+	if strings.HasPrefix(label, "//") {
+		colon := strings.LastIndex(label, ":")
+		if colon < 0 {
+			return nil
+		}
+		directory = filepath.Join(findWorkspaceRoot(filepath.Dir(currentPath)), strings.TrimPrefix(label[:colon], "//"))
+		targetName = label[colon+1:]
+	}
+	for _, fileName := range []string{"BUILD.star", "BUILD.bzl", "BUILD.yaml", "BUILD.yml"} {
+		definitionPath := filepath.Join(directory, fileName)
+		definitionURI := pathToURI(definitionPath)
+		definitionText := server.documentText(definitionURI)
+		if definitionText == "" {
+			continue
+		}
+		for _, declaration := range declarationsForFile(fileName, definitionText) {
+			if declaration.name == targetName {
+				return map[string]any{"uri": definitionURI, "range": declaration.rangeValue}
+			}
+		}
+	}
+	return nil
+}
+
+func labelAt(text string, textPosition position) string {
+	lines := strings.Split(text, "\n")
+	if textPosition.Line < 0 || textPosition.Line >= len(lines) {
+		return ""
+	}
+	line := lines[textPosition.Line]
+	if textPosition.Character < 0 || textPosition.Character > len(line) {
+		return ""
+	}
+	start := textPosition.Character
+	for start > 0 && isLabelCharacter(line[start-1]) {
+		start--
+	}
+	end := textPosition.Character
+	for end < len(line) && isLabelCharacter(line[end]) {
+		end++
+	}
+	label := line[start:end]
+	if strings.HasPrefix(label, ":") || strings.HasPrefix(label, "//") {
+		return label
+	}
+	return ""
+}
+
+func isLabelCharacter(character byte) bool {
+	return isWordCharacter(character) || character == ':' || character == '/' || character == '-' || character == '.'
+}
+
+func findWorkspaceRoot(directory string) string {
+	originalDirectory := directory
+	for {
+		if _, operationError := os.Stat(filepath.Join(directory, "grog.toml")); operationError == nil {
+			return directory
+		}
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			return originalDirectory
+		}
+		directory = parent
+	}
+}
+
+func collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []string {
+	labels := []string{}
+	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
+		if operationError != nil || directoryEntry.IsDir() {
+			if directoryEntry != nil && directoryEntry.IsDir() && strings.HasPrefix(directoryEntry.Name(), ".") && directoryEntry.Name() != "." {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := filepath.Base(path)
+		if name != "BUILD.star" && name != "BUILD.bzl" && name != "BUILD.yaml" && name != "BUILD.yml" {
+			return nil
+		}
+		content, operationError := os.ReadFile(path)
+		if operationError != nil {
+			return nil
+		}
+		packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(path))
+		if operationError != nil || packagePath == "." {
+			packagePath = ""
+		}
+		prefix := "//"
+		if packagePath != "" {
+			prefix += filepath.ToSlash(packagePath)
+		}
+		for _, declaration := range declarationsForFile(name, string(content)) {
+			label := prefix + ":" + declaration.name
+			labels = append(labels, label)
+			if filepath.Clean(filepath.Dir(path)) == filepath.Clean(currentDirectory) {
+				labels = append(labels, ":"+declaration.name)
+			}
+		}
+		return nil
+	})
+	return labels
+}
+
+func declarationsForFile(fileName string, text string) []namedDeclaration {
+	if isStarlarkFile(fileName) {
+		return starlarkNamedDeclarations(text)
+	}
+	var root yaml.Node
+	if operationError := yaml.Unmarshal([]byte(text), &root); operationError != nil {
+		return nil
+	}
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = *root.Content[0]
+	}
+	declarations := []namedDeclaration{}
+	if root.Kind != yaml.MappingNode {
+		return declarations
+	}
+	for index := 0; index+1 < len(root.Content); index += 2 {
+		key := root.Content[index]
+		value := root.Content[index+1]
+		kind, isDeclarationList := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}[key.Value]
+		if !isDeclarationList || value.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range value.Content {
+			nameNode := yamlMappingValue(item, "name")
+			if nameNode != nil && nameNode.Value != "" {
+				declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
+			}
+		}
+	}
+	return declarations
+}
+
+func starlarkLoadedSymbol(currentPath string, text string, identifier string) (string, string, bool) {
+	file, operationError := syntax.Parse(currentPath, text, 0)
+	if operationError != nil {
+		return "", "", false
+	}
+	for _, statement := range file.Stmts {
+		loadStatement, isLoad := statement.(*syntax.LoadStmt)
+		if !isLoad {
+			continue
+		}
+		for index, localIdentifier := range loadStatement.To {
+			if localIdentifier.Name == identifier {
+				return resolveStarlarkModulePath(currentPath, loadStatement.ModuleName()), loadStatement.From[index].Name, true
+			}
+		}
+	}
+	return "", "", false
+}
+
+func resolveStarlarkModulePath(currentPath string, module string) string {
+	if strings.HasPrefix(module, "//") {
+		return filepath.Join(findWorkspaceRoot(filepath.Dir(currentPath)), strings.TrimPrefix(module, "//"))
+	}
+	if filepath.IsAbs(module) {
+		return filepath.Clean(module)
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(currentPath), module))
+}
+
+func isStarlarkFile(fileName string) bool {
+	return fileName == "BUILD.star" || fileName == "BUILD.bzl" || strings.HasSuffix(fileName, ".star") || strings.HasSuffix(fileName, ".bzl")
+}
+
+func pathToURI(path string) string {
+	return (&url.URL{Scheme: "file", Path: path}).String()
+}
+
+func starlarkIdentifierDefinitionRange(text string, identifier string) (rangeValue, bool) {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`^\s*def\s+` + regexp.QuoteMeta(identifier) + `\s*\(`),
+		regexp.MustCompile(`^\s*` + regexp.QuoteMeta(identifier) + `\s*=`),
+	}
+	lines := strings.Split(text, "\n")
+	for lineNumber, line := range lines {
+		for _, pattern := range patterns {
+			match := pattern.FindStringIndex(line)
+			if match == nil {
+				continue
+			}
+			start := strings.Index(line, identifier)
+			if start < 0 {
+				continue
+			}
+			return rangeValue{Start: position{Line: lineNumber, Character: start}, End: position{Line: lineNumber, Character: start + len(identifier)}}, true
+		}
+	}
+	return rangeValue{}, false
+}
+
+func (server *server) documentSymbols(documentURI string) []map[string]any {
+	return symbolsFromText(filepath.Base(uriPath(documentURI)), server.documentText(documentURI))
+}
+
+func symbolsFromText(fileName string, text string) []map[string]any {
+	declarations := declarationsForFile(fileName, text)
+	symbols := make([]map[string]any, 0, len(declarations))
+	for _, declaration := range declarations {
+		symbols = append(symbols, map[string]any{
+			"name":           declaration.name,
+			"detail":         declaration.kind,
+			"kind":           19,
+			"range":          declaration.rangeValue,
+			"selectionRange": declaration.rangeValue,
+		})
+	}
+	if !isStarlarkFile(fileName) {
+		return symbols
+	}
+	file, operationError := syntax.Parse(fileName, text, 0)
+	if operationError != nil {
+		return symbols
+	}
+	for _, statement := range file.Stmts {
+		definition, isDefinition := statement.(*syntax.DefStmt)
+		if !isDefinition {
+			continue
+		}
+		definitionStart, definitionEnd := definition.Span()
+		nameStart, nameEnd := definition.Name.Span()
+		definitionRange := rangeFromSyntaxPositions(text, definitionStart, definitionEnd)
+		selectionRange := rangeFromSyntaxPositions(text, nameStart, nameEnd)
+		symbols = append(symbols, map[string]any{
+			"name":           definition.Name.Name,
+			"detail":         "macro",
+			"kind":           12,
+			"range":          definitionRange,
+			"selectionRange": selectionRange,
+		})
+	}
+	return symbols
+}
+
+func rangeFromSyntaxPositions(text string, start syntax.Position, end syntax.Position) rangeValue {
+	return rangeValue{Start: positionFromSyntaxPosition(text, start), End: positionFromSyntaxPosition(text, end)}
+}
+
+func positionFromSyntaxPosition(text string, syntaxPosition syntax.Position) position {
+	return positionFromOneBased(text, int(syntaxPosition.Line), int(syntaxPosition.Col))
+}
+
+func positionFromOneBased(text string, line int, column int) position {
+	lineNumber := max(line-1, 0)
+	character := max(column-1, 0)
+	lines := strings.Split(text, "\n")
+	if lineNumber >= len(lines) {
+		return position{Line: lineNumber}
+	}
+	runes := []rune(lines[lineNumber])
+	if character > len(runes) {
+		character = len(runes)
+	}
+	return position{Line: lineNumber, Character: len(string(runes[:character]))}
+}
+
+func uriPath(documentURI string) string {
+	parsed, operationError := url.Parse(documentURI)
+	if operationError != nil || parsed.Scheme != "file" {
+		return documentURI
+	}
+	return parsed.Path
+}

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -201,6 +201,7 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 	labels := []indexedLabel{}
 	includeHidden := loading.WorkspaceIncludesHidden(workspaceRoot)
 	evaluationOptions := loading.StarlarkOptionsForWorkspace(workspaceRoot)
+	packageLoader := loading.NewPackageLoader(nil)
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
 			if !includeHidden && directoryEntry != nil && directoryEntry.IsDir() && filepath.Clean(path) != filepath.Clean(workspaceRoot) && strings.HasPrefix(directoryEntry.Name(), ".") {
@@ -211,7 +212,14 @@ func (server *server) indexWorkspaceLabels(workspaceRoot string) []indexedLabel 
 		if !isSupportedBuildFile(filepath.Base(path)) {
 			return nil
 		}
-		for _, declaration := range server.declarationsForPathWithOptions(path, server.documentText(pathToURI(path)), evaluationOptions) {
+		text := server.documentText(pathToURI(path))
+		var declarations []namedDeclaration
+		if isStarlarkFile(filepath.Base(path)) {
+			declarations = server.declarationsForPathWithOptions(path, text, evaluationOptions)
+		} else {
+			declarations = packageFileDeclarations(path, text, packageLoader)
+		}
+		for _, declaration := range declarations {
 			if loading.IsBuildLabelKind(declaration.kind) {
 				labels = append(labels, indexedLabel{path: path, name: declaration.name})
 			}
@@ -238,7 +246,7 @@ func pathWithinWorkspace(workspaceRoot string, path string) bool {
 
 func (server *server) declarationsForPath(path string, text string) []namedDeclaration {
 	if !isStarlarkFile(filepath.Base(path)) {
-		return packageFileDeclarations(path, text)
+		return packageFileDeclarations(path, text, loading.NewPackageLoader(nil))
 	}
 	options := loading.StarlarkOptionsForWorkspace(findWorkspaceRoot(filepath.Dir(path)))
 	return server.declarationsForPathWithOptions(path, text, options)
@@ -246,7 +254,7 @@ func (server *server) declarationsForPath(path string, text string) []namedDecla
 
 func (server *server) declarationsForPathWithOptions(path string, text string, options loading.StarlarkEvaluationOptions) []namedDeclaration {
 	if !isStarlarkFile(filepath.Base(path)) {
-		return packageFileDeclarations(path, text)
+		return packageFileDeclarations(path, text, loading.NewPackageLoader(nil))
 	}
 	declarations, operationError := evaluateStarlarkWithOptions(path, text, func(modulePath string) (string, error) {
 		moduleURI := pathToURI(modulePath)
@@ -262,11 +270,11 @@ func (server *server) declarationsForPathWithOptions(path string, text string, o
 	return declarations
 }
 
-func packageFileDeclarations(path string, text string) []namedDeclaration {
+func packageFileDeclarations(path string, text string, packageLoader *loading.PackageLoader) []namedDeclaration {
 	if loading.IsYAMLPackageFile(filepath.Base(path)) {
 		return declarationsForFile(filepath.Base(path), text)
 	}
-	packageDTO, matched, operationError := loading.LoadPackageFile(context.Background(), path)
+	packageDTO, matched, operationError := packageLoader.LoadIfMatched(context.Background(), path, filepath.Base(path))
 	if operationError != nil || !matched {
 		return nil
 	}
@@ -389,10 +397,10 @@ func watchedFileRegistrations() []map[string]any {
 		registrations = append(registrations, map[string]any{"globPattern": pattern, "kind": 7})
 	}
 	if environmentFilePath := config.Global.EnvironmentVariablesFile; environmentFilePath != "" {
-		var pattern any = "**/" + filepath.ToSlash(environmentFilePath)
-		if filepath.IsAbs(environmentFilePath) {
-			pattern = map[string]any{"baseUri": pathToURI(filepath.Dir(environmentFilePath)), "pattern": filepath.Base(environmentFilePath)}
+		if !filepath.IsAbs(environmentFilePath) {
+			environmentFilePath = filepath.Join(config.Global.WorkspaceRoot, environmentFilePath)
 		}
+		pattern := map[string]any{"baseUri": pathToURI(filepath.Dir(environmentFilePath)), "pattern": filepath.Base(environmentFilePath)}
 		registrations = append(registrations, map[string]any{"globPattern": pattern, "kind": 7})
 	}
 	return registrations

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -65,8 +65,11 @@ func (server *server) labelDefinition(currentPath string, targetLabel string) an
 		if definitionText == "" {
 			continue
 		}
-		for _, declaration := range declarationsForFile(fileName, definitionText) {
+		for _, declaration := range server.declarationsForPath(definitionPath, definitionText) {
 			if declaration.name == parsedLabel.Name {
+				if declaration.path != "" {
+					definitionURI = pathToURI(declaration.path)
+				}
 				return map[string]any{"uri": definitionURI, "range": declaration.rangeValue}
 			}
 		}
@@ -117,7 +120,7 @@ func findWorkspaceRoot(directory string) string {
 	}
 }
 
-func collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []string {
+func (server *server) collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []string {
 	labels := []string{}
 	_ = filepath.WalkDir(workspaceRoot, func(path string, directoryEntry os.DirEntry, operationError error) error {
 		if operationError != nil || directoryEntry.IsDir() {
@@ -130,10 +133,7 @@ func collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []str
 		if name != "BUILD.star" && name != "BUILD.bzl" && name != "BUILD.yaml" && name != "BUILD.yml" {
 			return nil
 		}
-		content, operationError := os.ReadFile(path)
-		if operationError != nil {
-			return nil
-		}
+		content := server.documentText(pathToURI(path))
 		packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(path))
 		if operationError != nil || packagePath == "." {
 			packagePath = ""
@@ -142,7 +142,7 @@ func collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []str
 		if packagePath != "" {
 			prefix += filepath.ToSlash(packagePath)
 		}
-		for _, declaration := range declarationsForFile(name, string(content)) {
+		for _, declaration := range server.declarationsForPath(path, content) {
 			label := prefix + ":" + declaration.name
 			labels = append(labels, label)
 			if filepath.Clean(filepath.Dir(path)) == filepath.Clean(currentDirectory) {
@@ -154,13 +154,31 @@ func collectWorkspaceLabels(workspaceRoot string, currentDirectory string) []str
 	return labels
 }
 
+func (server *server) declarationsForPath(path string, text string) []namedDeclaration {
+	if !isStarlarkFile(filepath.Base(path)) {
+		return declarationsForFile(filepath.Base(path), text)
+	}
+	declarations, operationError := evaluateStarlark(path, text, func(modulePath string) (string, error) {
+		moduleURI := pathToURI(modulePath)
+		if moduleText, isOpen := server.documents[moduleURI]; isOpen {
+			return moduleText, nil
+		}
+		content, readError := os.ReadFile(modulePath)
+		return string(content), readError
+	})
+	if operationError != nil {
+		return starlarkNamedDeclarations(text)
+	}
+	return declarations
+}
+
 func declarationsForFile(fileName string, text string) []namedDeclaration {
 	if isStarlarkFile(fileName) {
 		return starlarkNamedDeclarations(text)
 	}
 	var root yaml.Node
 	if operationError := yaml.Unmarshal([]byte(text), &root); operationError != nil {
-		return nil
+		return incompleteYamlDeclarations(text)
 	}
 	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
 		root = *root.Content[0]
@@ -182,6 +200,31 @@ func declarationsForFile(fileName string, text string) []namedDeclaration {
 				declarations = append(declarations, namedDeclaration{kind: kind, name: nameNode.Value, rangeValue: yamlNodeRange(text, nameNode)})
 			}
 		}
+	}
+	return declarations
+}
+
+func incompleteYamlDeclarations(text string) []namedDeclaration {
+	sectionPattern := regexp.MustCompile(`^(targets|aliases|resources|environments):`)
+	namePattern := regexp.MustCompile(`^-\s+name:\s*["']?([^\s"'#]+)`)
+	kinds := map[string]string{"targets": "target", "aliases": "alias", "resources": "resource", "environments": "environment"}
+	declarations := []namedDeclaration{}
+	kind := ""
+	for lineNumber, line := range strings.Split(text, "\n") {
+		trimmedLine := strings.TrimSpace(line)
+		if matches := sectionPattern.FindStringSubmatch(trimmedLine); len(matches) == 2 {
+			kind = kinds[matches[1]]
+			continue
+		}
+		matches := namePattern.FindStringSubmatchIndex(trimmedLine)
+		if kind == "" || len(matches) != 4 {
+			continue
+		}
+		name := trimmedLine[matches[2]:matches[3]]
+		byteStart := strings.Index(line, name)
+		start := position{Line: lineNumber, Character: utf16Length(line[:byteStart])}
+		end := position{Line: lineNumber, Character: start.Character + utf16Length(name)}
+		declarations = append(declarations, namedDeclaration{kind: kind, name: name, rangeValue: rangeValue{Start: start, End: end}})
 	}
 	return declarations
 }

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -7,19 +7,21 @@ import (
 	"regexp"
 	"strings"
 
+	"grog/internal/label"
+
 	"go.starlark.net/syntax"
 	"gopkg.in/yaml.v3"
 )
 
 func (server *server) definition(documentURI string, textPosition position) any {
 	path := uriPath(documentURI)
+	text := server.documentText(documentURI)
+	targetLabel := labelAt(text, textPosition)
+	if targetLabel != "" {
+		return server.labelDefinition(path, targetLabel)
+	}
 	if !isStarlarkFile(filepath.Base(path)) {
 		return nil
-	}
-	text := server.documentText(documentURI)
-	label := labelAt(text, textPosition)
-	if label != "" {
-		return server.labelDefinition(path, label)
 	}
 	word := wordAt(text, textPosition)
 	if word == "" {
@@ -45,17 +47,17 @@ func (server *server) definition(documentURI string, textPosition position) any 
 	return map[string]any{"uri": moduleURI, "range": definitionRange}
 }
 
-func (server *server) labelDefinition(currentPath string, label string) any {
-	targetName := strings.TrimPrefix(label, ":")
-	directory := filepath.Dir(currentPath)
-	if strings.HasPrefix(label, "//") {
-		colon := strings.LastIndex(label, ":")
-		if colon < 0 {
-			return nil
-		}
-		directory = filepath.Join(findWorkspaceRoot(filepath.Dir(currentPath)), strings.TrimPrefix(label[:colon], "//"))
-		targetName = label[colon+1:]
+func (server *server) labelDefinition(currentPath string, targetLabel string) any {
+	workspaceRoot := findWorkspaceRoot(filepath.Dir(currentPath))
+	packagePath, operationError := filepath.Rel(workspaceRoot, filepath.Dir(currentPath))
+	if operationError != nil {
+		return nil
 	}
+	parsedLabel, operationError := label.ParseTargetLabel(filepath.ToSlash(packagePath), targetLabel)
+	if operationError != nil {
+		return nil
+	}
+	directory := filepath.Join(workspaceRoot, filepath.FromSlash(parsedLabel.Package))
 	for _, fileName := range []string{"BUILD.star", "BUILD.bzl", "BUILD.yaml", "BUILD.yml"} {
 		definitionPath := filepath.Join(directory, fileName)
 		definitionURI := pathToURI(definitionPath)
@@ -64,7 +66,7 @@ func (server *server) labelDefinition(currentPath string, label string) any {
 			continue
 		}
 		for _, declaration := range declarationsForFile(fileName, definitionText) {
-			if declaration.name == targetName {
+			if declaration.name == parsedLabel.Name {
 				return map[string]any{"uri": definitionURI, "range": declaration.rangeValue}
 			}
 		}
@@ -78,14 +80,15 @@ func labelAt(text string, textPosition position) string {
 		return ""
 	}
 	line := lines[textPosition.Line]
-	if textPosition.Character < 0 || textPosition.Character > len(line) {
+	characterOffset := characterByteOffset(line, textPosition.Character)
+	if characterOffset < 0 {
 		return ""
 	}
-	start := textPosition.Character
+	start := characterOffset
 	for start > 0 && isLabelCharacter(line[start-1]) {
 		start--
 	}
-	end := textPosition.Character
+	end := characterOffset
 	for end < len(line) && isLabelCharacter(line[end]) {
 		end++
 	}
@@ -236,7 +239,8 @@ func starlarkIdentifierDefinitionRange(text string, identifier string) (rangeVal
 			if start < 0 {
 				continue
 			}
-			return rangeValue{Start: position{Line: lineNumber, Character: start}, End: position{Line: lineNumber, Character: start + len(identifier)}}, true
+			startCharacter := utf16Length(line[:start])
+			return rangeValue{Start: position{Line: lineNumber, Character: startCharacter}, End: position{Line: lineNumber, Character: startCharacter + utf16Length(identifier)}}, true
 		}
 	}
 	return rangeValue{}, false
@@ -304,7 +308,7 @@ func positionFromOneBased(text string, line int, column int) position {
 	if character > len(runes) {
 		character = len(runes)
 	}
-	return position{Line: lineNumber, Character: len(string(runes[:character]))}
+	return position{Line: lineNumber, Character: utf16Length(string(runes[:character]))}
 }
 
 func uriPath(documentURI string) string {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -303,18 +303,29 @@ func packageFileDeclarations(path string, text string, packageLoader *loading.Pa
 	}
 	declarations := []namedDeclaration{}
 	for _, declaration := range loading.PackageDeclarations(packageDTO) {
-		start := position{}
-		if offset := strings.Index(text, declaration.Name); offset >= 0 {
-			start = positionForOffset(text, offset)
-		}
 		declarations = append(declarations, namedDeclaration{
 			kind:       declaration.Kind,
 			name:       declaration.Name,
 			path:       path,
-			rangeValue: rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + utf16Length(declaration.Name)}},
+			rangeValue: packageDeclarationRange(text, declaration.Name),
 		})
 	}
 	return declarations
+}
+
+func packageDeclarationRange(text string, name string) rangeValue {
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?m)\bname\b["']?\s*[:=]\s*["']?(` + regexp.QuoteMeta(name) + `)`),
+		regexp.MustCompile(`(?m)^\s*(` + regexp.QuoteMeta(name) + `)\s*:`),
+	}
+	for _, pattern := range patterns {
+		match := pattern.FindStringSubmatchIndex(text)
+		if len(match) == 4 {
+			start := positionForOffset(text, match[2])
+			return rangeValue{Start: start, End: position{Line: start.Line, Character: start.Character + utf16Length(name)}}
+		}
+	}
+	return rangeValue{}
 }
 
 func declarationsForFile(fileName string, text string) []namedDeclaration {

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -359,11 +359,15 @@ func watchedFileRegistrations() []map[string]any {
 	for _, extension := range loading.StarlarkSourceExtensions() {
 		patterns = append(patterns, "**/*"+extension)
 	}
-	if config.Global.EnvironmentVariablesFile != "" {
-		patterns = append(patterns, "**/"+filepath.Base(config.Global.EnvironmentVariablesFile))
-	}
-	registrations := make([]map[string]any, 0, len(patterns))
+	registrations := make([]map[string]any, 0, len(patterns)+1)
 	for _, pattern := range patterns {
+		registrations = append(registrations, map[string]any{"globPattern": pattern, "kind": 7})
+	}
+	if environmentFilePath := config.Global.EnvironmentVariablesFile; environmentFilePath != "" {
+		var pattern any = "**/" + filepath.ToSlash(environmentFilePath)
+		if filepath.IsAbs(environmentFilePath) {
+			pattern = map[string]any{"baseUri": pathToURI(filepath.Dir(environmentFilePath)), "pattern": filepath.Base(environmentFilePath)}
+		}
 		registrations = append(registrations, map[string]any{"globPattern": pattern, "kind": 7})
 	}
 	return registrations

--- a/internal/lsp/navigation.go
+++ b/internal/lsp/navigation.go
@@ -337,6 +337,21 @@ func isSupportedBuildFile(fileName string) bool {
 	return (loading.StarlarkLoader{}).Matches(fileName) || (loading.YamlLoader{}).Matches(fileName)
 }
 
+func watchedFileRegistrations() []map[string]any {
+	patterns := make([]string, 0)
+	for _, fileName := range loading.BuildFileNames() {
+		patterns = append(patterns, "**/"+fileName)
+	}
+	for _, extension := range loading.StarlarkSourceExtensions() {
+		patterns = append(patterns, "**/*"+extension)
+	}
+	registrations := make([]map[string]any, 0, len(patterns))
+	for _, pattern := range patterns {
+		registrations = append(registrations, map[string]any{"globPattern": pattern, "kind": 7})
+	}
+	return registrations
+}
+
 func pathToURI(path string) string {
 	return pathToURIForOperatingSystem(path, runtime.GOOS)
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -15,15 +15,16 @@ var errExit = errors.New("language server exit")
 
 // Serve runs the grog language server over an LSP stdio transport.
 func Serve(context context.Context, reader io.Reader, writer io.Writer) error {
-	server := &server{reader: bufio.NewReader(reader), writer: writer, documents: map[string]string{}}
+	server := &server{reader: bufio.NewReader(reader), writer: writer, documents: map[string]string{}, workspaceLabels: map[string][]indexedLabel{}}
 	return server.run(context)
 }
 
 type server struct {
-	reader    *bufio.Reader
-	writer    io.Writer
-	documents map[string]string
-	shutdown  bool
+	reader          *bufio.Reader
+	writer          io.Writer
+	documents       map[string]string
+	workspaceLabels map[string][]indexedLabel
+	shutdown        bool
 }
 
 type message struct {
@@ -129,6 +130,7 @@ func (server *server) handle(request message) error {
 			return nil
 		}
 		server.documents[params.TextDocument.URI] = params.TextDocument.Text
+		server.invalidateLabelIndexForDocument(params.TextDocument.URI)
 		return server.publishDiagnostics(params.TextDocument.URI)
 	case "textDocument/didChange":
 		var params didChangeParams
@@ -138,12 +140,14 @@ func (server *server) handle(request message) error {
 		if len(params.ContentChanges) > 0 {
 			server.documents[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
 		}
+		server.invalidateLabelIndexForDocument(params.TextDocument.URI)
 		return server.publishDiagnostics(params.TextDocument.URI)
 	case "textDocument/didSave":
 		var params textDocumentParams
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
 			return nil
 		}
+		server.invalidateLabelIndex()
 		return server.publishDiagnostics(params.TextDocument.URI)
 	case "textDocument/didClose":
 		var params textDocumentParams
@@ -151,7 +155,11 @@ func (server *server) handle(request message) error {
 			return nil
 		}
 		delete(server.documents, params.TextDocument.URI)
+		server.invalidateLabelIndex()
 		return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}})
+	case "workspace/didChangeWatchedFiles":
+		server.invalidateLabelIndex()
+		return nil
 	case "textDocument/completion":
 		var params positionedTextDocumentParams
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -137,14 +137,7 @@ func (server *server) handle(request message) error {
 		if !server.watchFiles {
 			return nil
 		}
-		return server.write(map[string]any{
-			"jsonrpc": "2.0",
-			"id":      "grog-watch-build-files",
-			"method":  "client/registerCapability",
-			"params": map[string]any{"registrations": []map[string]any{{
-				"id": "grog-watch-build-files", "method": "workspace/didChangeWatchedFiles", "registerOptions": map[string]any{"watchers": watchedFileRegistrations()},
-			}}},
-		})
+		return server.registerWatchedFiles("grog-register-watch-files")
 	case "$/cancelRequest", "$/setTrace":
 		return nil
 	case "textDocument/didOpen":
@@ -192,11 +185,14 @@ func (server *server) handle(request message) error {
 		_ = json.Unmarshal(request.Params, &params)
 		server.invalidateLabelIndex()
 		refreshBuildDiagnostics := false
+		watchRegistrationChanged := false
 		for _, change := range params.Changes {
 			path := uriPath(change.URI)
 			fileName := filepath.Base(path)
 			if strings.HasPrefix(fileName, "grog") && filepath.Ext(fileName) == ".toml" {
+				previousEnvironmentFile := config.Global.EnvironmentVariablesFile
 				_ = config.ReloadGlobalFromViper()
+				watchRegistrationChanged = watchRegistrationChanged || previousEnvironmentFile != config.Global.EnvironmentVariablesFile
 				refreshBuildDiagnostics = true
 			}
 			environmentFilePath := config.Global.EnvironmentVariablesFile
@@ -211,6 +207,11 @@ func (server *server) handle(request message) error {
 			}
 			if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
 				refreshBuildDiagnostics = true
+			}
+		}
+		if server.watchFiles && watchRegistrationChanged {
+			if operationError := server.refreshWatchedFiles(); operationError != nil {
+				return operationError
 			}
 		}
 		if refreshBuildDiagnostics {
@@ -253,6 +254,31 @@ func (server *server) handle(request message) error {
 		}
 		return nil
 	}
+}
+
+func (server *server) registerWatchedFiles(requestID string) error {
+	return server.write(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      requestID,
+		"method":  "client/registerCapability",
+		"params": map[string]any{"registrations": []map[string]any{{
+			"id": "grog-watch-files", "method": "workspace/didChangeWatchedFiles", "registerOptions": map[string]any{"watchers": watchedFileRegistrations()},
+		}}},
+	})
+}
+
+func (server *server) refreshWatchedFiles() error {
+	if operationError := server.write(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "grog-unregister-watch-files",
+		"method":  "client/unregisterCapability",
+		"params": map[string]any{"unregisterations": []map[string]any{{
+			"id": "grog-watch-files", "method": "workspace/didChangeWatchedFiles",
+		}}},
+	}); operationError != nil {
+		return operationError
+	}
+	return server.registerWatchedFiles("grog-reregister-watch-files")
 }
 
 func (server *server) respond(requestID json.RawMessage, result any) error {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -176,8 +176,8 @@ func (server *server) handle(request message) error {
 		if operationError := server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}}); operationError != nil {
 			return operationError
 		}
-		if loading.IsStarlarkSourceFile(fileName) {
-			return server.publishOpenStarlarkBuildDiagnostics("")
+		if loading.IsStarlarkSourceFile(fileName) || loading.IsPackageFile(fileName) {
+			return server.publishOpenPackageDiagnostics("")
 		}
 		return nil
 	case "workspace/didChangeWatchedFiles":
@@ -209,7 +209,7 @@ func (server *server) handle(request message) error {
 					refreshBuildDiagnostics = true
 				}
 			}
-			if loading.IsStarlarkSourceFile(fileName) {
+			if loading.IsStarlarkSourceFile(fileName) || loading.IsPackageFile(fileName) {
 				refreshBuildDiagnostics = true
 			}
 		}
@@ -219,7 +219,7 @@ func (server *server) handle(request message) error {
 			}
 		}
 		if refreshBuildDiagnostics {
-			return server.publishOpenStarlarkBuildDiagnostics("")
+			return server.publishOpenPackageDiagnostics("")
 		}
 		return nil
 	case "textDocument/completion":

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -205,6 +205,7 @@ func (server *server) handle(request message) error {
 					environmentFilePath = filepath.Join(config.Global.WorkspaceRoot, environmentFilePath)
 				}
 				if filepath.Clean(path) == filepath.Clean(environmentFilePath) {
+					_ = config.ReloadGlobalFromViper()
 					refreshBuildDiagnostics = true
 				}
 			}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strconv"
 	"strings"
+
+	"grog/internal/loading"
 )
 
 var errExit = errors.New("language server exit")
@@ -177,7 +180,15 @@ func (server *server) handle(request message) error {
 		server.invalidateLabelIndex()
 		return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}})
 	case "workspace/didChangeWatchedFiles":
+		var params didChangeWatchedFilesParams
+		_ = json.Unmarshal(request.Params, &params)
 		server.invalidateLabelIndex()
+		for _, change := range params.Changes {
+			fileName := filepath.Base(uriPath(change.URI))
+			if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
+				return server.publishOpenStarlarkBuildDiagnostics()
+			}
+		}
 		return nil
 	case "textDocument/completion":
 		var params positionedTextDocumentParams
@@ -268,6 +279,11 @@ type didChangeParams struct {
 }
 type textDocumentParams struct {
 	TextDocument textDocumentIdentifier `json:"textDocument"`
+}
+type didChangeWatchedFilesParams struct {
+	Changes []struct {
+		URI string `json:"uri"`
+	} `json:"changes"`
 }
 
 type positionedTextDocumentParams struct {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -24,6 +24,7 @@ type server struct {
 	writer          io.Writer
 	documents       map[string]string
 	workspaceLabels map[string][]indexedLabel
+	watchFiles      bool
 	shutdown        bool
 }
 
@@ -99,11 +100,17 @@ func (server *server) readMessage() (message, error) {
 }
 
 func (server *server) handle(request message) error {
+	if request.Method == "" {
+		return nil
+	}
 	if server.shutdown && request.Method != "exit" {
 		return server.respondError(request.ID, -32600, "server has shut down")
 	}
 	switch request.Method {
 	case "initialize":
+		var params initializeParams
+		_ = json.Unmarshal(request.Params, &params)
+		server.watchFiles = params.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration
 		return server.respond(request.ID, map[string]any{
 			"serverInfo": map[string]any{"name": "grog"},
 			"capabilities": map[string]any{
@@ -122,7 +129,19 @@ func (server *server) handle(request message) error {
 		return server.respond(request.ID, nil)
 	case "exit":
 		return errExit
-	case "initialized", "$/cancelRequest", "$/setTrace":
+	case "initialized":
+		if !server.watchFiles {
+			return nil
+		}
+		return server.write(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "grog-watch-build-files",
+			"method":  "client/registerCapability",
+			"params": map[string]any{"registrations": []map[string]any{{
+				"id": "grog-watch-build-files", "method": "workspace/didChangeWatchedFiles", "registerOptions": map[string]any{"watchers": watchedFileRegistrations()},
+			}}},
+		})
+	case "$/cancelRequest", "$/setTrace":
 		return nil
 	case "textDocument/didOpen":
 		var params didOpenParams
@@ -131,7 +150,7 @@ func (server *server) handle(request message) error {
 		}
 		server.documents[params.TextDocument.URI] = params.TextDocument.Text
 		server.invalidateLabelIndexForDocument(params.TextDocument.URI)
-		return server.publishDiagnostics(params.TextDocument.URI)
+		return server.publishDiagnosticsAfterChange(params.TextDocument.URI)
 	case "textDocument/didChange":
 		var params didChangeParams
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
@@ -141,14 +160,14 @@ func (server *server) handle(request message) error {
 			server.documents[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
 		}
 		server.invalidateLabelIndexForDocument(params.TextDocument.URI)
-		return server.publishDiagnostics(params.TextDocument.URI)
+		return server.publishDiagnosticsAfterChange(params.TextDocument.URI)
 	case "textDocument/didSave":
 		var params textDocumentParams
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
 			return nil
 		}
 		server.invalidateLabelIndex()
-		return server.publishDiagnostics(params.TextDocument.URI)
+		return server.publishDiagnosticsAfterChange(params.TextDocument.URI)
 	case "textDocument/didClose":
 		var params textDocumentParams
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
@@ -225,6 +244,15 @@ func (server *server) write(value any) error {
 type textDocument struct {
 	URI  string `json:"uri"`
 	Text string `json:"text"`
+}
+type initializeParams struct {
+	Capabilities struct {
+		Workspace struct {
+			DidChangeWatchedFiles struct {
+				DynamicRegistration bool `json:"dynamicRegistration"`
+			} `json:"didChangeWatchedFiles"`
+		} `json:"workspace"`
+	} `json:"capabilities"`
 }
 type textDocumentIdentifier struct {
 	URI string `json:"uri"`

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"grog/internal/config"
 	"grog/internal/loading"
 )
 
@@ -190,11 +191,29 @@ func (server *server) handle(request message) error {
 		var params didChangeWatchedFilesParams
 		_ = json.Unmarshal(request.Params, &params)
 		server.invalidateLabelIndex()
+		refreshBuildDiagnostics := false
 		for _, change := range params.Changes {
-			fileName := filepath.Base(uriPath(change.URI))
-			if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
-				return server.publishOpenStarlarkBuildDiagnostics()
+			path := uriPath(change.URI)
+			fileName := filepath.Base(path)
+			if strings.HasPrefix(fileName, "grog") && filepath.Ext(fileName) == ".toml" {
+				_ = config.ReloadGlobalFromViper()
+				refreshBuildDiagnostics = true
 			}
+			environmentFilePath := config.Global.EnvironmentVariablesFile
+			if environmentFilePath != "" {
+				if !filepath.IsAbs(environmentFilePath) {
+					environmentFilePath = filepath.Join(config.Global.WorkspaceRoot, environmentFilePath)
+				}
+				if filepath.Clean(path) == filepath.Clean(environmentFilePath) {
+					refreshBuildDiagnostics = true
+				}
+			}
+			if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
+				refreshBuildDiagnostics = true
+			}
+		}
+		if refreshBuildDiagnostics {
+			return server.publishOpenStarlarkBuildDiagnostics()
 		}
 		return nil
 	case "textDocument/completion":

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1,0 +1,255 @@
+package lsp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+var errExit = errors.New("language server exit")
+
+// Serve runs the grog language server over an LSP stdio transport.
+func Serve(context context.Context, reader io.Reader, writer io.Writer) error {
+	server := &server{reader: bufio.NewReader(reader), writer: writer, documents: map[string]string{}}
+	return server.run(context)
+}
+
+type server struct {
+	reader    *bufio.Reader
+	writer    io.Writer
+	documents map[string]string
+	shutdown  bool
+}
+
+type message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func (server *server) run(context context.Context) error {
+	for {
+		select {
+		case <-context.Done():
+			return context.Err()
+		default:
+		}
+		request, operationError := server.readMessage()
+		if operationError != nil {
+			if errors.Is(operationError, io.EOF) {
+				return nil
+			}
+			return operationError
+		}
+		if operationError := server.handle(request); operationError != nil {
+			if errors.Is(operationError, errExit) && server.shutdown {
+				return nil
+			}
+			return operationError
+		}
+	}
+}
+
+func (server *server) readMessage() (message, error) {
+	var length int
+	foundLength := false
+	for {
+		line, operationError := server.reader.ReadString('\n')
+		if operationError != nil {
+			return message{}, operationError
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(parts[0]), "Content-Length") {
+			length, operationError = strconv.Atoi(strings.TrimSpace(parts[1]))
+			if operationError != nil {
+				return message{}, fmt.Errorf("parse Content-Length: %w", operationError)
+			}
+			foundLength = true
+		}
+	}
+	if !foundLength {
+		return message{}, fmt.Errorf("missing Content-Length")
+	}
+	if length < 0 {
+		return message{}, fmt.Errorf("invalid Content-Length %d", length)
+	}
+	payload := make([]byte, length)
+	if _, operationError := io.ReadFull(server.reader, payload); operationError != nil {
+		return message{}, operationError
+	}
+	var request message
+	if operationError := json.Unmarshal(payload, &request); operationError != nil {
+		return message{}, operationError
+	}
+	return request, nil
+}
+
+func (server *server) handle(request message) error {
+	if server.shutdown && request.Method != "exit" {
+		return server.respondError(request.ID, -32600, "server has shut down")
+	}
+	switch request.Method {
+	case "initialize":
+		return server.respond(request.ID, map[string]any{
+			"serverInfo": map[string]any{"name": "grog"},
+			"capabilities": map[string]any{
+				"positionEncoding":       "utf-8",
+				"textDocumentSync":       1,
+				"hoverProvider":          true,
+				"definitionProvider":     true,
+				"documentSymbolProvider": true,
+				"completionProvider": map[string]any{
+					"triggerCharacters": []string{"(", ",", "=", "\"", "'", ":", "_", "/", "."},
+				},
+				"signatureHelpProvider": map[string]any{"triggerCharacters": []string{"(", ","}},
+			}})
+	case "shutdown":
+		server.shutdown = true
+		return server.respond(request.ID, nil)
+	case "exit":
+		return errExit
+	case "initialized", "$/cancelRequest", "$/setTrace":
+		return nil
+	case "textDocument/didOpen":
+		var params didOpenParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return nil
+		}
+		server.documents[params.TextDocument.URI] = params.TextDocument.Text
+		return server.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didChange":
+		var params didChangeParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return nil
+		}
+		if len(params.ContentChanges) > 0 {
+			server.documents[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
+		}
+		return server.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didSave":
+		var params textDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return nil
+		}
+		return server.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didClose":
+		var params textDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return nil
+		}
+		delete(server.documents, params.TextDocument.URI)
+		return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}})
+	case "textDocument/completion":
+		var params positionedTextDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return server.respondError(request.ID, -32602, "invalid completion parameters")
+		}
+		return server.respond(request.ID, server.completionItems(params.TextDocument.URI, params.Position))
+	case "textDocument/hover":
+		var params positionedTextDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return server.respondError(request.ID, -32602, "invalid hover parameters")
+		}
+		return server.respond(request.ID, server.hover(params.TextDocument.URI, params.Position))
+	case "textDocument/signatureHelp":
+		var params positionedTextDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return server.respondError(request.ID, -32602, "invalid signature help parameters")
+		}
+		return server.respond(request.ID, signatureHelp(server.documentText(params.TextDocument.URI), params.Position))
+	case "textDocument/definition":
+		var params positionedTextDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return server.respondError(request.ID, -32602, "invalid definition parameters")
+		}
+		return server.respond(request.ID, server.definition(params.TextDocument.URI, params.Position))
+	case "textDocument/documentSymbol":
+		var params textDocumentParams
+		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
+			return server.respondError(request.ID, -32602, "invalid document symbol parameters")
+		}
+		return server.respond(request.ID, server.documentSymbols(params.TextDocument.URI))
+	default:
+		if len(request.ID) > 0 {
+			return server.respondError(request.ID, -32601, "method not found")
+		}
+		return nil
+	}
+}
+
+func (server *server) respond(requestID json.RawMessage, result any) error {
+	return server.write(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(requestID), "result": result})
+}
+
+func (server *server) respondError(requestID json.RawMessage, code int, message string) error {
+	if len(requestID) == 0 {
+		return nil
+	}
+	return server.write(map[string]any{"jsonrpc": "2.0", "id": json.RawMessage(requestID), "error": map[string]any{"code": code, "message": message}})
+}
+
+func (server *server) notify(method string, params any) error {
+	return server.write(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+}
+
+func (server *server) write(value any) error {
+	payload, operationError := json.Marshal(value)
+	if operationError != nil {
+		return operationError
+	}
+	_, operationError = fmt.Fprintf(server.writer, "Content-Length: %d\r\n\r\n%s", len(payload), payload)
+	return operationError
+}
+
+type textDocument struct {
+	URI  string `json:"uri"`
+	Text string `json:"text"`
+}
+type textDocumentIdentifier struct {
+	URI string `json:"uri"`
+}
+type didOpenParams struct {
+	TextDocument textDocument `json:"textDocument"`
+}
+type didChangeParams struct {
+	TextDocument   textDocumentIdentifier `json:"textDocument"`
+	ContentChanges []struct {
+		Text string `json:"text"`
+	} `json:"contentChanges"`
+}
+type textDocumentParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+}
+
+type positionedTextDocumentParams struct {
+	TextDocument textDocumentIdentifier `json:"textDocument"`
+	Position     position               `json:"position"`
+}
+
+type diagnostic struct {
+	Range    rangeValue `json:"range"`
+	Severity int        `json:"severity"`
+	Source   string     `json:"source"`
+	Message  string     `json:"message"`
+}
+type rangeValue struct {
+	Start position `json:"start"`
+	End   position `json:"end"`
+}
+type position struct {
+	Line      int `json:"line"`
+	Character int `json:"character"`
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -106,7 +106,7 @@ func (server *server) handle(request message) error {
 		return server.respond(request.ID, map[string]any{
 			"serverInfo": map[string]any{"name": "grog"},
 			"capabilities": map[string]any{
-				"positionEncoding":       "utf-8",
+				"positionEncoding":       "utf-16",
 				"textDocumentSync":       1,
 				"hoverProvider":          true,
 				"definitionProvider":     true,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -176,9 +176,16 @@ func (server *server) handle(request message) error {
 		if operationError := json.Unmarshal(request.Params, &params); operationError != nil {
 			return nil
 		}
+		fileName := filepath.Base(uriPath(params.TextDocument.URI))
 		delete(server.documents, params.TextDocument.URI)
 		server.invalidateLabelIndex()
-		return server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}})
+		if operationError := server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}}); operationError != nil {
+			return operationError
+		}
+		if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
+			return server.publishOpenStarlarkBuildDiagnostics()
+		}
+		return nil
 	case "workspace/didChangeWatchedFiles":
 		var params didChangeWatchedFilesParams
 		_ = json.Unmarshal(request.Params, &params)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -191,7 +191,9 @@ func (server *server) handle(request message) error {
 			fileName := filepath.Base(path)
 			if strings.HasPrefix(fileName, "grog") && filepath.Ext(fileName) == ".toml" {
 				previousEnvironmentFile := config.Global.EnvironmentVariablesFile
-				_ = config.ReloadGlobalFromViper()
+				if operationError := config.ReloadGlobalFromViper(); operationError != nil {
+					return server.notify("window/showMessage", map[string]any{"type": 1, "message": "Failed to reload grog configuration: " + operationError.Error()})
+				}
 				watchRegistrationChanged = watchRegistrationChanged || previousEnvironmentFile != config.Global.EnvironmentVariablesFile
 				refreshBuildDiagnostics = true
 			}
@@ -201,7 +203,9 @@ func (server *server) handle(request message) error {
 					environmentFilePath = filepath.Join(config.Global.WorkspaceRoot, environmentFilePath)
 				}
 				if filepath.Clean(path) == filepath.Clean(environmentFilePath) {
-					_ = config.ReloadGlobalFromViper()
+					if operationError := config.ReloadGlobalFromViper(); operationError != nil {
+						return server.notify("window/showMessage", map[string]any{"type": 1, "message": "Failed to reload grog configuration: " + operationError.Error()})
+					}
 					refreshBuildDiagnostics = true
 				}
 			}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -176,8 +176,8 @@ func (server *server) handle(request message) error {
 		if operationError := server.notify("textDocument/publishDiagnostics", map[string]any{"uri": params.TextDocument.URI, "diagnostics": []diagnostic{}}); operationError != nil {
 			return operationError
 		}
-		if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
-			return server.publishOpenStarlarkBuildDiagnostics()
+		if loading.IsStarlarkSourceFile(fileName) {
+			return server.publishOpenStarlarkBuildDiagnostics("")
 		}
 		return nil
 	case "workspace/didChangeWatchedFiles":
@@ -209,7 +209,7 @@ func (server *server) handle(request message) error {
 					refreshBuildDiagnostics = true
 				}
 			}
-			if loading.IsStarlarkSourceFile(fileName) && !(loading.StarlarkLoader{}).Matches(fileName) {
+			if loading.IsStarlarkSourceFile(fileName) {
 				refreshBuildDiagnostics = true
 			}
 		}
@@ -219,7 +219,7 @@ func (server *server) handle(request message) error {
 			}
 		}
 		if refreshBuildDiagnostics {
-			return server.publishOpenStarlarkBuildDiagnostics()
+			return server.publishOpenStarlarkBuildDiagnostics("")
 		}
 		return nil
 	case "textDocument/completion":

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1125,6 +1125,40 @@ func TestWorkspaceLabelIndexInvalidatesForFilesystemChanges(t *testing.T) {
 	}
 }
 
+func TestWorkspaceLabelIndexInvalidatesForOpenBuildModules(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	moduleDirectory := filepath.Join(workspaceRoot, "rules")
+	if operationError := os.Mkdir(moduleDirectory, 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	modulePath := filepath.Join(moduleDirectory, "BUILD.star")
+	moduleText := "def make():\n  target(name = \"first\")\n"
+	if operationError := os.WriteFile(modulePath, []byte(moduleText), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	if operationError := os.WriteFile(buildPath, []byte("load(\"rules/BUILD.star\", \"make\")\nmake()\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	var output bytes.Buffer
+	server := &server{writer: &output, documents: map[string]string{}}
+	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//:first") {
+		t.Fatalf("unexpected initial labels: %#v", labels)
+	}
+	updatedText := "def make():\n  target(name = \"second\")\n"
+	params := json.RawMessage(fmt.Sprintf(`{"textDocument":{"uri":%q,"text":%q}}`, pathToURI(modulePath), updatedText))
+	if operationError := server.handle(message{Method: "textDocument/didOpen", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
+	if !slices.Contains(labels, "//:second") || slices.Contains(labels, "//:first") {
+		t.Fatalf("unexpected refreshed labels: %#v", labels)
+	}
+}
+
 func TestPositionConversionUsesUTF16CodeUnits(t *testing.T) {
 	text := "é😀target"
 	targetOffset := strings.Index(text, "target")

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -91,6 +91,13 @@ func TestDiagnosticsForStarlarkUsesLoaderSyntaxOptions(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsForStarlarkValidatesTimeout(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", timeout = "forever")`)
+	if len(diagnostics) == 0 {
+		t.Fatal("expected invalid timeout diagnostic")
+	}
+}
+
 func TestStarlarkDiagnosticsReadWorkspaceVariables(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	configuration := "environment_variables_file = \"environment.env\"\n\n[environment_variables]\nINLINE_VALUE = \"inline\"\n"
@@ -275,6 +282,20 @@ func TestStarlarkDependencyCompletionSkipsAlreadyListedLabels(t *testing.T) {
 	}
 }
 
+func TestScalarLabelCompletionDoesNotUseEarlierListValues(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte(""), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	text := "target(name = \"build\")\ntarget(name = \"test\", dependencies = [\":build\"])\nalias(name = \"current\", actual = \":bu"
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, ":build") {
+		t.Fatalf("expected scalar label completion, got %#v", items)
+	}
+}
+
 func TestStarlarkDependencyCompletionFindsMultilineTargets(t *testing.T) {
 	temporaryDirectory := t.TempDir()
 	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
@@ -424,6 +445,15 @@ func TestStarlarkCompletionIgnoresQuotesInComments(t *testing.T) {
 	items := server.completionItems("file:///repo/BUILD.star", position{Line: 2, Character: 4})
 	if !hasCompletionLabel(items, "name") {
 		t.Fatalf("expected name completion, got %#v", items)
+	}
+}
+
+func TestStarlarkCompletionClosesStringAfterEvenBackslashes(t *testing.T) {
+	text := "target(name = \"first\", command = \"C:\\\\\")\ntarget(\n  na"
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": text}}
+	items := server.completionItems("file:///repo/BUILD.star", positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected parameter completion after closed string, got %#v", items)
 	}
 }
 
@@ -587,6 +617,42 @@ func TestWorkspaceLabelsUseOpenDocumentsAndEvaluateMacros(t *testing.T) {
 	}
 }
 
+func TestWorkspaceLabelsExcludeEnvironments(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	text := "environment(name = \"container\", type = \"oci\")\ntarget(name = \"build\")\n"
+	if operationError := os.WriteFile(buildPath, []byte(text), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{}}
+	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
+	if slices.Contains(labels, "//:container") || !slices.Contains(labels, "//:build") {
+		t.Fatalf("unexpected labels: %#v", labels)
+	}
+}
+
+func TestWorkspaceLabelIndexInvalidatesForFilesystemChanges(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	if operationError := os.WriteFile(buildPath, []byte("target(name = \"first\")\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{}}
+	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//:first") {
+		t.Fatalf("unexpected initial labels: %#v", labels)
+	}
+	if operationError := os.WriteFile(buildPath, []byte("target(name = \"second\")\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles"}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
+	if !slices.Contains(labels, "//:second") || slices.Contains(labels, "//:first") {
+		t.Fatalf("unexpected refreshed labels: %#v", labels)
+	}
+}
+
 func TestPositionConversionUsesUTF16CodeUnits(t *testing.T) {
 	text := "é😀target"
 	targetOffset := strings.Index(text, "target")
@@ -596,6 +662,28 @@ func TestPositionConversionUsesUTF16CodeUnits(t *testing.T) {
 	}
 	if offset := byteOffset(text, textPosition); offset != targetOffset {
 		t.Fatalf("offset = %d, want %d", offset, targetOffset)
+	}
+}
+
+func TestURIPathForWindows(t *testing.T) {
+	tests := map[string]string{
+		"file:///C:/repo/BUILD.star":     `C:\repo\BUILD.star`,
+		"file://server/share/BUILD.star": `\\server\share\BUILD.star`,
+	}
+	for documentURI, want := range tests {
+		t.Run(documentURI, func(t *testing.T) {
+			if path := uriPathForOperatingSystem(documentURI, "windows"); path != want {
+				t.Fatalf("path = %q, want %q", path, want)
+			}
+		})
+	}
+	for path, want := range map[string]string{
+		`C:\repo\BUILD.star`:        "file:///C:/repo/BUILD.star",
+		`\\server\share\BUILD.star`: "file://server/share/BUILD.star",
+	} {
+		if documentURI := pathToURIForOperatingSystem(path, "windows"); documentURI != want {
+			t.Fatalf("URI = %q, want %q", documentURI, want)
+		}
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"grog/internal/loading"
 	"os"
 	"path/filepath"
 	"slices"
@@ -151,13 +152,27 @@ func TestDiagnosticsForYamlResource(t *testing.T) {
 	}
 }
 
-func TestDiagnosticsForYamlReportsUnknownFields(t *testing.T) {
+func TestDiagnosticsForYamlMatchesLoaderUnknownFieldBehavior(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    commmand: go build ./...\n")
-	if len(diagnostics) == 0 {
-		t.Fatal("expected unknown field diagnostic")
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected unknown field to match loader behavior, got %#v", diagnostics)
 	}
-	if diagnostics[0].Range.Start.Line != 2 {
-		t.Fatalf("expected diagnostic on line 2, got %#v", diagnostics[0].Range)
+}
+
+func TestCompletionMetadataCoversLoaderSchema(t *testing.T) {
+	for _, format := range []string{"starlark", "yaml"} {
+		for _, declarationKind := range append([]string{""}, loading.StarlarkBuiltinNames()...) {
+			for _, field := range loading.BuildFieldNames(format, declarationKind) {
+				if docs[field] == "" {
+					t.Errorf("missing documentation for %s %s field %q", format, declarationKind, field)
+				}
+			}
+		}
+	}
+	for _, name := range append(loading.StarlarkBuiltinNames(), loading.StarlarkGlobalNames()...) {
+		if docs[name] == "" {
+			t.Errorf("missing documentation for Starlark name %q", name)
+		}
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -1,0 +1,447 @@
+package lsp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestServeLifecycle(t *testing.T) {
+	input := framedMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`) +
+		framedMessage(`{"jsonrpc":"2.0","id":2,"method":"shutdown"}`) +
+		framedMessage(`{"jsonrpc":"2.0","method":"exit"}`)
+	var output bytes.Buffer
+
+	if operationError := Serve(context.Background(), strings.NewReader(input), &output); operationError != nil {
+		t.Fatalf("serve: %v", operationError)
+	}
+	if !strings.Contains(output.String(), `"positionEncoding":"utf-8"`) {
+		t.Fatalf("initialize response does not advertise UTF-8 positions: %s", output.String())
+	}
+	if !strings.Contains(output.String(), `"id":2`) || !strings.Contains(output.String(), `"result":null`) {
+		t.Fatalf("missing shutdown response: %s", output.String())
+	}
+}
+
+func TestServeExitBeforeShutdownFails(t *testing.T) {
+	input := framedMessage(`{"jsonrpc":"2.0","method":"exit"}`)
+	if operationError := Serve(context.Background(), strings.NewReader(input), &bytes.Buffer{}); operationError == nil {
+		t.Fatal("expected exit before shutdown to fail")
+	}
+}
+
+func framedMessage(payload string) string {
+	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(payload), payload)
+}
+
+func TestDiagnosticsForStarlarkAcceptsGrogTarget(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", command = "go build ./...")`)
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForStarlarkReportsMissingTargetName(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(command = "go build ./...")`)
+	if len(diagnostics) == 0 {
+		t.Fatalf("expected diagnostics")
+	}
+}
+
+func TestDiagnosticsForStarlarkReportsDuplicateName(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", "target(name = \"build\")\nalias(name = \"build\", actual = \":other\")\n")
+	if len(diagnostics) == 0 {
+		t.Fatalf("expected duplicate name diagnostic")
+	}
+}
+
+func TestDiagnosticsForStarlarkIgnoresDeclarationsInsideMacros(t *testing.T) {
+	text := "def package(name):\n  target(name = name)\n\ntarget(name = \"build\")\n"
+	if diagnostics := diagnosticsFor("file:///repo/BUILD.star", text); len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForCurrentStarlarkSchema(t *testing.T) {
+	text := `resource(name = "database", up = "start", ready = "ready")
+target(name = "release", binary_requires_push = True, dependencies = [":database"])
+value = json.encode({"platform": GROG_PLATFORM, "root": GROG_WORKSPACE_ROOT, "hash": GROG_GIT_HASH})`
+	if diagnostics := diagnosticsFor("file:///repo/BUILD.star", text); len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestStarlarkDiagnosticsReadWorkspaceVariables(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	configuration := "environment_variables_file = \"environment.env\"\n\n[environment_variables]\nINLINE_VALUE = \"inline\"\n"
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte(configuration), 0o644); operationError != nil {
+		t.Fatalf("write grog.toml: %v", operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "environment.env"), []byte("FILE_VALUE=from-file\n"), 0o644); operationError != nil {
+		t.Fatalf("write environment file: %v", operationError)
+	}
+	text := `target(name = "build", command = INLINE_VALUE + FILE_VALUE)`
+	if diagnostics := starlarkDiagnostics(filepath.Join(workspaceRoot, "BUILD.star"), text); len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForStarlarkHighlightsRepeatedKeywordName(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", name = "again")`)
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Range.Start.Character == 23 && diagnostic.Range.End.Character == 24 {
+			t.Fatalf("did not expect single-character repeated keyword diagnostic: %#v", diagnostic)
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Message == `duplicate keyword argument "name"` {
+			if diagnostic.Range.Start.Character != 23 || diagnostic.Range.End.Character != 27 {
+				t.Fatalf("expected repeated keyword range 23:27, got %#v", diagnostic.Range)
+			}
+			return
+		}
+	}
+	t.Fatalf("expected duplicate keyword diagnostic, got %#v", diagnostics)
+}
+
+func TestDiagnosticsForYaml(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    command: go build ./...\n")
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForYamlReportsMissingName(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - command: go build ./...\n")
+	if len(diagnostics) == 0 {
+		t.Fatalf("expected missing name diagnostic")
+	}
+}
+
+func TestDiagnosticsForYamlReportsDuplicateName(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\naliases:\n  - name: build\n    actual: :other\n")
+	if len(diagnostics) == 0 {
+		t.Fatalf("expected duplicate name diagnostic")
+	}
+}
+
+func TestDiagnosticsForYamlResource(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "resources:\n  - name: database\n    up: docker compose up\n")
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForYamlReportsUnknownFields(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    commmand: go build ./...\n")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected unknown field diagnostic")
+	}
+	if diagnostics[0].Range.Start.Line != 2 {
+		t.Fatalf("expected diagnostic on line 2, got %#v", diagnostics[0].Range)
+	}
+}
+
+func TestStarlarkCompletionDoesNotSuggestYamlTopLevelFields(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": ""}}
+	items := server.completionItems("file:///repo/BUILD.star", position{})
+	for _, item := range items {
+		if item["label"] == "targets" {
+			t.Fatalf("did not expect starlark completion to suggest yaml top-level field targets")
+		}
+	}
+}
+
+func TestStarlarkDependencyCompletionSuggestsLabels(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := "target(name = \"build\")\ntarget(name = \"test\", dependencies = [\""
+	if operationError := os.WriteFile(buildPath, []byte(text), 0644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 1, Character: 39})
+	if !hasCompletionLabel(items, ":build") {
+		t.Fatalf("expected :build completion item, got %#v", items)
+	}
+}
+
+func TestStarlarkDependencyCompletionPrefersAbsoluteLabels(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := "target(name = \"build\")\ntarget(name = \"test\", dependencies = [\""
+	if operationError := os.WriteFile(buildPath, []byte(text), 0644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 1, Character: 39})
+	if len(items) < 2 || items[0]["label"] != "//:build" || items[1]["label"] != "//:test" {
+		t.Fatalf("expected absolute labels first, got %#v", items)
+	}
+}
+
+func TestStarlarkDependencyCompletionKeepsLocalLabelsWhenPrefixStartsWithColon(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := "target(name = \"build\")\ntarget(name = \"test\", dependencies = [\":"
+	if operationError := os.WriteFile(buildPath, []byte(text), 0644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 1, Character: 40})
+	if len(items) == 0 || items[0]["label"] != ":build" {
+		t.Fatalf("expected local labels for colon prefix, got %#v", items)
+	}
+}
+
+func TestStarlarkDependencyCompletionSkipsAlreadyListedLabels(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := "target(name = \"build\")\ntarget(name = \"test\", dependencies = [\"//:build\", \""
+	if operationError := os.WriteFile(buildPath, []byte(text), 0644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 1, Character: 51})
+	if hasCompletionLabel(items, "//:build") {
+		t.Fatalf("did not expect already listed dependency, got %#v", items)
+	}
+}
+
+func TestStarlarkDependencyCompletionFindsMultilineTargets(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := "target(\n  name = \"build\",\n)\ntarget(name = \"test\", dependencies = [\""
+	if operationError := os.WriteFile(buildPath, []byte(text), 0644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 3, Character: 39})
+	if !hasCompletionLabel(items, ":build") {
+		t.Fatalf("expected :build completion item, got %#v", items)
+	}
+}
+
+func TestPathCompletionPrefix(t *testing.T) {
+	prefix := pathCompletionPrefix("target(inputs = [\"src/ma", position{Line: 0, Character: 24})
+	if prefix != "src/ma" {
+		t.Fatalf("prefix = %q", prefix)
+	}
+}
+
+func TestOutputDirPathCompletionCompletesPathAfterDirPrefix(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.Mkdir(filepath.Join(temporaryDirectory, "dist"), 0755); operationError != nil {
+		t.Fatalf("create dist directory: %v", operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "doc.txt"), []byte(""), 0644); operationError != nil {
+		t.Fatalf("create doc file: %v", operationError)
+	}
+	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(outputs = ["dir::d`, position{Line: 0, Character: 25})
+	if !hasCompletionLabel(items, "dir::dist/") {
+		t.Fatalf("expected dir::dist/ completion item, got %#v", items)
+	}
+	if hasCompletionLabel(items, "dir::doc.txt") {
+		t.Fatalf("did not expect file completion for dir:: output, got %#v", items)
+	}
+	for _, item := range items {
+		if item["label"] == "dir::dist/" && item["insertText"] != "ist/" {
+			t.Fatalf("expected insertText ist/ for existing dir::d prefix, got %#v", item["insertText"])
+		}
+		if item["label"] == "dir::dist/" {
+			textEdit, isMap := item["textEdit"].(map[string]any)
+			if !isMap || textEdit["newText"] != "dir::dist/" {
+				t.Fatalf("expected text edit to replace the full path prefix, got %#v", item["textEdit"])
+			}
+		}
+	}
+}
+
+func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "main.go"), []byte(""), 0644); operationError != nil {
+		t.Fatalf("create main file: %v", operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "more.go"), []byte(""), 0644); operationError != nil {
+		t.Fatalf("create more file: %v", operationError)
+	}
+	items := pathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(inputs = ["main.go", "m`, position{Line: 0, Character: 30})
+	if hasCompletionLabel(items, "main.go") {
+		t.Fatalf("did not expect already listed path, got %#v", items)
+	}
+	if !hasCompletionLabel(items, "more.go") {
+		t.Fatalf("expected more.go path, got %#v", items)
+	}
+}
+
+func TestDotPathCompletionFiltersHiddenFiles(t *testing.T) {
+	items := pathCompletionItems("/repo/BUILD.star", `target(inputs = [".g`, position{Line: 0, Character: 21})
+	for _, item := range items {
+		label, _ := item["label"].(string)
+		if label != "" && !strings.HasPrefix(label, ".g") {
+			t.Fatalf("expected .g-prefixed label, got %q", label)
+		}
+	}
+}
+
+func TestStarlarkPathStringDoesNotSuggestTopLevelSymbols(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": `target(name = "x", inputs = [".`}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 0, Character: 30})
+	for _, item := range items {
+		if item["label"] == "target" || item["label"] == "GROG_OS" {
+			t.Fatalf("did not expect top-level completion inside path string")
+		}
+	}
+}
+
+func TestStarlarkTargetCompletionSuggestsTargetFieldsAfterPartialIdentifier(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "target(\n  na"}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 1, Character: 4})
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected name completion, got %#v", items)
+	}
+	for _, item := range items {
+		if item["label"] == "actual" || item["label"] == "alias" {
+			t.Fatalf("did not expect target completion to suggest %s", item["label"])
+		}
+	}
+}
+
+func TestStarlarkTargetCompletionSuppressesTargetFieldsAtEmptyArgument(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "target(\n  "}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 1, Character: 2})
+	if items != nil {
+		t.Fatalf("expected no completions at empty target argument, got %#v", items)
+	}
+}
+
+func TestStarlarkTargetCompletionSuggestsTargetFieldsAfterComma(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": `target(name = "x", )`}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 0, Character: 19})
+	if !hasCompletionLabel(items, "command") {
+		t.Fatalf("expected command completion after comma, got %#v", items)
+	}
+}
+
+func TestStarlarkTargetCompletionDoesNotSuggestPathsAfterPreviousOutputField(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "target(outputs = [\"dist\"])\ntarget(\n  na"}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 2, Character: 4})
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected target parameter completions, got %#v", items)
+	}
+	for _, item := range items {
+		if item["documentation"] == "file path" {
+			t.Fatalf("did not expect path completion inside target parameter list, got %#v", item)
+		}
+	}
+}
+
+func hasCompletionLabel(items []map[string]any, label string) bool {
+	for _, item := range items {
+		if item["label"] == label {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDefinitionForStarlarkTargetLabel(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "target(name = \"build\", command = \"go build\")\ntarget(name = \"test\", dependencies = [\":build\"])\n"}}
+	definition := server.definition("file:///repo/BUILD.star", position{Line: 1, Character: 39})
+	if definition == nil {
+		t.Fatalf("expected definition")
+	}
+}
+
+func TestDefinitionForStarlarkFunction(t *testing.T) {
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "def deb_target(name):\n  target(name = name)\n\ndeb_target(\"pkg\")\n"}}
+	definition := server.definition("file:///repo/BUILD.star", position{Line: 3, Character: 2})
+	if definition == nil {
+		t.Fatalf("expected definition")
+	}
+}
+
+func TestLoadedSymbolParsing(t *testing.T) {
+	modulePath, symbol, found := starlarkLoadedSymbol("/repo/BUILD.star", `load("defs.star", "deb_target", alias_target = "real_target")`, "alias_target")
+	if !found {
+		t.Fatalf("expected loaded symbol")
+	}
+	if modulePath != "/repo/defs.star" {
+		t.Fatalf("modulePath = %q", modulePath)
+	}
+	if symbol != "real_target" {
+		t.Fatalf("symbol = %q", symbol)
+	}
+}
+
+func TestLoadedSymbolParsingMultilineAbsoluteLoad(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), nil, 0o644); operationError != nil {
+		t.Fatalf("write grog.toml: %v", operationError)
+	}
+	currentPath := filepath.Join(workspaceRoot, "package", "BUILD.star")
+	modulePath, symbol, found := starlarkLoadedSymbol(currentPath, "load(\n  \"//rules.star\",\n  local_name = \"remote_name\",\n)\n", "local_name")
+	if !found {
+		t.Fatal("expected loaded symbol")
+	}
+	if modulePath != filepath.Join(workspaceRoot, "rules.star") {
+		t.Fatalf("modulePath = %q", modulePath)
+	}
+	if symbol != "remote_name" {
+		t.Fatalf("symbol = %q", symbol)
+	}
+}
+
+func TestDocumentSymbolsIncludeDeclarationsAndMacros(t *testing.T) {
+	text := "def package(name):\n  target(name = name)\n\ntarget(name = \"build\")\nresource(name = \"database\", up = \"start\")\n"
+	symbols := symbolsFromText("BUILD.star", text)
+	for _, expectedName := range []string{"package", "build", "database"} {
+		if !hasSymbol(symbols, expectedName) {
+			t.Fatalf("expected symbol %q, got %#v", expectedName, symbols)
+		}
+	}
+}
+
+func TestDocumentSymbolsSupportYamlAndStarlarkModules(t *testing.T) {
+	if symbols := symbolsFromText("BUILD.yaml", "resources:\n  - name: database\n    up: start\n"); !hasSymbol(symbols, "database") {
+		t.Fatalf("expected YAML resource symbol, got %#v", symbols)
+	}
+	if symbols := symbolsFromText("rules.bzl", "def package(name):\n  pass\n"); !hasSymbol(symbols, "package") {
+		t.Fatalf("expected Starlark macro symbol, got %#v", symbols)
+	}
+}
+
+func TestDefinitionForAbsoluteTargetLabel(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), nil, 0o644); operationError != nil {
+		t.Fatalf("write grog.toml: %v", operationError)
+	}
+	dependencyDirectory := filepath.Join(workspaceRoot, "dependency")
+	if operationError := os.Mkdir(dependencyDirectory, 0o755); operationError != nil {
+		t.Fatalf("create dependency directory: %v", operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(dependencyDirectory, "BUILD.yaml"), []byte("targets:\n  - name: compile\n"), 0o644); operationError != nil {
+		t.Fatalf("write dependency build file: %v", operationError)
+	}
+	buildPath := filepath.Join(workspaceRoot, "package", "BUILD.star")
+	text := `target(name = "build", dependencies = ["//dependency:compile"])`
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	definition := server.definition(pathToURI(buildPath), position{Line: 0, Character: 52})
+	location, isMap := definition.(map[string]any)
+	if !isMap || location["uri"] != pathToURI(filepath.Join(dependencyDirectory, "BUILD.yaml")) {
+		t.Fatalf("unexpected definition: %#v", definition)
+	}
+}
+
+func hasSymbol(symbols []map[string]any, name string) bool {
+	for _, symbol := range symbols {
+		if symbol["name"] == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -435,6 +435,27 @@ func TestDiagnosticsForYamlReportsDuplicateName(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsReportDuplicateNamesAcrossPackageFiles(t *testing.T) {
+	packageDirectory := t.TempDir()
+	starlarkPath := filepath.Join(packageDirectory, "BUILD.star")
+	starlarkText := `target(name = "build")`
+	yamlPath := filepath.Join(packageDirectory, "BUILD.yaml")
+	yamlText := "targets:\n  - name: build\n"
+	if operationError := os.WriteFile(starlarkPath, []byte(starlarkText), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(yamlPath, []byte(yamlText), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{}}
+	for path, text := range map[string]string{starlarkPath: starlarkText, yamlPath: yamlText} {
+		diagnostics := server.diagnosticsFor(pathToURI(path), text)
+		if len(diagnostics) == 0 || !strings.Contains(diagnostics[len(diagnostics)-1].Message, "duplicate declaration") {
+			t.Errorf("expected sibling duplicate diagnostic for %s, got %#v", path, diagnostics)
+		}
+	}
+}
+
 func TestDiagnosticsForYamlResource(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "resources:\n  - name: database\n    up: docker compose up\n")
 	if len(diagnostics) != 0 {
@@ -859,11 +880,13 @@ func TestStarlarkCallHelpAllowsWhitespaceBeforeParenthesis(t *testing.T) {
 	}
 }
 
-func TestStarlarkTargetCompletionSuppressesTargetFieldsAtEmptyArgument(t *testing.T) {
-	server := &server{documents: map[string]string{"file:///repo/BUILD.star": "target(\n  "}}
-	items := server.completionItems("file:///repo/BUILD.star", position{Line: 1, Character: 2})
-	if items != nil {
-		t.Fatalf("expected no completions at empty target argument, got %#v", items)
+func TestStarlarkTargetCompletionSuggestsFieldsAtEmptyArgument(t *testing.T) {
+	for _, text := range []string{"target(", "target(\n  "} {
+		server := &server{documents: map[string]string{"file:///repo/BUILD.star": text}}
+		items := server.completionItems("file:///repo/BUILD.star", positionForOffset(text, len(text)))
+		if !hasCompletionLabel(items, "name") {
+			t.Fatalf("expected parameter completions for %q, got %#v", text, items)
+		}
 	}
 }
 
@@ -1162,6 +1185,19 @@ func TestWorkspaceLabelsIncludeHiddenDirectoriesWhenConfigured(t *testing.T) {
 	server := &server{documents: map[string]string{}}
 	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//.tools:generator") {
 		t.Fatalf("expected hidden package label, got %#v", labels)
+	}
+}
+
+func TestWorkspaceLabelsExcludeHiddenPackageFilesByDefault(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	text := "#!/usr/bin/env bash\n# @grog\n# name: hidden\ntrue\n"
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, ".tool.grog.sh"), []byte(text), 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	hiddenPath := filepath.Join(workspaceRoot, ".tool.grog.sh")
+	server := &server{documents: map[string]string{pathToURI(hiddenPath): text}}
+	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); slices.Contains(labels, "//:hidden") {
+		t.Fatalf("unexpected hidden package label: %#v", labels)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -36,6 +36,20 @@ func TestServeExitBeforeShutdownFails(t *testing.T) {
 	}
 }
 
+func TestServeRegistersBuildFileWatchers(t *testing.T) {
+	input := framedMessage(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"workspace":{"didChangeWatchedFiles":{"dynamicRegistration":true}}}}}`) +
+		framedMessage(`{"jsonrpc":"2.0","method":"initialized"}`) +
+		framedMessage(`{"jsonrpc":"2.0","id":2,"method":"shutdown"}`) +
+		framedMessage(`{"jsonrpc":"2.0","method":"exit"}`)
+	var output bytes.Buffer
+	if operationError := Serve(context.Background(), strings.NewReader(input), &output); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), `"method":"client/registerCapability"`) || !strings.Contains(output.String(), `**/BUILD.yaml`) {
+		t.Fatalf("missing watched-file registration: %s", output.String())
+	}
+}
+
 func framedMessage(payload string) string {
 	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(payload), payload)
 }
@@ -146,6 +160,44 @@ func TestDiagnosticsMapsLoadedModuleErrorsToLoad(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsMapsDuplicateMacroDeclarationsToLoad(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	modulePath := filepath.Join(workspaceRoot, "rules.star")
+	text := "load(\"rules.star\", \"make\")\nmake()\nmake()\n"
+	diagnostics := starlarkDiagnostics(buildPath, text, func(path string) (string, error) {
+		if path == modulePath {
+			return "def make():\n  target(name = \"same\")\n", nil
+		}
+		return text, nil
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Range.Start.Line != 0 {
+		t.Fatalf("expected duplicate declaration on the load statement, got %#v", diagnostics)
+	}
+}
+
+func TestModuleChangesRepublishBuildDiagnostics(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	modulePath := filepath.Join(workspaceRoot, "rules.star")
+	buildText := "load(\"rules.star\", \"make\")\nmake()\n"
+	moduleText := "def make():\n  target(command = \"build\")\n"
+	var output bytes.Buffer
+	server := &server{
+		writer: &output,
+		documents: map[string]string{
+			pathToURI(buildPath):  buildText,
+			pathToURI(modulePath): moduleText,
+		},
+	}
+	if operationError := server.publishDiagnosticsAfterChange(pathToURI(modulePath)); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), pathToURI(buildPath)) || !strings.Contains(output.String(), "missing argument") {
+		t.Fatalf("missing dependent BUILD diagnostics: %s", output.String())
+	}
+}
+
 func TestDiagnosticsForStarlarkHighlightsRepeatedKeywordName(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", name = "again")`)
 	for _, diagnostic := range diagnostics {
@@ -168,6 +220,24 @@ func TestDiagnosticsForYaml(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    command: go build ./...\n")
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForIncompleteYamlDeclaration(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  -\n")
+	if len(diagnostics) == 0 {
+		t.Fatal("expected incomplete declaration diagnostic")
+	}
+}
+
+func TestDiagnosticsForYamlRequiredFields(t *testing.T) {
+	for _, text := range []string{
+		"aliases:\n  - name: release\n",
+		"resources:\n  - name: database\n",
+	} {
+		if diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", text); len(diagnostics) == 0 {
+			t.Fatalf("expected required field diagnostic for %q", text)
+		}
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -57,14 +57,15 @@ func TestServeRegistersBuildFileWatchers(t *testing.T) {
 
 func TestRefreshWatchedFilesUsesCurrentEnvironmentFile(t *testing.T) {
 	previousConfiguration := config.Global
-	config.Global.EnvironmentVariablesFile = "new.env"
+	environmentFilePath := filepath.Join(t.TempDir(), "new.env")
+	config.Global.EnvironmentVariablesFile = environmentFilePath
 	t.Cleanup(func() { config.Global = previousConfiguration })
 	var output bytes.Buffer
 	server := &server{writer: &output}
 	if operationError := server.refreshWatchedFiles(); operationError != nil {
 		t.Fatal(operationError)
 	}
-	if !strings.Contains(output.String(), `"method":"client/unregisterCapability"`) || !strings.Contains(output.String(), `**/new.env`) {
+	if !strings.Contains(output.String(), `"method":"client/unregisterCapability"`) || !strings.Contains(output.String(), pathToURI(filepath.Dir(environmentFilePath))) || !strings.Contains(output.String(), `"pattern":"new.env"`) {
 		t.Fatalf("missing refreshed watcher: %s", output.String())
 	}
 }
@@ -734,6 +735,20 @@ func TestStarlarkTargetCompletionSuggestsTargetFieldsAfterPartialIdentifier(t *t
 		if item["label"] == "actual" || item["label"] == "alias" {
 			t.Fatalf("did not expect target completion to suggest %s", item["label"])
 		}
+	}
+}
+
+func TestStarlarkCallHelpAllowsWhitespaceBeforeParenthesis(t *testing.T) {
+	text := "target (\n  na"
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": text}}
+	if items := server.completionItems("file:///repo/BUILD.star", positionForOffset(text, len(text))); !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected parameter completion, got %#v", items)
+	}
+
+	text = `target (name = "build", command = "`
+	help, isMap := signatureHelp(text, positionForOffset(text, len(text))).(map[string]any)
+	if !isMap || help["activeParameter"] != 1 {
+		t.Fatalf("expected command parameter to be active, got %#v", help)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -375,14 +375,15 @@ func TestConfigurationChangesRepublishBuildDiagnostics(t *testing.T) {
 	}
 	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
 	buildText := "target(name = BUILD_NAME)\n"
+	modulePath := filepath.Join(workspaceRoot, "rules.star")
 	var output bytes.Buffer
-	server := &server{writer: &output, documents: map[string]string{pathToURI(buildPath): buildText}}
+	server := &server{writer: &output, documents: map[string]string{pathToURI(buildPath): buildText, pathToURI(modulePath): "value = BUILD_NAME\n"}}
 	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(configurationPath)))
 	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
 		t.Fatal(operationError)
 	}
-	if !strings.Contains(output.String(), pathToURI(buildPath)) {
-		t.Fatalf("missing refreshed BUILD diagnostics: %s", output.String())
+	if !strings.Contains(output.String(), pathToURI(buildPath)) || !strings.Contains(output.String(), pathToURI(modulePath)) {
+		t.Fatalf("missing refreshed Starlark diagnostics: %s", output.String())
 	}
 }
 
@@ -505,6 +506,7 @@ func TestDiagnosticsForYamlAliasesAndMergeKeys(t *testing.T) {
 	tests := map[string]string{
 		"item alias":       "common: &common\n  name: build\ntargets:\n  - *common\n",
 		"collection alias": "common: &common [{name: build}]\ntargets: *common\n",
+		"name alias":       "target_name: &target_name build\ntargets: [{name: *target_name}]\n",
 		"merge":            "common: &common\n  name: database\n  up: start\nresources:\n  - <<: *common\n",
 	}
 	for name, text := range tests {
@@ -513,6 +515,14 @@ func TestDiagnosticsForYamlAliasesAndMergeKeys(t *testing.T) {
 				t.Fatalf("expected no diagnostics, got %#v", diagnostics)
 			}
 		})
+	}
+}
+
+func TestYamlDeclarationsDereferenceNameAlias(t *testing.T) {
+	text := "target_name: &target_name build\ntargets: [{name: *target_name}]\n"
+	declarations := declarationsForFile("BUILD.yaml", text)
+	if len(declarations) != 1 || declarations[0].name != "build" {
+		t.Fatalf("unexpected declarations: %#v", declarations)
 	}
 }
 
@@ -1206,6 +1216,27 @@ func TestWorkspaceLabelsUseAdditionalProductionLoaders(t *testing.T) {
 		if !found || location["uri"] == nil {
 			t.Errorf("expected definition for %q, got %#v", targetLabel, location)
 		}
+	}
+}
+
+func TestWorkspaceLabelsUseUnsavedPackageSource(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	packageDirectory := filepath.Join(workspaceRoot, "json")
+	if operationError := os.Mkdir(packageDirectory, 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	path := filepath.Join(packageDirectory, "BUILD.json")
+	if operationError := os.WriteFile(path, []byte(`{"targets":[{"name":"saved"}]}`), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	openText := `{"targets":[{"name":"edited"}]}`
+	server := &server{documents: map[string]string{pathToURI(path): openText}}
+	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
+	if !slices.Contains(labels, "//json:edited") || slices.Contains(labels, "//json:saved") {
+		t.Fatalf("unexpected labels: %#v", labels)
+	}
+	if definition := server.labelDefinition(filepath.Join(workspaceRoot, "BUILD.star"), "//json:edited"); definition == nil {
+		t.Fatal("expected definition from unsaved source")
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -13,6 +13,8 @@ import (
 
 	"grog/internal/config"
 	"grog/internal/loading"
+
+	"github.com/spf13/viper"
 )
 
 func TestServeLifecycle(t *testing.T) {
@@ -217,6 +219,29 @@ func TestDiagnosticsMapsDuplicateMacroDeclarationsToLoad(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsMapTransitiveDeclarationsToDirectLoad(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	otherPath := filepath.Join(workspaceRoot, "other.star")
+	middlePath := filepath.Join(workspaceRoot, "middle.star")
+	leafPath := filepath.Join(workspaceRoot, "leaf.star")
+	text := "load(\"other.star\", \"noop\")\nload(\"middle.star\", \"make\")\nmake()\nmake()\n"
+	modules := map[string]string{
+		otherPath:  "def noop():\n  pass\n",
+		middlePath: "load(\"leaf.star\", leaf_make = \"make\")\ndef make():\n  leaf_make()\n",
+		leafPath:   "def make():\n  target(name = \"same\")\n",
+	}
+	diagnostics := starlarkDiagnostics(buildPath, text, func(path string) (string, error) {
+		if moduleText, found := modules[path]; found {
+			return moduleText, nil
+		}
+		return text, nil
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Range.Start.Line != 1 {
+		t.Fatalf("expected duplicate declaration on the second load, got %#v", diagnostics)
+	}
+}
+
 func TestModuleChangesRepublishBuildDiagnostics(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
@@ -281,6 +306,36 @@ func TestConfigurationChangesRepublishBuildDiagnostics(t *testing.T) {
 	}
 	if !strings.Contains(output.String(), pathToURI(buildPath)) {
 		t.Fatalf("missing refreshed BUILD diagnostics: %s", output.String())
+	}
+}
+
+func TestConfigurationReloadErrorsAreReported(t *testing.T) {
+	previousConfiguration := config.Global
+	t.Cleanup(func() {
+		config.Global = previousConfiguration
+		viper.Reset()
+	})
+	viper.Reset()
+	workspaceRoot := t.TempDir()
+	configurationPath := filepath.Join(workspaceRoot, "grog.toml")
+	if operationError := os.WriteFile(configurationPath, []byte("environment_variables_file = \"missing.env\"\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	viper.SetConfigFile(configurationPath)
+	viper.Set("workspace_root", workspaceRoot)
+	if operationError := viper.ReadInConfig(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: workspaceRoot, EnvironmentVariablesFile: "missing.env"}
+	var output bytes.Buffer
+	server := &server{writer: &output, documents: map[string]string{}}
+	missingPath := filepath.Join(workspaceRoot, "missing.env")
+	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(missingPath)))
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), `"method":"window/showMessage"`) || !strings.Contains(output.String(), "Failed to reload") {
+		t.Fatalf("missing configuration error: %s", output.String())
 	}
 }
 
@@ -524,6 +579,15 @@ func TestYamlBlockDependencyCompletionIgnoresEarlierLists(t *testing.T) {
 	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
 	if !hasCompletionLabel(items, ":build") {
 		t.Fatalf("expected :build completion item, got %#v", items)
+	}
+}
+
+func TestYamlFieldCompletionStopsAtPreviousListItem(t *testing.T) {
+	text := "targets:\n  - name: first\n    dependencies:\n      - \":other\"\n  - na"
+	server := &server{documents: map[string]string{"file:///repo/BUILD.yaml": text}}
+	items := server.completionItems("file:///repo/BUILD.yaml", positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected field completion, got %#v", items)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"grog/internal/config"
 	"grog/internal/loading"
 )
 
@@ -52,6 +53,20 @@ func TestServeRegistersBuildFileWatchers(t *testing.T) {
 	}
 }
 
+func TestRefreshWatchedFilesUsesCurrentEnvironmentFile(t *testing.T) {
+	previousConfiguration := config.Global
+	config.Global.EnvironmentVariablesFile = "new.env"
+	t.Cleanup(func() { config.Global = previousConfiguration })
+	var output bytes.Buffer
+	server := &server{writer: &output}
+	if operationError := server.refreshWatchedFiles(); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), `"method":"client/unregisterCapability"`) || !strings.Contains(output.String(), `**/new.env`) {
+		t.Fatalf("missing refreshed watcher: %s", output.String())
+	}
+}
+
 func framedMessage(payload string) string {
 	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(payload), payload)
 }
@@ -74,6 +89,23 @@ func TestDiagnosticsForStarlarkReportsDuplicateName(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.star", "target(name = \"build\")\nalias(name = \"build\", actual = \":other\")\n")
 	if len(diagnostics) == 0 {
 		t.Fatalf("expected duplicate name diagnostic")
+	}
+}
+
+func TestDiagnosticsIgnoreEnvironmentNameCollisions(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		documentURI string
+		text        string
+	}{
+		{name: "starlark", documentURI: "file:///repo/BUILD.star", text: "environment(name = \"build\", type = \"oci\")\ntarget(name = \"build\")\n"},
+		{name: "yaml", documentURI: "file:///repo/BUILD.yaml", text: "environments:\n  - name: build\n    type: oci\ntargets:\n  - name: build\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if diagnostics := diagnosticsFor(test.documentURI, test.text); len(diagnostics) != 0 {
+				t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+			}
+		})
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -186,6 +186,25 @@ func TestStarlarkDiagnosticsReadWorkspaceVariables(t *testing.T) {
 	}
 }
 
+func TestStarlarkDiagnosticsReportMalformedWorkspaceConfiguration(t *testing.T) {
+	previousConfiguration := config.Global
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: t.TempDir()}
+	viper.Reset()
+	t.Setenv("CI", "")
+	t.Cleanup(func() {
+		config.Global = previousConfiguration
+		viper.Reset()
+	})
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("platform_tag = ["), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	diagnostics := diagnosticsFor(pathToURI(filepath.Join(workspaceRoot, "BUILD.star")), `target(name = "build")`)
+	if len(diagnostics) == 0 || !strings.Contains(diagnostics[0].Message, "parse workspace configuration") {
+		t.Fatalf("expected configuration diagnostic, got %#v", diagnostics)
+	}
+}
+
 func TestDiagnosticsUsesOpenLoadedModule(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	modulePath := filepath.Join(workspaceRoot, "rules.star")
@@ -484,8 +503,9 @@ func TestDiagnosticsForYamlResource(t *testing.T) {
 
 func TestDiagnosticsForYamlAliasesAndMergeKeys(t *testing.T) {
 	tests := map[string]string{
-		"alias": "common: &common\n  name: build\ntargets:\n  - *common\n",
-		"merge": "common: &common\n  name: database\n  up: start\nresources:\n  - <<: *common\n",
+		"item alias":       "common: &common\n  name: build\ntargets:\n  - *common\n",
+		"collection alias": "common: &common [{name: build}]\ntargets: *common\n",
+		"merge":            "common: &common\n  name: database\n  up: start\nresources:\n  - <<: *common\n",
 	}
 	for name, text := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -427,6 +427,20 @@ func TestDiagnosticsForYamlResource(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsForYamlAliasesAndMergeKeys(t *testing.T) {
+	tests := map[string]string{
+		"alias": "common: &common\n  name: build\ntargets:\n  - *common\n",
+		"merge": "common: &common\n  name: database\n  up: start\nresources:\n  - <<: *common\n",
+	}
+	for name, text := range tests {
+		t.Run(name, func(t *testing.T) {
+			if diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", text); len(diagnostics) != 0 {
+				t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+			}
+		})
+	}
+}
+
 func TestDiagnosticsForYamlMatchesLoaderUnknownFieldBehavior(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    commmand: go build ./...\n")
 	if len(diagnostics) != 0 {
@@ -620,6 +634,18 @@ func TestYamlFieldAtUsesFlowMappingKeyAtCursor(t *testing.T) {
 	textPosition := positionForOffset(text, strings.Index(text, ":lib")+3)
 	if field := yamlFieldAt(text, textPosition); field != "dependencies" {
 		t.Fatalf("field = %q", field)
+	}
+}
+
+func TestYamlFieldAtIgnoresColonInUnquotedLabel(t *testing.T) {
+	for _, text := range []string{
+		`targets: [{name: app, dependencies: [//pkg:bu]}]`,
+		`targets: [{name: app, dependencies: [//pkg:]}]`,
+	} {
+		textPosition := positionForOffset(text, strings.Index(text, "]"))
+		if field := yamlFieldAt(text, textPosition); field != "dependencies" {
+			t.Fatalf("field = %q for %q", field, text)
+		}
 	}
 }
 
@@ -1068,6 +1094,34 @@ func TestWorkspaceLabelsExcludeEnvironments(t *testing.T) {
 	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
 	if slices.Contains(labels, "//:container") || !slices.Contains(labels, "//:build") {
 		t.Fatalf("unexpected labels: %#v", labels)
+	}
+}
+
+func TestWorkspaceLabelsUseAdditionalProductionLoaders(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	files := map[string]string{
+		"json/BUILD.json":     `{"targets":[{"name":"json_target"}]}`,
+		"make/Makefile":       "# @grog\n# name: make_target\nmake_target:\n\ttrue\n",
+		"script/tool.grog.sh": "#!/usr/bin/env bash\n# @grog\n# name: script_target\ntrue\n",
+	}
+	for relativePath, text := range files {
+		path := filepath.Join(workspaceRoot, relativePath)
+		if operationError := os.MkdirAll(filepath.Dir(path), 0o755); operationError != nil {
+			t.Fatal(operationError)
+		}
+		if operationError := os.WriteFile(path, []byte(text), 0o755); operationError != nil {
+			t.Fatal(operationError)
+		}
+	}
+	server := &server{documents: map[string]string{}}
+	for _, targetLabel := range []string{"//json:json_target", "//make:make_target", "//script:script_target"} {
+		if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, targetLabel) {
+			t.Errorf("expected %q, got %#v", targetLabel, labels)
+		}
+		location, found := server.labelDefinition(filepath.Join(workspaceRoot, "BUILD.star"), targetLabel).(map[string]any)
+		if !found || location["uri"] == nil {
+			t.Errorf("expected definition for %q, got %#v", targetLabel, location)
+		}
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -70,6 +70,21 @@ func TestRefreshWatchedFilesUsesCurrentEnvironmentFile(t *testing.T) {
 	}
 }
 
+func TestWatchedFilesResolveRelativeEnvironmentFile(t *testing.T) {
+	previousConfiguration := config.Global
+	parentDirectory := t.TempDir()
+	workspaceRoot := filepath.Join(parentDirectory, "workspace")
+	config.Global = config.WorkspaceConfig{WorkspaceRoot: workspaceRoot, EnvironmentVariablesFile: "../shared.env"}
+	t.Cleanup(func() { config.Global = previousConfiguration })
+	registrations, operationError := json.Marshal(watchedFileRegistrations())
+	if operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(string(registrations), pathToURI(parentDirectory)) || !strings.Contains(string(registrations), `"pattern":"shared.env"`) {
+		t.Fatalf("missing resolved environment watcher: %s", registrations)
+	}
+}
+
 func framedMessage(payload string) string {
 	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(payload), payload)
 }
@@ -678,9 +693,16 @@ func TestYamlBlockOutputCompletionIgnoresEarlierLists(t *testing.T) {
 }
 
 func TestPathCompletionPrefix(t *testing.T) {
-	prefix := pathCompletionPrefix("target(inputs = [\"src/ma", position{Line: 0, Character: 24})
-	if prefix != "src/ma" {
-		t.Fatalf("prefix = %q", prefix)
+	for _, test := range []struct {
+		text string
+		want string
+	}{
+		{text: "target(inputs = [\"src/ma", want: "src/ma"},
+		{text: `target(command = """say " hi""", inputs = ["ma`, want: "ma"},
+	} {
+		if prefix := pathCompletionPrefix(test.text, positionForOffset(test.text, len(test.text))); prefix != test.want {
+			t.Errorf("prefix = %q, want %q", prefix, test.want)
+		}
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -3,13 +3,15 @@ package lsp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
-	"grog/internal/loading"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	"grog/internal/loading"
 )
 
 func TestServeLifecycle(t *testing.T) {
@@ -190,7 +192,8 @@ func TestModuleChangesRepublishBuildDiagnostics(t *testing.T) {
 			pathToURI(modulePath): moduleText,
 		},
 	}
-	if operationError := server.publishDiagnosticsAfterChange(pathToURI(modulePath)); operationError != nil {
+	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(modulePath)))
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
 		t.Fatal(operationError)
 	}
 	if !strings.Contains(output.String(), pathToURI(buildPath)) || !strings.Contains(output.String(), "missing argument") {
@@ -266,6 +269,23 @@ func TestDiagnosticsForYamlMatchesLoaderUnknownFieldBehavior(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.yaml", "targets:\n  - name: build\n    commmand: go build ./...\n")
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected unknown field to match loader behavior, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsValidateLabels(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		documentURI string
+		text        string
+	}{
+		{name: "starlark", documentURI: "file:///repo/BUILD.star", text: `target(name = "build", dependencies = ["build"])`},
+		{name: "yaml", documentURI: "file:///repo/BUILD.yaml", text: "aliases:\n  - name: release\n    actual: build\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if diagnostics := diagnosticsFor(test.documentURI, test.text); len(diagnostics) == 0 {
+				t.Fatal("expected invalid label diagnostic")
+			}
+		})
 	}
 }
 
@@ -390,6 +410,17 @@ func TestYamlDependencyCompletionInsideBlockSequence(t *testing.T) {
 	text := "targets:\n  - name: build\n  - name: test\n    dependencies:\n      - \":bu"
 	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
 	items := server.completionItems(pathToURI(buildPath), position{Line: 4, Character: 12})
+	if !hasCompletionLabel(items, ":build") {
+		t.Fatalf("expected :build completion item, got %#v", items)
+	}
+}
+
+func TestYamlBlockDependencyCompletionIgnoresEarlierLists(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.yaml")
+	text := "targets:\n  - name: build\n  - name: first\n    dependencies: [\":build\"]\n  - name: second\n    dependencies:\n      - \":bu"
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
 	if !hasCompletionLabel(items, ":build") {
 		t.Fatalf("expected :build completion item, got %#v", items)
 	}
@@ -549,6 +580,28 @@ func TestDefinitionForStarlarkFunction(t *testing.T) {
 	definition := server.definition("file:///repo/BUILD.star", position{Line: 3, Character: 2})
 	if definition == nil {
 		t.Fatalf("expected definition")
+	}
+}
+
+func TestStarlarkDefinitionUsesTopLevelAssignment(t *testing.T) {
+	text := "def helper():\n  exported = 1\n\nexported = 2\n"
+	definitionRange, found := starlarkIdentifierDefinitionRange(text, "exported")
+	if !found || definitionRange.Start.Line != 3 {
+		t.Fatalf("expected top-level definition, got %#v", definitionRange)
+	}
+}
+
+func TestSignatureHelpTracksActiveParameter(t *testing.T) {
+	text := `target(command = "go build", name = "`
+	help, isMap := signatureHelp(text, positionForOffset(text, len(text))).(map[string]any)
+	if !isMap || help["activeParameter"] != 0 {
+		t.Fatalf("expected name parameter to be active, got %#v", help)
+	}
+
+	text = `target(name = "build", command = "`
+	help, isMap = signatureHelp(text, positionForOffset(text, len(text))).(map[string]any)
+	if !isMap || help["activeParameter"] != 1 {
+		t.Fatalf("expected command parameter to be active, got %#v", help)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -19,8 +19,8 @@ func TestServeLifecycle(t *testing.T) {
 	if operationError := Serve(context.Background(), strings.NewReader(input), &output); operationError != nil {
 		t.Fatalf("serve: %v", operationError)
 	}
-	if !strings.Contains(output.String(), `"positionEncoding":"utf-8"`) {
-		t.Fatalf("initialize response does not advertise UTF-8 positions: %s", output.String())
+	if !strings.Contains(output.String(), `"positionEncoding":"utf-16"`) {
+		t.Fatalf("initialize response does not advertise UTF-16 positions: %s", output.String())
 	}
 	if !strings.Contains(output.String(), `"id":2`) || !strings.Contains(output.String(), `"result":null`) {
 		t.Fatalf("missing shutdown response: %s", output.String())
@@ -221,6 +221,21 @@ func TestStarlarkDependencyCompletionFindsMultilineTargets(t *testing.T) {
 	}
 	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
 	items := server.completionItems(pathToURI(buildPath), position{Line: 3, Character: 39})
+	if !hasCompletionLabel(items, ":build") {
+		t.Fatalf("expected :build completion item, got %#v", items)
+	}
+}
+
+func TestYamlDependencyCompletionInsideBlockSequence(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.yaml")
+	diskText := "targets:\n  - name: build\n  - name: test\n    dependencies: []\n"
+	if operationError := os.WriteFile(buildPath, []byte(diskText), 0o644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	text := "targets:\n  - name: test\n    dependencies:\n      - \":bu"
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), position{Line: 3, Character: 12})
 	if !hasCompletionLabel(items, ":build") {
 		t.Fatalf("expected :build completion item, got %#v", items)
 	}
@@ -434,6 +449,50 @@ func TestDefinitionForAbsoluteTargetLabel(t *testing.T) {
 	location, isMap := definition.(map[string]any)
 	if !isMap || location["uri"] != pathToURI(filepath.Join(dependencyDirectory, "BUILD.yaml")) {
 		t.Fatalf("unexpected definition: %#v", definition)
+	}
+}
+
+func TestDefinitionForYamlTargetLabel(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.yaml")
+	text := "targets:\n  - name: build\n  - name: test\n    dependencies: [\":build\"]\n"
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	if definition := server.definition(pathToURI(buildPath), position{Line: 3, Character: 21}); definition == nil {
+		t.Fatal("expected YAML label definition")
+	}
+}
+
+func TestDefinitionForShorthandAbsoluteTargetLabel(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), nil, 0o644); operationError != nil {
+		t.Fatalf("write grog.toml: %v", operationError)
+	}
+	dependencyDirectory := filepath.Join(workspaceRoot, "dependency")
+	if operationError := os.Mkdir(dependencyDirectory, 0o755); operationError != nil {
+		t.Fatalf("create dependency directory: %v", operationError)
+	}
+	dependencyPath := filepath.Join(dependencyDirectory, "BUILD.star")
+	if operationError := os.WriteFile(dependencyPath, []byte(`target(name = "dependency")`), 0o644); operationError != nil {
+		t.Fatalf("write dependency build file: %v", operationError)
+	}
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	text := `target(name = "build", dependencies = ["//dependency"])`
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	location, isLocation := server.definition(pathToURI(buildPath), position{Line: 0, Character: 47}).(map[string]any)
+	if !isLocation || location["uri"] != pathToURI(dependencyPath) {
+		t.Fatalf("unexpected definition: %#v", location)
+	}
+}
+
+func TestPositionConversionUsesUTF16CodeUnits(t *testing.T) {
+	text := "é😀target"
+	targetOffset := strings.Index(text, "target")
+	textPosition := positionForOffset(text, targetOffset)
+	if textPosition.Character != 3 {
+		t.Fatalf("character = %d, want 3", textPosition.Character)
+	}
+	if offset := byteOffset(text, textPosition); offset != targetOffset {
+		t.Fatalf("offset = %d, want %d", offset, targetOffset)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -72,6 +73,20 @@ target(name = "release", binary_requires_push = True, dependencies = [":database
 value = json.encode({"platform": GROG_PLATFORM, "root": GROG_WORKSPACE_ROOT, "hash": GROG_GIT_HASH})`
 	if diagnostics := diagnosticsFor("file:///repo/BUILD.star", text); len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsForStarlarkValidatesListElements(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", dependencies = [1])`)
+	if len(diagnostics) == 0 {
+		t.Fatal("expected invalid dependency diagnostic")
+	}
+}
+
+func TestDiagnosticsForStarlarkUsesLoaderSyntaxOptions(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `values = {"one", "two"}`)
+	if len(diagnostics) == 0 {
+		t.Fatal("expected unsupported set diagnostic")
 	}
 }
 
@@ -233,9 +248,9 @@ func TestYamlDependencyCompletionInsideBlockSequence(t *testing.T) {
 	if operationError := os.WriteFile(buildPath, []byte(diskText), 0o644); operationError != nil {
 		t.Fatalf("write build file: %v", operationError)
 	}
-	text := "targets:\n  - name: test\n    dependencies:\n      - \":bu"
+	text := "targets:\n  - name: build\n  - name: test\n    dependencies:\n      - \":bu"
 	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
-	items := server.completionItems(pathToURI(buildPath), position{Line: 3, Character: 12})
+	items := server.completionItems(pathToURI(buildPath), position{Line: 4, Character: 12})
 	if !hasCompletionLabel(items, ":build") {
 		t.Fatalf("expected :build completion item, got %#v", items)
 	}
@@ -352,6 +367,15 @@ func TestStarlarkTargetCompletionDoesNotSuggestPathsAfterPreviousOutputField(t *
 		if item["documentation"] == "file path" {
 			t.Fatalf("did not expect path completion inside target parameter list, got %#v", item)
 		}
+	}
+}
+
+func TestStarlarkCompletionIgnoresQuotesInComments(t *testing.T) {
+	text := "# don't hide completions\ntarget(\n  na"
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": text}}
+	items := server.completionItems("file:///repo/BUILD.star", position{Line: 2, Character: 4})
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected name completion, got %#v", items)
 	}
 }
 
@@ -481,6 +505,37 @@ func TestDefinitionForShorthandAbsoluteTargetLabel(t *testing.T) {
 	location, isLocation := server.definition(pathToURI(buildPath), position{Line: 0, Character: 47}).(map[string]any)
 	if !isLocation || location["uri"] != pathToURI(dependencyPath) {
 		t.Fatalf("unexpected definition: %#v", location)
+	}
+}
+
+func TestWorkspaceLabelsUseOpenDocumentsAndEvaluateMacros(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), nil, 0o644); operationError != nil {
+		t.Fatalf("write grog.toml: %v", operationError)
+	}
+	rulesPath := filepath.Join(workspaceRoot, "rules.star")
+	rulesText := "def package(name):\n  target(name = name)\n"
+	if operationError := os.WriteFile(rulesPath, []byte(rulesText), 0o644); operationError != nil {
+		t.Fatalf("write rules: %v", operationError)
+	}
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	if operationError := os.WriteFile(buildPath, []byte(`target(name = "saved")`), 0o644); operationError != nil {
+		t.Fatalf("write build file: %v", operationError)
+	}
+	openText := "load(\"rules.star\", \"package\")\npackage(\"generated\")\ntarget(name = \"open\")\n"
+	server := &server{documents: map[string]string{pathToURI(buildPath): openText, pathToURI(rulesPath): rulesText}}
+	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
+	for _, expectedLabel := range []string{"//:generated", "//:open"} {
+		if !slices.Contains(labels, expectedLabel) {
+			t.Fatalf("expected label %q, got %#v", expectedLabel, labels)
+		}
+	}
+	if slices.Contains(labels, "//:saved") {
+		t.Fatalf("did not expect stale saved label, got %#v", labels)
+	}
+	location, isLocation := server.labelDefinition(buildPath, ":generated").(map[string]any)
+	if !isLocation || location["uri"] != pathToURI(rulesPath) {
+		t.Fatalf("unexpected macro-generated definition: %#v", location)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -101,8 +101,41 @@ func TestStarlarkDiagnosticsReadWorkspaceVariables(t *testing.T) {
 		t.Fatalf("write environment file: %v", operationError)
 	}
 	text := `target(name = "build", command = INLINE_VALUE + FILE_VALUE)`
-	if diagnostics := starlarkDiagnostics(filepath.Join(workspaceRoot, "BUILD.star"), text); len(diagnostics) != 0 {
+	if diagnostics := diagnosticsFor(pathToURI(filepath.Join(workspaceRoot, "BUILD.star")), text); len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsUsesOpenLoadedModule(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	modulePath := filepath.Join(workspaceRoot, "rules.star")
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte(""), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(modulePath, []byte("def saved():\n  pass\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{pathToURI(modulePath): "def edited():\n  target(name = \"from_module\")\n"}}
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	diagnostics := server.diagnosticsFor(pathToURI(buildPath), "load(\"rules.star\", \"edited\")\nedited()\n")
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected open module to be evaluated, got %#v", diagnostics)
+	}
+}
+
+func TestDiagnosticsMapsLoadedModuleErrorsToLoad(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	modulePath := filepath.Join(workspaceRoot, "broken.star")
+	text := "load(\"broken.star\", \"value\")\n"
+	diagnostics := starlarkDiagnostics(buildPath, text, func(path string) (string, error) {
+		if path == modulePath {
+			return "\n\nvalue =\n", nil
+		}
+		return text, nil
+	})
+	if len(diagnostics) != 1 || diagnostics[0].Range.Start.Line != 0 {
+		t.Fatalf("expected module error on the load statement, got %#v", diagnostics)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -201,6 +201,31 @@ func TestModuleChangesRepublishBuildDiagnostics(t *testing.T) {
 	}
 }
 
+func TestModuleCloseRepublishesBuildDiagnostics(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	modulePath := filepath.Join(workspaceRoot, "rules.star")
+	buildText := "load(\"rules.star\", \"make\")\nmake()\n"
+	if operationError := os.WriteFile(modulePath, []byte("def make():\n  target(name = \"build\")\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	var output bytes.Buffer
+	server := &server{
+		writer: &output,
+		documents: map[string]string{
+			pathToURI(buildPath):  buildText,
+			pathToURI(modulePath): "def make():\n  target(command = \"build\")\n",
+		},
+	}
+	params := json.RawMessage(fmt.Sprintf(`{"textDocument":{"uri":%q}}`, pathToURI(modulePath)))
+	if operationError := server.handle(message{Method: "textDocument/didClose", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), pathToURI(buildPath)) || strings.Contains(output.String(), "missing argument") {
+		t.Fatalf("missing refreshed BUILD diagnostics: %s", output.String())
+	}
+}
+
 func TestDiagnosticsForStarlarkHighlightsRepeatedKeywordName(t *testing.T) {
 	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `target(name = "build", name = "again")`)
 	for _, diagnostic := range diagnostics {
@@ -284,6 +309,24 @@ func TestDiagnosticsValidateLabels(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if diagnostics := diagnosticsFor(test.documentURI, test.text); len(diagnostics) == 0 {
 				t.Fatal("expected invalid label diagnostic")
+			}
+		})
+	}
+}
+
+func TestDiagnosticsValidateOutputs(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		documentURI string
+		text        string
+	}{
+		{name: "starlark", documentURI: "file:///repo/BUILD.star", text: `target(name = "build", outputs = ["unknown::artifact"])`},
+		{name: "yaml", documentURI: "file:///repo/BUILD.yaml", text: "targets:\n  - name: build\n    outputs: [unknown::artifact]\n"},
+		{name: "binary", documentURI: "file:///repo/BUILD.star", text: `target(name = "build", bin_output = "dir::artifact")`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if diagnostics := diagnosticsFor(test.documentURI, test.text); len(diagnostics) == 0 {
+				t.Fatal("expected invalid output diagnostic")
 			}
 		})
 	}
@@ -461,6 +504,35 @@ func TestOutputDirPathCompletionCompletesPathAfterDirPrefix(t *testing.T) {
 	}
 }
 
+func TestOutputFilePathCompletionSupportsExplicitPrefix(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "disk.img"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	text := `target(outputs = ["file::di`
+	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), text, positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "file::disk.img") {
+		t.Fatalf("expected explicit file output completion, got %#v", items)
+	}
+}
+
+func TestBinOutputCompletionIgnoresEarlierOutputList(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.Mkdir(filepath.Join(temporaryDirectory, "bin"), 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "bin", "app"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := `target(name = "build", outputs = ["bin/app"], bin_output = "bin/a`
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "bin/app") {
+		t.Fatalf("expected scalar bin output completion, got %#v", items)
+	}
+}
+
 func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
 	temporaryDirectory := t.TempDir()
 	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "main.go"), []byte(""), 0644); operationError != nil {
@@ -469,7 +541,7 @@ func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
 	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "more.go"), []byte(""), 0644); operationError != nil {
 		t.Fatalf("create more file: %v", operationError)
 	}
-	items := pathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(inputs = ["main.go", "m`, position{Line: 0, Character: 30})
+	items := pathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(inputs = ["main.go", "m`, position{Line: 0, Character: 30}, true)
 	if hasCompletionLabel(items, "main.go") {
 		t.Fatalf("did not expect already listed path, got %#v", items)
 	}
@@ -479,7 +551,7 @@ func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
 }
 
 func TestDotPathCompletionFiltersHiddenFiles(t *testing.T) {
-	items := pathCompletionItems("/repo/BUILD.star", `target(inputs = [".g`, position{Line: 0, Character: 21})
+	items := pathCompletionItems("/repo/BUILD.star", `target(inputs = [".g`, position{Line: 0, Character: 21}, true)
 	for _, item := range items {
 		label, _ := item["label"].(string)
 		if label != "" && !strings.HasPrefix(label, ".g") {
@@ -751,6 +823,24 @@ func TestWorkspaceLabelsExcludeEnvironments(t *testing.T) {
 	labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot)
 	if slices.Contains(labels, "//:container") || !slices.Contains(labels, "//:build") {
 		t.Fatalf("unexpected labels: %#v", labels)
+	}
+}
+
+func TestWorkspaceLabelsIncludeHiddenDirectoriesWhenConfigured(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "grog.toml"), []byte("include_hidden = true\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	hiddenDirectory := filepath.Join(workspaceRoot, ".tools")
+	if operationError := os.Mkdir(hiddenDirectory, 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(hiddenDirectory, "BUILD.star"), []byte(`target(name = "generator")`), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{}}
+	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//.tools:generator") {
+		t.Fatalf("expected hidden package label, got %#v", labels)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -266,6 +266,29 @@ func TestModuleChangesRepublishBuildDiagnostics(t *testing.T) {
 	}
 }
 
+func TestWatchedBuildModuleChangesRepublishDependents(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	moduleDirectory := filepath.Join(workspaceRoot, "rules")
+	if operationError := os.Mkdir(moduleDirectory, 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	modulePath := filepath.Join(moduleDirectory, "BUILD.star")
+	if operationError := os.WriteFile(modulePath, []byte("def make():\n  target(command = \"build\")\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildText := "load(\"rules/BUILD.star\", \"make\")\nmake()\n"
+	var output bytes.Buffer
+	server := &server{writer: &output, documents: map[string]string{pathToURI(buildPath): buildText}}
+	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(modulePath)))
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), pathToURI(buildPath)) || !strings.Contains(output.String(), "missing argument") {
+		t.Fatalf("missing dependent BUILD diagnostics: %s", output.String())
+	}
+}
+
 func TestModuleCloseRepublishesBuildDiagnostics(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
@@ -589,6 +612,14 @@ func TestYamlFieldCompletionStopsAtPreviousListItem(t *testing.T) {
 	items := server.completionItems("file:///repo/BUILD.yaml", positionForOffset(text, len(text)))
 	if !hasCompletionLabel(items, "name") {
 		t.Fatalf("expected field completion, got %#v", items)
+	}
+}
+
+func TestYamlFieldAtUsesFlowMappingKeyAtCursor(t *testing.T) {
+	text := `targets: [{name: app, dependencies: [":lib"]}]`
+	textPosition := positionForOffset(text, strings.Index(text, ":lib")+3)
+	if field := yamlFieldAt(text, textPosition); field != "dependencies" {
+		t.Fatalf("field = %q", field)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -47,7 +47,7 @@ func TestServeRegistersBuildFileWatchers(t *testing.T) {
 	if operationError := Serve(context.Background(), strings.NewReader(input), &output); operationError != nil {
 		t.Fatal(operationError)
 	}
-	if !strings.Contains(output.String(), `"method":"client/registerCapability"`) || !strings.Contains(output.String(), `**/BUILD.yaml`) {
+	if !strings.Contains(output.String(), `"method":"client/registerCapability"`) || !strings.Contains(output.String(), `**/BUILD.yaml`) || !strings.Contains(output.String(), `**/grog*.toml`) {
 		t.Fatalf("missing watched-file registration: %s", output.String())
 	}
 }
@@ -222,6 +222,25 @@ func TestModuleCloseRepublishesBuildDiagnostics(t *testing.T) {
 		t.Fatal(operationError)
 	}
 	if !strings.Contains(output.String(), pathToURI(buildPath)) || strings.Contains(output.String(), "missing argument") {
+		t.Fatalf("missing refreshed BUILD diagnostics: %s", output.String())
+	}
+}
+
+func TestConfigurationChangesRepublishBuildDiagnostics(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	configurationPath := filepath.Join(workspaceRoot, "grog.toml")
+	if operationError := os.WriteFile(configurationPath, []byte("[environment_variables]\nBUILD_NAME = \"build\"\n"), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
+	buildText := "target(name = BUILD_NAME)\n"
+	var output bytes.Buffer
+	server := &server{writer: &output, documents: map[string]string{pathToURI(buildPath): buildText}}
+	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(configurationPath)))
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), pathToURI(buildPath)) {
 		t.Fatalf("missing refreshed BUILD diagnostics: %s", output.String())
 	}
 }
@@ -469,6 +488,20 @@ func TestYamlBlockDependencyCompletionIgnoresEarlierLists(t *testing.T) {
 	}
 }
 
+func TestYamlBlockPathCompletionIgnoresEarlierLists(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "main.go"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.yaml")
+	text := "targets:\n  - name: first\n    inputs: [main.go]\n  - name: second\n    inputs:\n      - \"ma"
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "main.go") {
+		t.Fatalf("expected main.go completion item, got %#v", items)
+	}
+}
+
 func TestPathCompletionPrefix(t *testing.T) {
 	prefix := pathCompletionPrefix("target(inputs = [\"src/ma", position{Line: 0, Character: 24})
 	if prefix != "src/ma" {
@@ -541,7 +574,8 @@ func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
 	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "more.go"), []byte(""), 0644); operationError != nil {
 		t.Fatalf("create more file: %v", operationError)
 	}
-	items := pathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(inputs = ["main.go", "m`, position{Line: 0, Character: 30}, true)
+	text := `target(inputs = ["main.go", "m`
+	items := pathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), text, position{Line: 0, Character: 30}, stringListValuesAt(text, position{Line: 0, Character: 30}))
 	if hasCompletionLabel(items, "main.go") {
 		t.Fatalf("did not expect already listed path, got %#v", items)
 	}
@@ -551,7 +585,7 @@ func TestPathCompletionSkipsAlreadyListedPaths(t *testing.T) {
 }
 
 func TestDotPathCompletionFiltersHiddenFiles(t *testing.T) {
-	items := pathCompletionItems("/repo/BUILD.star", `target(inputs = [".g`, position{Line: 0, Character: 21}, true)
+	items := pathCompletionItems("/repo/BUILD.star", `target(inputs = [".g`, position{Line: 0, Character: 21}, map[string]bool{})
 	for _, item := range items {
 		label, _ := item["label"].(string)
 		if label != "" && !strings.HasPrefix(label, ".g") {
@@ -627,6 +661,15 @@ func TestStarlarkCompletionClosesStringAfterEvenBackslashes(t *testing.T) {
 	items := server.completionItems("file:///repo/BUILD.star", positionForOffset(text, len(text)))
 	if !hasCompletionLabel(items, "name") {
 		t.Fatalf("expected parameter completion after closed string, got %#v", items)
+	}
+}
+
+func TestStarlarkCompletionRecognizesTripleQuotedStrings(t *testing.T) {
+	text := "target(name = \"first\", command = \"\"\"say \" hi\"\"\")\ntarget(\n  na"
+	server := &server{documents: map[string]string{"file:///repo/BUILD.star": text}}
+	items := server.completionItems("file:///repo/BUILD.star", positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "name") {
+		t.Fatalf("expected parameter completion after triple-quoted string, got %#v", items)
 	}
 }
 
@@ -841,6 +884,20 @@ func TestWorkspaceLabelsIncludeHiddenDirectoriesWhenConfigured(t *testing.T) {
 	server := &server{documents: map[string]string{}}
 	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//.tools:generator") {
 		t.Fatalf("expected hidden package label, got %#v", labels)
+	}
+}
+
+func TestWorkspaceLabelsDoNotSkipHiddenWorkspaceRoot(t *testing.T) {
+	workspaceRoot := filepath.Join(t.TempDir(), ".project")
+	if operationError := os.Mkdir(workspaceRoot, 0o755); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if operationError := os.WriteFile(filepath.Join(workspaceRoot, "BUILD.star"), []byte(`target(name = "build")`), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	server := &server{documents: map[string]string{}}
+	if labels := server.collectWorkspaceLabels(workspaceRoot, workspaceRoot); !slices.Contains(labels, "//:build") {
+		t.Fatalf("expected root package label, got %#v", labels)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -658,6 +658,20 @@ func TestPathCompletionPrefix(t *testing.T) {
 	}
 }
 
+func TestPathCompletionPrefixSupportsUnquotedYaml(t *testing.T) {
+	for _, test := range []struct {
+		text string
+		want string
+	}{
+		{text: "      - ma", want: "ma"},
+		{text: "dependencies: [:bu", want: ":bu"},
+	} {
+		if prefix := pathCompletionPrefix(test.text, positionForOffset(test.text, len(test.text))); prefix != test.want {
+			t.Errorf("prefix = %q, want %q", prefix, test.want)
+		}
+	}
+}
+
 func TestOutputDirPathCompletionCompletesPathAfterDirPrefix(t *testing.T) {
 	temporaryDirectory := t.TempDir()
 	if operationError := os.Mkdir(filepath.Join(temporaryDirectory, "dist"), 0755); operationError != nil {
@@ -753,6 +767,20 @@ func TestStarlarkPathStringDoesNotSuggestTopLevelSymbols(t *testing.T) {
 		if item["label"] == "target" || item["label"] == "GROG_OS" {
 			t.Fatalf("did not expect top-level completion inside path string")
 		}
+	}
+}
+
+func TestStarlarkPathCompletionIgnoresEqualsInsideString(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "generated=main.go"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.star")
+	text := `target(name = "build", inputs = ["generated=ma`
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "generated=main.go") {
+		t.Fatalf("expected path completion, got %#v", items)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -304,6 +304,25 @@ func TestWatchedBuildModuleChangesRepublishDependents(t *testing.T) {
 	}
 }
 
+func TestWatchedPackageChangesRepublishSiblingDiagnostics(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	starlarkPath := filepath.Join(workspaceRoot, "BUILD.star")
+	starlarkText := `target(name = "build")`
+	jsonPath := filepath.Join(workspaceRoot, "BUILD.json")
+	if operationError := os.WriteFile(jsonPath, []byte(`{"targets":[{"name":"build"}]}`), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	var output bytes.Buffer
+	server := &server{writer: &output, documents: map[string]string{pathToURI(starlarkPath): starlarkText}}
+	params := json.RawMessage(fmt.Sprintf(`{"changes":[{"uri":%q}]}`, pathToURI(jsonPath)))
+	if operationError := server.handle(message{Method: "workspace/didChangeWatchedFiles", Params: params}); operationError != nil {
+		t.Fatal(operationError)
+	}
+	if !strings.Contains(output.String(), pathToURI(starlarkPath)) || !strings.Contains(output.String(), "duplicate declaration") {
+		t.Fatalf("missing sibling diagnostics refresh: %s", output.String())
+	}
+}
+
 func TestModuleCloseRepublishesBuildDiagnostics(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	buildPath := filepath.Join(workspaceRoot, "BUILD.star")
@@ -1167,6 +1186,20 @@ func TestWorkspaceLabelsUseAdditionalProductionLoaders(t *testing.T) {
 		if !found || location["uri"] == nil {
 			t.Errorf("expected definition for %q, got %#v", targetLabel, location)
 		}
+	}
+}
+
+func TestPackageDeclarationRangeUsesNameField(t *testing.T) {
+	packageDirectory := t.TempDir()
+	path := filepath.Join(packageDirectory, "BUILD.json")
+	text := `{"targets":[{"command":"build","name":"build"}]}`
+	if operationError := os.WriteFile(path, []byte(text), 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	declarations := packageFileDeclarations(path, text, loading.NewPackageLoader(nil))
+	want := positionForOffset(text, strings.LastIndex(text, "build"))
+	if len(declarations) != 1 || declarations[0].rangeValue.Start != want {
+		t.Fatalf("unexpected declaration range: %#v, want %#v", declarations, want)
 	}
 }
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -114,6 +114,13 @@ func TestDiagnosticsForStarlarkValidatesTimeout(t *testing.T) {
 	}
 }
 
+func TestDiagnosticsForStarlarkValidatesEmptyRequiredValue(t *testing.T) {
+	diagnostics := diagnosticsFor("file:///repo/BUILD.star", `resource(name = "database", up = "")`)
+	if len(diagnostics) == 0 {
+		t.Fatal("expected empty required value diagnostic")
+	}
+}
+
 func TestStarlarkDiagnosticsReadWorkspaceVariables(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	configuration := "environment_variables_file = \"environment.env\"\n\n[environment_variables]\nINLINE_VALUE = \"inline\"\n"
@@ -502,6 +509,20 @@ func TestYamlBlockPathCompletionIgnoresEarlierLists(t *testing.T) {
 	}
 }
 
+func TestYamlBlockOutputCompletionIgnoresEarlierLists(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "main.go"), nil, 0o644); operationError != nil {
+		t.Fatal(operationError)
+	}
+	buildPath := filepath.Join(temporaryDirectory, "BUILD.yaml")
+	text := "targets:\n  - name: first\n    outputs: [main.go]\n  - name: second\n    outputs:\n      - \"ma"
+	server := &server{documents: map[string]string{pathToURI(buildPath): text}}
+	items := server.completionItems(pathToURI(buildPath), positionForOffset(text, len(text)))
+	if !hasCompletionLabel(items, "main.go") {
+		t.Fatalf("expected main.go completion item, got %#v", items)
+	}
+}
+
 func TestPathCompletionPrefix(t *testing.T) {
 	prefix := pathCompletionPrefix("target(inputs = [\"src/ma", position{Line: 0, Character: 24})
 	if prefix != "src/ma" {
@@ -517,7 +538,9 @@ func TestOutputDirPathCompletionCompletesPathAfterDirPrefix(t *testing.T) {
 	if operationError := os.WriteFile(filepath.Join(temporaryDirectory, "doc.txt"), []byte(""), 0644); operationError != nil {
 		t.Fatalf("create doc file: %v", operationError)
 	}
-	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), `target(outputs = ["dir::d`, position{Line: 0, Character: 25})
+	text := `target(outputs = ["dir::d`
+	textPosition := position{Line: 0, Character: 25}
+	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), text, textPosition, stringListValuesAt(text, textPosition))
 	if !hasCompletionLabel(items, "dir::dist/") {
 		t.Fatalf("expected dir::dist/ completion item, got %#v", items)
 	}
@@ -543,7 +566,8 @@ func TestOutputFilePathCompletionSupportsExplicitPrefix(t *testing.T) {
 		t.Fatal(operationError)
 	}
 	text := `target(outputs = ["file::di`
-	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), text, positionForOffset(text, len(text)))
+	textPosition := positionForOffset(text, len(text))
+	items := outputPathCompletionItems(filepath.Join(temporaryDirectory, "BUILD.star"), text, textPosition, stringListValuesAt(text, textPosition))
 	if !hasCompletionLabel(items, "file::disk.img") {
 		t.Fatalf("expected explicit file output completion, got %#v", items)
 	}
@@ -789,6 +813,14 @@ func TestDefinitionForAbsoluteTargetLabel(t *testing.T) {
 	location, isMap := definition.(map[string]any)
 	if !isMap || location["uri"] != pathToURI(filepath.Join(dependencyDirectory, "BUILD.yaml")) {
 		t.Fatalf("unexpected definition: %#v", definition)
+	}
+}
+
+func TestLabelAtUsesAcceptedPackagePathCharacters(t *testing.T) {
+	text := `target(name = "build", dependencies = ["//pkg $!?:compile"])`
+	textPosition := positionForOffset(text, strings.Index(text, "compile")+2)
+	if targetLabel := labelAt(text, textPosition); targetLabel != "//pkg $!?:compile" {
+		t.Fatalf("unexpected label: %q", targetLabel)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a built-in stdio language server with diagnostics, completions, hover, signatures, symbols, and definitions for Starlark and YAML build files.
- Derive editor metadata and evaluation from the production loaders, with contract tests preventing schema drift.
- Supersedes #164.

## Verification
- `go test ./internal/...`
- `make lint`
- `cd docs && npm run build`